### PR TITLE
Throttle replication event retry logging and scrub event payloads

### DIFF
--- a/.changeset/replication-retry-log-throttle.md
+++ b/.changeset/replication-retry-log-throttle.md
@@ -1,0 +1,7 @@
+---
+"@core/sync-service": patch
+---
+
+Throttle the replication event retry logging and stop logging full event payloads.
+
+A failing replication event is retried every 50ms for up to 10 minutes. Previously every attempt logged at error level, flooding the logs (and any error tracker fed from them) with up to ~12,000 messages per incident, each embedding the full inspected event — potentially megabytes of row data. Now the first failure and one progress update every 10 seconds are logged at error level with the event identity (xid/LSN/relation) and a scrubbed failure reason, while the remaining attempts log full detail at debug level.

--- a/.changeset/replication-retry-log-throttle.md
+++ b/.changeset/replication-retry-log-throttle.md
@@ -4,4 +4,4 @@
 
 Throttle the replication event retry logging and stop logging full event payloads.
 
-A failing replication event is retried every 50ms for up to 10 minutes. Previously every attempt logged at error level, flooding the logs (and any error tracker fed from them) with up to ~12,000 messages per incident, each embedding the full inspected event — potentially megabytes of row data. Now the first failure and one progress update every 10 seconds are logged at error level with the event identity (xid/LSN/relation) and a scrubbed failure reason, while the remaining attempts log full detail at debug level.
+A failing replication event is retried every 50ms for up to 10 minutes. Previously every attempt logged at error level, flooding the logs (and any error tracker fed from them) with up to ~12,000 messages per incident, each embedding the full inspected event — potentially megabytes of row data. Now the first failure and one progress update every 30 seconds are logged at error level with the event identity (xid/LSN/relation) and a scrubbed failure reason; the attempts in between are not logged.

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -611,14 +611,14 @@ defmodule Electric.Postgres.ReplicationClient do
 
   # Replace replication events embedded in an exit reason (e.g. as arguments
   # in a :noproc tuple) with their one-line summary before inspecting, so that
-  # error-level logs never carry full row data. limit: :infinity keeps the full
-  # error structure (every tuple/list/map element) so the reason reaches the
-  # logs — and any error tracker fed from them — untruncated. printable_limit
-  # stays bounded as a backstop: should an event payload slip past scrub_events
-  # in some unanticipated reason shape, individual string blobs are still capped
-  # rather than dumping unbounded row data.
+  # error-level logs never carry full row data. The limits are generous rather
+  # than infinite: real exit reasons are small, so a few-thousand element/binary
+  # cap leaves them untruncated while still bounding a pathological collection or
+  # an event payload that slips past scrub_events in some unanticipated reason
+  # shape — neither can dump unbounded row data into the logs (or any error
+  # tracker fed from them).
   defp inspect_scrubbed(term) do
-    term |> scrub_events() |> inspect(limit: :infinity, printable_limit: 8192)
+    term |> scrub_events() |> inspect(limit: 4000, printable_limit: 8192)
   end
 
   defp scrub_events(%TransactionFragment{} = event), do: "#<#{describe_event(event)}>"

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -567,10 +567,10 @@ defmodule Electric.Postgres.ReplicationClient do
     end
   end
 
-  # A failing event is retried every @event_retry_delay (50ms) for up to
-  # @max_event_retry_time (10 minutes), so logging every attempt at error
-  # level floods the log output — and any error tracker fed from it — with up
-  # to ~12000 messages for a single incident. Log the first failure and one
+  # A failing event is retried every @event_retry_delay for up to
+  # @max_event_retry_time, so logging every attempt at error level floods the
+  # log output — and any error tracker fed from it — with thousands of
+  # messages for a single incident. Log the first failure and one
   # progress update per @retry_log_interval at error level, and every other
   # attempt at debug level. The throttle window is wall-clock time tracked in
   # the state because a fast failure (e.g. :noproc) consumes no measurable

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -611,10 +611,12 @@ defmodule Electric.Postgres.ReplicationClient do
   end
 
   # Replace replication events embedded in an exit reason (e.g. as arguments
-  # in a :noproc tuple) with their one-line summary before inspecting, so
-  # that error-level logs never carry full row data.
+  # in a :noproc tuple) with their one-line summary before inspecting, so that
+  # error-level logs never carry full row data. Only the event payloads are
+  # collapsed — the rest of the reason is inspected without limits so the full
+  # error structure reaches the logs (and any error tracker fed from them).
   defp inspect_scrubbed(term) do
-    term |> scrub_events() |> inspect(limit: 100, printable_limit: 2048)
+    term |> scrub_events() |> inspect(limit: :infinity, printable_limit: :infinity)
   end
 
   defp scrub_events(%TransactionFragment{} = event), do: "#<#{describe_event(event)}>"

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -11,6 +11,7 @@ defmodule Electric.Postgres.ReplicationClient do
   alias Electric.Postgres.ReplicationClient.ConnectionSetup
   alias Electric.Replication.Changes.TransactionFragment
   alias Electric.Replication.Changes.Relation
+  alias Electric.Replication.Changes.LogScrubber
   alias Electric.Telemetry.OpenTelemetry
   alias Electric.Telemetry.Sampler
 
@@ -400,8 +401,8 @@ defmodule Electric.Postgres.ReplicationClient do
       {:noreply, state}
     else
       Logger.error(
-        "Exhausted retry budget processing replication event: #{describe_event(event)} failed with: " <>
-          inspect_scrubbed(reason)
+        "Exhausted retry budget processing replication event: #{LogScrubber.summarize(event)} failed with: " <>
+          LogScrubber.inspect_scrubbed(reason)
       )
 
       exit(reason)
@@ -565,8 +566,8 @@ defmodule Electric.Postgres.ReplicationClient do
           {:noreply, state}
         else
           Logger.error(
-            "Exhausted retry budget dispatching replication event: #{describe_event(event)} failed with: " <>
-              inspect_scrubbed(reason)
+            "Exhausted retry budget dispatching replication event: #{LogScrubber.summarize(event)} failed with: " <>
+              LogScrubber.inspect_scrubbed(reason)
           )
 
           :erlang.raise(kind, reason, __STACKTRACE__)
@@ -592,7 +593,7 @@ defmodule Electric.Postgres.ReplicationClient do
          now - state.last_retry_error_log >= @retry_log_interval do
       Logger.error(
         "Error #{action} replication event (#{div(remaining, 1000)}s retry budget left, retrying every #{@event_retry_delay}ms): " <>
-          "#{describe_event(event)} failed with: " <> inspect_scrubbed(reason)
+          "#{LogScrubber.summarize(event)} failed with: " <> LogScrubber.inspect_scrubbed(reason)
       )
 
       %{state | last_retry_error_log: now}
@@ -600,43 +601,6 @@ defmodule Electric.Postgres.ReplicationClient do
       state
     end
   end
-
-  defp describe_event(%TransactionFragment{} = fragment) do
-    "transaction fragment xid=#{fragment.xid} lsn=#{fragment.lsn} changes=#{fragment.change_count}"
-  end
-
-  defp describe_event(%Relation{} = rel) do
-    ~s|relation "#{rel.schema}"."#{rel.table}" (oid #{rel.id})|
-  end
-
-  # Replace replication events embedded in an exit reason (e.g. as arguments
-  # in a :noproc tuple) with their one-line summary before inspecting, so that
-  # error-level logs never carry full row data. The limits are generous rather
-  # than infinite: real exit reasons are small, so a few-thousand element/binary
-  # cap leaves them untruncated while still bounding a pathological collection or
-  # an event payload that slips past scrub_events in some unanticipated reason
-  # shape — neither can dump unbounded row data into the logs (or any error
-  # tracker fed from them).
-  defp inspect_scrubbed(term) do
-    term |> scrub_events() |> inspect(limit: 4000, printable_limit: 8192)
-  end
-
-  defp scrub_events(%TransactionFragment{} = event), do: "#<#{describe_event(event)}>"
-  defp scrub_events(%Relation{} = event), do: "#<#{describe_event(event)}>"
-  defp scrub_events(%_{} = other_struct), do: other_struct
-
-  defp scrub_events(tuple) when is_tuple(tuple),
-    do: tuple |> Tuple.to_list() |> Enum.map(&scrub_events/1) |> List.to_tuple()
-
-  # Recurse into plain maps too — an event can be nested in a map value within
-  # an arbitrary exit reason.
-  defp scrub_events(map) when is_map(map),
-    do: Map.new(map, fn {k, v} -> {scrub_events(k), scrub_events(v)} end)
-
-  # head/tail recursion keeps this safe for improper lists, which can show up
-  # in arbitrary exit reasons
-  defp scrub_events([head | tail]), do: [scrub_events(head) | scrub_events(tail)]
-  defp scrub_events(other), do: other
 
   # Downstream returned :not_ready — subscribe to StatusMonitor for notification
   # when the stack becomes active, then retry. This replaces the old blocking

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -400,10 +400,12 @@ defmodule Electric.Postgres.ReplicationClient do
       Process.send_after(self(), {:process_event, event, remaining}, @event_retry_delay)
       {:noreply, state}
     else
-      Logger.error(
-        "Exhausted retry budget processing replication event: #{LogScrubber.summarize(event)} failed with: " <>
-          LogScrubber.inspect_scrubbed(reason)
-      )
+      Logger.error([
+        "Exhausted retry budget processing replication event: ",
+        LogScrubber.summarize(event),
+        " failed with: ",
+        LogScrubber.inspect_scrubbed(reason)
+      ])
 
       exit(reason)
     end
@@ -555,8 +557,10 @@ defmodule Electric.Postgres.ReplicationClient do
             stacktrace = __STACKTRACE__
 
             Logger.debug(fn ->
-              "Replication event dispatch failed, retrying: " <>
+              [
+                "Replication event dispatch failed, retrying: ",
                 Exception.format(kind, reason, stacktrace)
+              ]
             end)
           end
 
@@ -565,10 +569,12 @@ defmodule Electric.Postgres.ReplicationClient do
           Process.send_after(self(), {:process_event, event, remaining}, @event_retry_delay)
           {:noreply, state}
         else
-          Logger.error(
-            "Exhausted retry budget dispatching replication event: #{LogScrubber.summarize(event)} failed with: " <>
-              LogScrubber.inspect_scrubbed(reason)
-          )
+          Logger.error([
+            "Exhausted retry budget dispatching replication event: ",
+            LogScrubber.summarize(event),
+            " failed with: ",
+            LogScrubber.inspect_scrubbed(reason)
+          ])
 
           :erlang.raise(kind, reason, __STACKTRACE__)
         end
@@ -591,10 +597,12 @@ defmodule Electric.Postgres.ReplicationClient do
 
     if is_nil(state.last_retry_error_log) or
          now - state.last_retry_error_log >= @retry_log_interval do
-      Logger.error(
-        "Error #{action} replication event (#{div(remaining, 1000)}s retry budget left, retrying every #{@event_retry_delay}ms): " <>
-          "#{LogScrubber.summarize(event)} failed with: " <> LogScrubber.inspect_scrubbed(reason)
-      )
+      Logger.error([
+        "Error #{action} replication event (#{div(remaining, 1000)}s retry budget left, retrying every #{@event_retry_delay}ms): ",
+        LogScrubber.summarize(event),
+        " failed with: ",
+        LogScrubber.inspect_scrubbed(reason)
+      ])
 
       %{state | last_retry_error_log: now}
     else

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -629,7 +629,7 @@ defmodule Electric.Postgres.ReplicationClient do
     do: tuple |> Tuple.to_list() |> Enum.map(&scrub_events/1) |> List.to_tuple()
 
   # Recurse into plain maps too — an event can be nested in a map value within
-  # an arbitrary exit reason, and the inspect no longer truncates to catch it.
+  # an arbitrary exit reason.
   defp scrub_events(map) when is_map(map),
     do: Map.new(map, fn {k, v} -> {scrub_events(k), scrub_events(v)} end)
 

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -394,8 +394,7 @@ defmodule Electric.Postgres.ReplicationClient do
     state = %{state | pending_event: nil}
 
     if remaining > 0 do
-      state =
-        log_event_retry(state, :processing, event, remaining, reason)
+      state = log_event_retry(state, :processing, event, remaining, reason)
 
       Process.send_after(self(), {:process_event, event, remaining}, @event_retry_delay)
       {:noreply, state}
@@ -612,11 +611,14 @@ defmodule Electric.Postgres.ReplicationClient do
 
   # Replace replication events embedded in an exit reason (e.g. as arguments
   # in a :noproc tuple) with their one-line summary before inspecting, so that
-  # error-level logs never carry full row data. Only the event payloads are
-  # collapsed — the rest of the reason is inspected without limits so the full
-  # error structure reaches the logs (and any error tracker fed from them).
+  # error-level logs never carry full row data. limit: :infinity keeps the full
+  # error structure (every tuple/list/map element) so the reason reaches the
+  # logs — and any error tracker fed from them — untruncated. printable_limit
+  # stays bounded as a backstop: should an event payload slip past scrub_events
+  # in some unanticipated reason shape, individual string blobs are still capped
+  # rather than dumping unbounded row data.
   defp inspect_scrubbed(term) do
-    term |> scrub_events() |> inspect(limit: :infinity, printable_limit: :infinity)
+    term |> scrub_events() |> inspect(limit: :infinity, printable_limit: 8192)
   end
 
   defp scrub_events(%TransactionFragment{} = event), do: "#<#{describe_event(event)}>"
@@ -625,6 +627,11 @@ defmodule Electric.Postgres.ReplicationClient do
 
   defp scrub_events(tuple) when is_tuple(tuple),
     do: tuple |> Tuple.to_list() |> Enum.map(&scrub_events/1) |> List.to_tuple()
+
+  # Recurse into plain maps too — an event can be nested in a map value within
+  # an arbitrary exit reason, and the inspect no longer truncates to catch it.
+  defp scrub_events(map) when is_map(map),
+    do: Map.new(map, fn {k, v} -> {scrub_events(k), scrub_events(v)} end)
 
   # head/tail recursion keeps this safe for improper lists, which can show up
   # in arbitrary exit reasons

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -547,6 +547,19 @@ defmodule Electric.Postgres.ReplicationClient do
         remaining = time_remaining - (System.monotonic_time(:millisecond) - start_time)
 
         if remaining > 0 do
+          # On the first failure of an incident, debug-log the full stacktrace
+          # once before entering the throttled retry loop. The error-level log
+          # only carries the scrubbed reason, so this is the only place the
+          # stacktrace is recorded while retries are still in progress.
+          if is_nil(state.last_retry_error_log) do
+            stacktrace = __STACKTRACE__
+
+            Logger.debug(fn ->
+              "Replication event dispatch failed, retrying: " <>
+                Exception.format(kind, reason, stacktrace)
+            end)
+          end
+
           state = log_event_retry(state, :dispatching, event, remaining, reason)
 
           Process.send_after(self(), {:process_event, event, remaining}, @event_retry_delay)

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -158,8 +158,8 @@ defmodule Electric.Postgres.ReplicationClient do
   @max_event_retry_time 10 * 60_000
 
   # How often a still-failing event retry is logged at error level; attempts
-  # in between are logged at debug level. See log_event_retry/6.
-  @retry_log_interval 10_000
+  # in between are not logged. See log_event_retry/5.
+  @retry_log_interval 30_000
 
   @spec start_link(Keyword.t()) :: :gen_statem.start_ret()
   def start_link(opts) do
@@ -395,7 +395,7 @@ defmodule Electric.Postgres.ReplicationClient do
 
     if remaining > 0 do
       state =
-        log_event_retry(state, :processing, event, remaining, reason, fn -> inspect(reason) end)
+        log_event_retry(state, :processing, event, remaining, reason)
 
       Process.send_after(self(), {:process_event, event, remaining}, @event_retry_delay)
       {:noreply, state}
@@ -547,12 +547,7 @@ defmodule Electric.Postgres.ReplicationClient do
         remaining = time_remaining - (System.monotonic_time(:millisecond) - start_time)
 
         if remaining > 0 do
-          stacktrace = __STACKTRACE__
-
-          state =
-            log_event_retry(state, :dispatching, event, remaining, reason, fn ->
-              Exception.format(kind, reason, stacktrace)
-            end)
+          state = log_event_retry(state, :dispatching, event, remaining, reason)
 
           Process.send_after(self(), {:process_event, event, remaining}, @event_retry_delay)
           {:noreply, state}
@@ -570,17 +565,15 @@ defmodule Electric.Postgres.ReplicationClient do
   # A failing event is retried every @event_retry_delay for up to
   # @max_event_retry_time, so logging every attempt at error level floods the
   # log output — and any error tracker fed from it — with thousands of
-  # messages for a single incident. Log the first failure and one
-  # progress update per @retry_log_interval at error level, and every other
-  # attempt at debug level. The throttle window is wall-clock time tracked in
-  # the state because a fast failure (e.g. :noproc) consumes no measurable
-  # retry budget.
+  # messages for a single incident. Log the first failure and one progress
+  # update per @retry_log_interval at error level; attempts in between are not
+  # logged. The throttle window is wall-clock time tracked in the state because
+  # a fast failure (e.g. :noproc) consumes no measurable retry budget.
   #
   # The error-level message carries the event identity instead of the full
   # event: the payload can be megabytes of row data, which both bloats the
-  # message and copies user data into the logs. The full detail remains
-  # available at debug level.
-  defp log_event_retry(state, action, event, remaining, reason, debug_detail_fn) do
+  # message and copies user data into the logs.
+  defp log_event_retry(state, action, event, remaining, reason) do
     now = System.monotonic_time(:millisecond)
 
     if is_nil(state.last_retry_error_log) or
@@ -592,11 +585,6 @@ defmodule Electric.Postgres.ReplicationClient do
 
       %{state | last_retry_error_log: now}
     else
-      Logger.debug(fn ->
-        "Error #{action} replication event (#{remaining}ms retry budget left): " <>
-          debug_detail_fn.()
-      end)
-
       state
     end
   end

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -55,6 +55,7 @@ defmodule Electric.Postgres.ReplicationClient do
       step: :disconnected,
       wait_for_active_ref: nil,
       pending_event: nil,
+      last_retry_error_log: nil,
       received_wal: 0,
       flushed_wal: 0,
       last_seen_txn_lsn: Lsn.from_integer(0),
@@ -81,6 +82,7 @@ defmodule Electric.Postgres.ReplicationClient do
             step: Electric.Postgres.ReplicationClient.step(),
             wait_for_active_ref: {reference(), term()} | nil,
             pending_event: {reference(), term(), non_neg_integer(), integer()} | nil,
+            last_retry_error_log: integer() | nil,
             received_wal: non_neg_integer(),
             flushed_wal: non_neg_integer(),
             last_seen_txn_lsn: Lsn.t(),
@@ -154,6 +156,10 @@ defmodule Electric.Postgres.ReplicationClient do
 
   # Maximum time to spend retrying a crashed event handler before giving up.
   @max_event_retry_time 10 * 60_000
+
+  # How often a still-failing event retry is logged at error level; attempts
+  # in between are logged at debug level. See log_event_retry/6.
+  @retry_log_interval 10_000
 
   @spec start_link(Keyword.t()) :: :gen_statem.start_ret()
   def start_link(opts) do
@@ -361,7 +367,7 @@ defmodule Electric.Postgres.ReplicationClient do
       )
       when is_reference(ref) do
     Process.demonitor(ref, [:flush])
-    state = %{state | pending_event: nil}
+    state = %{state | pending_event: nil, last_retry_error_log: nil}
     state = maybe_update_flush_up_to_date(state)
     {acks, state} = acknowledge_transaction(event, state)
     {:noreply_and_resume, acks, state}
@@ -388,15 +394,15 @@ defmodule Electric.Postgres.ReplicationClient do
     state = %{state | pending_event: nil}
 
     if remaining > 0 do
-      Logger.error(
-        "Error processing replication event (#{remaining}ms retry budget left): " <>
-          inspect(reason)
-      )
+      state = log_event_retry(state, :processing, event, remaining, reason, fn -> inspect(reason) end)
 
       Process.send_after(self(), {:process_event, event, remaining}, @event_retry_delay)
       {:noreply, state}
     else
-      Logger.error("Exhausted retry budget processing replication event: " <> inspect(reason))
+      Logger.error(
+        "Exhausted retry budget processing replication event: #{describe_event(event)} failed with: " <>
+          inspect_scrubbed(reason)
+      )
 
       exit(reason)
     end
@@ -540,23 +546,83 @@ defmodule Electric.Postgres.ReplicationClient do
         remaining = time_remaining - (System.monotonic_time(:millisecond) - start_time)
 
         if remaining > 0 do
-          Logger.error(
-            "Error dispatching replication event (#{remaining}ms retry budget left): " <>
-              Exception.format(kind, reason, __STACKTRACE__)
-          )
+          stacktrace = __STACKTRACE__
+
+          state =
+            log_event_retry(state, :dispatching, event, remaining, reason, fn ->
+              Exception.format(kind, reason, stacktrace)
+            end)
 
           Process.send_after(self(), {:process_event, event, remaining}, @event_retry_delay)
           {:noreply, state}
         else
           Logger.error(
-            "Exhausted retry budget dispatching replication event: " <>
-              Exception.format(kind, reason, __STACKTRACE__)
+            "Exhausted retry budget dispatching replication event: #{describe_event(event)} failed with: " <>
+              inspect_scrubbed(reason)
           )
 
           :erlang.raise(kind, reason, __STACKTRACE__)
         end
     end
   end
+
+  # A failing event is retried every @event_retry_delay (50ms) for up to
+  # @max_event_retry_time (10 minutes), so logging every attempt at error
+  # level floods the log output — and any error tracker fed from it — with up
+  # to ~12000 messages for a single incident. Log the first failure and one
+  # progress update per @retry_log_interval at error level, and every other
+  # attempt at debug level. The throttle window is wall-clock time tracked in
+  # the state because a fast failure (e.g. :noproc) consumes no measurable
+  # retry budget.
+  #
+  # The error-level message carries the event identity instead of the full
+  # event: the payload can be megabytes of row data, which both bloats the
+  # message and copies user data into the logs. The full detail remains
+  # available at debug level.
+  defp log_event_retry(state, action, event, remaining, reason, debug_detail_fn) do
+    now = System.monotonic_time(:millisecond)
+
+    if is_nil(state.last_retry_error_log) or
+         now - state.last_retry_error_log >= @retry_log_interval do
+      Logger.error(
+        "Error #{action} replication event (#{div(remaining, 1000)}s retry budget left, retrying every #{@event_retry_delay}ms): " <>
+          "#{describe_event(event)} failed with: " <> inspect_scrubbed(reason)
+      )
+
+      %{state | last_retry_error_log: now}
+    else
+      Logger.debug(fn ->
+        "Error #{action} replication event (#{remaining}ms retry budget left): " <>
+          debug_detail_fn.()
+      end)
+
+      state
+    end
+  end
+
+  defp describe_event(%TransactionFragment{} = fragment) do
+    "transaction fragment xid=#{fragment.xid} lsn=#{fragment.lsn} changes=#{fragment.change_count}"
+  end
+
+  defp describe_event(%Relation{} = rel) do
+    ~s|relation "#{rel.schema}"."#{rel.table}" (oid #{rel.id})|
+  end
+
+  # Replace replication events embedded in an exit reason (e.g. as arguments
+  # in a :noproc tuple) with their one-line summary before inspecting, so
+  # that error-level logs never carry full row data.
+  defp inspect_scrubbed(term) do
+    term |> scrub_events() |> inspect(limit: 100, printable_limit: 2048)
+  end
+
+  defp scrub_events(%TransactionFragment{} = event), do: "#<#{describe_event(event)}>"
+  defp scrub_events(%Relation{} = event), do: "#<#{describe_event(event)}>"
+
+  defp scrub_events(tuple) when is_tuple(tuple),
+    do: tuple |> Tuple.to_list() |> Enum.map(&scrub_events/1) |> List.to_tuple()
+
+  defp scrub_events(list) when is_list(list), do: Enum.map(list, &scrub_events/1)
+  defp scrub_events(other), do: other
 
   # Downstream returned :not_ready — subscribe to StatusMonitor for notification
   # when the stack becomes active, then retry. This replaces the old blocking

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -394,7 +394,8 @@ defmodule Electric.Postgres.ReplicationClient do
     state = %{state | pending_event: nil}
 
     if remaining > 0 do
-      state = log_event_retry(state, :processing, event, remaining, reason, fn -> inspect(reason) end)
+      state =
+        log_event_retry(state, :processing, event, remaining, reason, fn -> inspect(reason) end)
 
       Process.send_after(self(), {:process_event, event, remaining}, @event_retry_delay)
       {:noreply, state}
@@ -617,11 +618,14 @@ defmodule Electric.Postgres.ReplicationClient do
 
   defp scrub_events(%TransactionFragment{} = event), do: "#<#{describe_event(event)}>"
   defp scrub_events(%Relation{} = event), do: "#<#{describe_event(event)}>"
+  defp scrub_events(%_{} = other_struct), do: other_struct
 
   defp scrub_events(tuple) when is_tuple(tuple),
     do: tuple |> Tuple.to_list() |> Enum.map(&scrub_events/1) |> List.to_tuple()
 
-  defp scrub_events(list) when is_list(list), do: Enum.map(list, &scrub_events/1)
+  # head/tail recursion keeps this safe for improper lists, which can show up
+  # in arbitrary exit reasons
+  defp scrub_events([head | tail]), do: [scrub_events(head) | scrub_events(tail)]
   defp scrub_events(other), do: other
 
   # Downstream returned :not_ready — subscribe to StatusMonitor for notification

--- a/packages/sync-service/lib/electric/replication/changes/log_scrubber.ex
+++ b/packages/sync-service/lib/electric/replication/changes/log_scrubber.ex
@@ -1,0 +1,138 @@
+defmodule Electric.Replication.Changes.LogScrubber do
+  @moduledoc """
+  Produces log-safe representations of replication events.
+
+  Replication events (`t:Electric.Replication.Changes.TransactionFragment.t/0`
+  and `t:Electric.Replication.Changes.Relation.t/0`) carry full row data — a
+  single event can be megabytes of customer data. When such an event is logged,
+  or embedded in an exit/crash reason that gets logged, that payload is copied
+  into the log output and any error tracker (e.g. Sentry) fed from it.
+
+  This module replaces those payloads with a one-line identity summary so the
+  logs keep enough context to diagnose a failure (which transaction, which
+  relation) without the row data. It offers three operations:
+
+    * `summarize/1` — summarize a single event as a one-line string.
+    * `scrub/1` — walk an arbitrary term and replace any event embedded in it
+      (in a tuple, list, or map) with its summary, leaving everything else
+      untouched.
+    * `inspect_scrubbed/1` — `scrub/1` then `Kernel.inspect/2` with bounded
+      limits, yielding the string that actually goes into a log line.
+
+  ## Scope of the scrub
+
+  `scrub/1` recurses into tuples, lists (including improper lists) and plain
+  maps, which covers the exit-reason shapes seen in practice — for example a
+  `:noproc` reason of the form `{:noproc, {GenServer, :call, [pid, {:handle_event,
+  event}, timeout]}}`. It deliberately does **not** recurse into the fields of
+  non-event structs: rebuilding arbitrary structs is unsafe (enforced keys,
+  opaque types), and `inspect_scrubbed/1`'s finite limits bound the damage if an
+  event ever hides inside one.
+  """
+
+  alias Electric.Replication.Changes.Relation
+  alias Electric.Replication.Changes.TransactionFragment
+
+  @typedoc "An event whose payload is scrubbed to an identity summary."
+  @type event() :: TransactionFragment.t() | Relation.t()
+
+  # Inspect limits for a scrubbed term. Generous rather than infinite: real exit
+  # reasons are small, so a few-thousand element/binary cap leaves them
+  # untruncated while still bounding a pathological collection — or an event
+  # payload that slips past scrub/1 in some unanticipated reason shape — so
+  # neither can dump unbounded row data into the logs.
+  @inspect_limit 4000
+  @inspect_printable_limit 8192
+
+  @doc """
+  Summarize a single replication event as a one-line, payload-free string.
+
+  ## Examples
+
+      iex> alias Electric.Replication.Changes.TransactionFragment
+      iex> alias Electric.Postgres.Lsn
+      iex> summarize(%TransactionFragment{xid: 42, lsn: %Lsn{segment: 0, offset: 0}, change_count: 3})
+      "transaction fragment xid=42 lsn=0/0 changes=3"
+
+      iex> alias Electric.Replication.Changes.Relation
+      iex> summarize(%Relation{id: 16384, schema: "public", table: "items"})
+      ~S|relation "public"."items" (oid 16384)|
+  """
+  @spec summarize(event()) :: String.t()
+  def summarize(%TransactionFragment{} = fragment) do
+    "transaction fragment xid=#{fragment.xid} lsn=#{fragment.lsn} changes=#{fragment.change_count}"
+  end
+
+  def summarize(%Relation{} = rel) do
+    ~s|relation "#{rel.schema}"."#{rel.table}" (oid #{rel.id})|
+  end
+
+  @doc """
+  Replace any replication event embedded in `term` with its `summarize/1` string.
+
+  Recurses through tuples, lists and plain maps; every other value — scalars,
+  non-event structs — is returned unchanged.
+
+  ## Examples
+
+  An event nested in a tuple/list (the `:noproc` exit-reason shape) is collapsed,
+  while the surrounding structure is preserved:
+
+      iex> alias Electric.Replication.Changes.TransactionFragment
+      iex> alias Electric.Postgres.Lsn
+      iex> event = %TransactionFragment{xid: 42, lsn: %Lsn{segment: 0, offset: 0}, change_count: 3}
+      iex> scrub({:noproc, [event]})
+      {:noproc, ["#<transaction fragment xid=42 lsn=0/0 changes=3>"]}
+
+  An event nested in a map value is collapsed too:
+
+      iex> alias Electric.Replication.Changes.TransactionFragment
+      iex> alias Electric.Postgres.Lsn
+      iex> event = %TransactionFragment{xid: 7, lsn: %Lsn{segment: 0, offset: 0}, change_count: 1}
+      iex> scrub(%{reason: :crash, event: event})
+      %{reason: :crash, event: "#<transaction fragment xid=7 lsn=0/0 changes=1>"}
+
+  Terms without events pass through unchanged:
+
+      iex> scrub({:error, :not_ready})
+      {:error, :not_ready}
+
+  Non-event structs are left whole and are not recursed into:
+
+      iex> scrub(%RuntimeError{message: "boom"})
+      %RuntimeError{message: "boom"}
+  """
+  @spec scrub(term()) :: term()
+  def scrub(%TransactionFragment{} = event), do: "#<#{summarize(event)}>"
+  def scrub(%Relation{} = event), do: "#<#{summarize(event)}>"
+  def scrub(%_{} = other_struct), do: other_struct
+
+  def scrub(tuple) when is_tuple(tuple),
+    do: tuple |> Tuple.to_list() |> Enum.map(&scrub/1) |> List.to_tuple()
+
+  def scrub(map) when is_map(map),
+    do: Map.new(map, fn {k, v} -> {scrub(k), scrub(v)} end)
+
+  # head/tail recursion keeps this safe for improper lists, which can show up
+  # in arbitrary exit reasons
+  def scrub([head | tail]), do: [scrub(head) | scrub(tail)]
+  def scrub(other), do: other
+
+  @doc """
+  `scrub/1` a term, then `inspect/2` it with bounded limits for logging.
+
+  ## Examples
+
+      iex> alias Electric.Replication.Changes.TransactionFragment
+      iex> alias Electric.Postgres.Lsn
+      iex> event = %TransactionFragment{xid: 42, lsn: %Lsn{segment: 0, offset: 0}, change_count: 3}
+      iex> inspect_scrubbed({:noproc, [event]})
+      ~S|{:noproc, ["#<transaction fragment xid=42 lsn=0/0 changes=3>"]}|
+  """
+  @spec inspect_scrubbed(term()) :: String.t()
+  def inspect_scrubbed(term) do
+    term
+    |> scrub()
+    |> inspect(limit: @inspect_limit, printable_limit: @inspect_printable_limit)
+  end
+end

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -273,6 +273,43 @@ defmodule Electric.Postgres.ReplicationClientTest do
       assert %NewRecord{record: %{"value" => "test value 2"}} = receive_tx_change()
     end
 
+    @tag handle_event: {MockTransactionProcessor, :handle_event_async, []}
+    test "logs a failing event dispatch at error level once, not per retry attempt",
+         %{db_conn: conn} = ctx do
+      start_client(ctx)
+
+      # process one transaction so that the relation message is already
+      # handled and the failing event below is the transaction itself
+      start_supervised({MockTransactionProcessor, self()})
+      insert_item(conn, "first value")
+      assert %NewRecord{record: %{"value" => "first value"}} = receive_tx_change()
+
+      stop_supervised(MockTransactionProcessor)
+
+      error_log =
+        capture_log([level: :error], fn ->
+          # with the processor stopped every dispatch exits with :noproc and
+          # is retried every 50ms
+          insert_item(conn, "a private row value")
+          Process.sleep(500)
+        end)
+
+      error_lines =
+        error_log
+        |> String.split("\n")
+        |> Enum.count(&(&1 =~ "Error dispatching replication event"))
+
+      assert error_lines == 1
+
+      # the error-level log identifies the event without embedding row data
+      assert error_log =~ "xid="
+      refute error_log =~ "a private row value"
+
+      # the event is still delivered once the handler comes back up
+      start_supervised({MockTransactionProcessor, self()})
+      assert %NewRecord{record: %{"value" => "a private row value"}} = receive_tx_change()
+    end
+
     @tag database_settings: ["wal_sender_timeout='3s'"]
     @tag handle_event: {MockTransactionProcessor, :handle_event_async, []}
     test "connection survives wal_sender_timeout when event handler is unavailable",

--- a/packages/sync-service/test/electric/replication/changes/log_scrubber_test.exs
+++ b/packages/sync-service/test/electric/replication/changes/log_scrubber_test.exs
@@ -1,0 +1,68 @@
+defmodule Electric.Replication.Changes.LogScrubberTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Postgres.Lsn
+  alias Electric.Replication.Changes.LogScrubber
+  alias Electric.Replication.Changes.Relation
+  alias Electric.Replication.Changes.TransactionFragment
+
+  doctest LogScrubber, import: true
+
+  defp fragment(xid),
+    do: %TransactionFragment{xid: xid, lsn: %Lsn{segment: 0, offset: 0}, change_count: 1}
+
+  describe "scrub/1" do
+    test "replaces events nested at arbitrary depth, leaving the structure intact" do
+      reason = {:noproc, {GenServer, :call, [:pid, {:handle_event, fragment(99)}, 5000]}}
+
+      assert {:noproc, {GenServer, :call, [:pid, {:handle_event, summary}, 5000]}} =
+               LogScrubber.scrub(reason)
+
+      assert summary == "#<transaction fragment xid=99 lsn=0/0 changes=1>"
+    end
+
+    test "scrubs events embedded in an improper list without crashing" do
+      assert [:a | "#<transaction fragment xid=1 lsn=0/0 changes=1>"] =
+               LogScrubber.scrub([:a | fragment(1)])
+    end
+
+    test "scrubs events in map keys and values" do
+      assert %{"#<transaction fragment xid=2 lsn=0/0 changes=1>" => :v, k: summary} =
+               LogScrubber.scrub(%{fragment(2) => :v, k: fragment(3)})
+
+      assert summary == "#<transaction fragment xid=3 lsn=0/0 changes=1>"
+    end
+
+    test "leaves non-event structs untouched and does not recurse into their fields" do
+      # an event hidden in a non-event struct's field is NOT scrubbed by design
+      wrapper = %RuntimeError{message: "boom"}
+      assert ^wrapper = LogScrubber.scrub(wrapper)
+    end
+
+    test "passes scalar and event-free terms through unchanged" do
+      assert {:error, :not_ready} = LogScrubber.scrub({:error, :not_ready})
+      assert :noproc = LogScrubber.scrub(:noproc)
+    end
+  end
+
+  describe "summarize/1" do
+    test "summarizes a Relation by schema/table/oid" do
+      rel = %Relation{id: 16384, schema: "public", table: "items"}
+      assert LogScrubber.summarize(rel) == ~S|relation "public"."items" (oid 16384)|
+    end
+  end
+
+  describe "inspect_scrubbed/1" do
+    test "returns a bounded string with events collapsed and row data absent" do
+      event = %{
+        fragment(7)
+        | changes: [%{"value" => String.duplicate("secret", 10_000)}]
+      }
+
+      out = LogScrubber.inspect_scrubbed({:noproc, [event]})
+
+      assert out == ~S|{:noproc, ["#<transaction fragment xid=7 lsn=0/0 changes=1>"]}|
+      refute out =~ "secret"
+    end
+  end
+end


### PR DESCRIPTION
Fixes the log-flooding half of #4563.

A failing replication event is retried every `@event_retry_delay` for up to `@max_event_retry_time`, and every attempt logged at error level — up to thousands of error logs for a single incident. In Electric Cloud each of those lines becomes a Sentry event (`capture_log_messages: true`), which is how one tenant produced 7,000+ Sentry events from a single incident. Each message also embedded the full inspected event — potentially megabytes of customer row data copied into the logs on every attempt.

## Changes

- The first failure and one progress update per `@retry_log_interval` (30s) log at **error** level; attempts in between are not logged.
- On the first failure of an incident, the full `Exception.format/3` stacktrace is logged once at **debug** level before entering the throttled retry loop, so dispatch-crash detail is still captured without re-logging it on every attempt.
- The throttle window is wall-clock time tracked in the client state (reset on successful delivery), not retry budget: a fast failure like `:noproc` consumes no measurable budget, so budget-based throttling would never fire.
- Error-level messages carry the event identity (`xid`/LSN/relation instead of the full payload) and a scrubbed failure reason: any `TransactionFragment`/`Relation` embedded in the exit reason (e.g. as arguments in a `:noproc` tuple, or nested in a list/tuple/map) is replaced with a one-line summary before inspecting, so row data never reaches error-level logs. The scrubber is safe for improper lists and leaves non-event structs untouched.
- The reason is inspected with generous-but-finite limits (`limit: 4000`, `printable_limit: 8192`): real exit reasons are small so they reach the logs untruncated, while a pathological collection or an event payload that slips past the scrubber in an unanticipated reason shape stays bounded rather than dumping unbounded row data.
- The budget-exhaustion messages get the same identity + scrubbed-reason treatment (the subsequent raise/exit is unchanged).

Side observation (behavior unchanged in this PR): because the retry budget only counts time spent inside attempts, sub-millisecond failures like `:noproc` barely consume it, so the budget can run much longer in wall-clock terms for fast failures.

## Refactor (no behavior change)

- The event-summarising and exit-reason scrubbing logic is extracted from `ReplicationClient` into a dedicated `Electric.Replication.Changes.LogScrubber` utility with `@spec`s and doctested examples (`summarize/1`, `scrub/1`, `inspect_scrubbed/1`).
- The retry/exhaustion log messages are built as iolists passed to `Logger` instead of being concatenated with `<>`.

## Test

- A test drives the real `:noproc` retry loop against a database and asserts that the retry attempts produce exactly one error-level log line, that the line identifies the event by xid without containing the inserted row value, and that the event is still delivered once the handler comes back.
- `LogScrubberTest` adds doctests plus unit coverage for deep nesting, improper lists, events in map keys/values, non-event-struct passthrough, and absence of row data from the bounded `inspect_scrubbed/1` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
