### PR TITLE
Increase agent tool timeouts

### DIFF
--- a/.changeset/agent-tool-timeouts.md
+++ b/.changeset/agent-tool-timeouts.md
@@ -1,6 +1,7 @@
 ---
 '@electric-ax/agents-runtime': patch
 '@electric-ax/agents-mcp': patch
+'@electric-ax/agents-server-conformance-tests': patch
 ---
 
 Increase agent tool call timeouts to a 2-minute default with a 10-minute maximum, and allow bash calls to request longer timeouts per command.

--- a/.changeset/agent-tool-timeouts.md
+++ b/.changeset/agent-tool-timeouts.md
@@ -1,0 +1,6 @@
+---
+'@electric-ax/agents-runtime': patch
+'@electric-ax/agents-mcp': patch
+---
+
+Increase agent tool call timeouts to a 2-minute default with a 10-minute maximum, and allow bash calls to request longer timeouts per command.

--- a/packages/agents-mcp/src/transports/timeout.ts
+++ b/packages/agents-mcp/src/transports/timeout.ts
@@ -1,6 +1,14 @@
 import type { McpToolError } from '../types'
 
-export const DEFAULT_TIMEOUT_MS = 30_000
+export const DEFAULT_TIMEOUT_MS = 120_000
+export const MAX_TIMEOUT_MS = 600_000
+
+export function normalizeTimeoutMs(ms: number | undefined): number {
+  if (typeof ms !== `number` || !Number.isFinite(ms)) {
+    return DEFAULT_TIMEOUT_MS
+  }
+  return Math.min(Math.max(Math.trunc(ms), 1), MAX_TIMEOUT_MS)
+}
 
 class TimeoutError extends Error implements McpToolError {
   kind = `timeout` as const
@@ -10,9 +18,10 @@ class TimeoutError extends Error implements McpToolError {
 }
 
 export function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  const timeoutMs = normalizeTimeoutMs(ms)
   let timer: NodeJS.Timeout | undefined
   const guard = new Promise<T>((_, reject) => {
-    timer = setTimeout(() => reject(new TimeoutError(ms)), ms)
+    timer = setTimeout(() => reject(new TimeoutError(timeoutMs)), timeoutMs)
   })
   return Promise.race([p, guard]).finally(() => {
     if (timer) clearTimeout(timer)

--- a/packages/agents-mcp/src/types.ts
+++ b/packages/agents-mcp/src/types.ts
@@ -85,7 +85,7 @@ export interface McpHttpServerConfig {
   transport: `http`
   url: string
   auth: McpAuthConfig
-  /** Per-server timeout override in ms. Default 30000. */
+  /** Per-server timeout override in ms. Default 120000, maximum 600000. */
   timeoutMs?: number
 }
 
@@ -96,7 +96,7 @@ export interface McpStdioServerConfig {
   args?: string[]
   env?: Record<string, string>
   auth?: McpAuthConfig /* typically 'none' for stdio */
-  /** Per-server timeout override in ms. Default 30000. */
+  /** Per-server timeout override in ms. Default 120000, maximum 600000. */
   timeoutMs?: number
 }
 

--- a/packages/agents-mcp/test/transports/timeout.test.ts
+++ b/packages/agents-mcp/test/transports/timeout.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { withTimeout } from '../../src/transports/timeout'
+import {
+  DEFAULT_TIMEOUT_MS,
+  MAX_TIMEOUT_MS,
+  normalizeTimeoutMs,
+  withTimeout,
+} from '../../src/transports/timeout'
 
 describe(`withTimeout`, () => {
   it(`resolves when the inner promise resolves first`, async () => {
@@ -14,5 +19,11 @@ describe(`withTimeout`, () => {
     await expect(
       withTimeout(Promise.reject(new Error(`boom`)), 100)
     ).rejects.toThrow(`boom`)
+  })
+  it(`defaults to 2 minutes and clamps to a 10-minute maximum`, () => {
+    expect(DEFAULT_TIMEOUT_MS).toBe(120_000)
+    expect(MAX_TIMEOUT_MS).toBe(600_000)
+    expect(normalizeTimeoutMs(undefined)).toBe(120_000)
+    expect(normalizeTimeoutMs(900_000)).toBe(600_000)
   })
 })

--- a/packages/agents-runtime/src/tools/bash.ts
+++ b/packages/agents-runtime/src/tools/bash.ts
@@ -2,22 +2,40 @@ import { Type } from '@sinclair/typebox'
 import type { Sandbox } from '../sandbox/types'
 import type { AgentTool } from '@mariozechner/pi-agent-core'
 
-const TIMEOUT_MS = 30_000
+const DEFAULT_TIMEOUT_MS = 120_000
+const MAX_TIMEOUT_MS = 600_000
 const MAX_OUTPUT_BYTES = 50_000
+
+function normalizeTimeoutMs(value: unknown): number {
+  if (typeof value !== `number` || !Number.isFinite(value)) {
+    return DEFAULT_TIMEOUT_MS
+  }
+  return Math.min(Math.max(Math.trunc(value), 1), MAX_TIMEOUT_MS)
+}
 
 export function createBashTool(sandbox: Sandbox): AgentTool {
   return {
     name: `bash`,
     label: `Bash`,
-    description: `Execute a shell command and return its output. Commands run with a 30-second timeout and a 50KB output cap. The host process environment is not forwarded, so host secrets (e.g. API keys) are not available as environment variables.`,
+    description: `Execute a shell command and return its output. Commands run with a 2-minute timeout by default; pass timeoutMs to request up to 10 minutes. Commands have a 50KB output cap. The host process environment is not forwarded, so host secrets (e.g. API keys) are not available as environment variables.`,
     parameters: Type.Object({
       command: Type.String({ description: `The shell command to execute` }),
+      timeoutMs: Type.Optional(
+        Type.Number({
+          description: `Optional timeout in milliseconds. Defaults to 120000 (2 minutes), maximum 600000 (10 minutes). Values above the maximum are clamped.`,
+          minimum: 1,
+        })
+      ),
     }),
     execute: async (_toolCallId, params) => {
-      const { command } = params as { command: string }
+      const { command, timeoutMs: requestedTimeoutMs } = params as {
+        command: string
+        timeoutMs?: number
+      }
+      const timeoutMs = normalizeTimeoutMs(requestedTimeoutMs)
       const result = await sandbox.exec({
         command,
-        timeoutMs: TIMEOUT_MS,
+        timeoutMs,
         maxOutputBytes: MAX_OUTPUT_BYTES,
       })
 
@@ -27,7 +45,7 @@ export function createBashTool(sandbox: Sandbox): AgentTool {
         output += output ? `\n\nSTDERR:\n${stderr}` : stderr
       }
       if (result.timedOut) {
-        output += `\n\n[Command timed out after ${TIMEOUT_MS / 1000}s]`
+        output += `\n\n[Command timed out after ${timeoutMs / 1000}s]`
       }
       if (result.outputTruncated) {
         output += `\n\n[Output truncated at ${MAX_OUTPUT_BYTES} bytes]`

--- a/packages/agents-runtime/test/bash-tool.test.ts
+++ b/packages/agents-runtime/test/bash-tool.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createBashTool } from '../src/tools/bash'
 import { unrestrictedSandbox } from '../src/sandbox/unrestricted'
+import type { Sandbox } from '../src/sandbox/types'
 
 describe(`bash tool`, () => {
   let cwd: string
@@ -30,6 +31,29 @@ describe(`bash tool`, () => {
     expect(lines[0]).toBe(await realpath(cwd))
     expect(lines[1]).toBe(process.env.HOME ?? ``)
     await sandbox.dispose()
+  })
+
+  it(`uses a 2-minute default timeout and clamps requested timeouts to 10 minutes`, async () => {
+    const calls: Array<{ timeoutMs?: number }> = []
+    const sandbox = {
+      exec: async (opts: { timeoutMs?: number }) => {
+        calls.push(opts)
+        return {
+          stdout: Buffer.from(`ok`),
+          stderr: Buffer.from(``),
+          exitCode: 0,
+          timedOut: false,
+          outputTruncated: false,
+        }
+      },
+    } as unknown as Sandbox
+
+    const tool = createBashTool(sandbox)
+    await tool.execute(`call-1`, { command: `echo ok` })
+    await tool.execute(`call-2`, { command: `echo ok`, timeoutMs: 900_000 })
+
+    expect(calls[0]?.timeoutMs).toBe(120_000)
+    expect(calls[1]?.timeoutMs).toBe(600_000)
   })
 
   // The env-scrubbing characterization tests from #4354 documented the

--- a/packages/agents-server-conformance-tests/src/electric-agents-tests.ts
+++ b/packages/agents-server-conformance-tests/src/electric-agents-tests.ts
@@ -1908,12 +1908,15 @@ export function runElectricAgentsConformanceTests(
       const sandbox = await makeSandbox(`/tmp`)
       try {
         const tool = createBashTool(sandbox)
-        const result = await tool.execute(`test-tc`, { command: `sleep 60` })
+        const result = await tool.execute(`test-tc`, {
+          command: `sleep 60`,
+          timeoutMs: 1_000,
+        })
         expect(result.details.timedOut).toBe(true)
       } finally {
         await sandbox.dispose()
       }
-    }, 35_000)
+    }, 5_000)
 
     test(`read_file rejects paths outside working directory`, async () => {
       const { createReadFileTool } = await import(


### PR DESCRIPTION
## Summary

Increase agent tool call timeouts to better match real coding workflows.

Agent bash and MCP tool calls now default to 2 minutes, and timeout requests/configuration are capped at 10 minutes so longer builds/tests can run without allowing unbounded tool calls.

## Root Cause

The existing 30-second default was too short for common coding-agent tasks like dependency installs, builds, migrations, and focused test runs. Agents either had to avoid these commands or work around the tool limit with detached/background processes.

## Approach

- Change the built-in bash tool default timeout from 30 seconds to 2 minutes.
- Add an optional bash `timeoutMs` parameter so callers can request longer command execution.
- Clamp bash timeout requests to a 10-minute maximum before invoking the sandbox.
- Change MCP tool-call timeout defaults to 2 minutes and clamp configured values to the same 10-minute maximum.
- Update MCP config comments and add focused tests for the default/max behavior.

## Key Invariants

- Bash tool calls default to `120_000ms`.
- Bash tool calls never pass more than `600_000ms` to the sandbox.
- MCP tool calls normalize to the same `120_000ms` default / `600_000ms` maximum contract.
- Over-max bash timeout requests are accepted and clamped rather than rejected by schema validation.
- The existing 50KB bash output cap is unchanged.

## Non-goals

- This does not add a cross-package shared timeout helper; runtime and MCP keep local helpers to avoid unnecessary coupling.
- This does not change output truncation behavior.
- This does not document every lower-bound normalization edge case for invalid timeout values.

## Trade-offs

This follows Claude Code's rough timeout shape: a safer default that is long enough for most coding tasks, plus a hard upper bound so tool calls cannot run indefinitely. The bash schema documents the max without enforcing it as a JSON-schema `maximum`, which lets the runtime clamp over-max values consistently.

## Verification

```bash
pnpm install
pnpm --filter @electric-ax/agents-runtime test bash-tool.test.ts --run
pnpm --filter @electric-ax/agents-mcp test timeout.test.ts --run
pnpm --filter @electric-ax/agents-runtime build
pnpm --filter @electric-ax/agents-mcp build
GITHUB_BASE_REF=main node scripts/check-changeset.mjs
```

Note: the first `pnpm install` run hit the current 30-second tool-call timeout in this agent environment, so I completed it as a background command and then reran the verification commands successfully.

## Files changed

- `.changeset/agent-tool-timeouts.md` — patch changeset for runtime/MCP timeout changes.
- `packages/agents-runtime/src/tools/bash.ts` — add 2-minute default, optional `timeoutMs`, and 10-minute clamp for bash calls.
- `packages/agents-runtime/test/bash-tool.test.ts` — verify bash default and max timeout behavior.
- `packages/agents-mcp/src/transports/timeout.ts` — add 2-minute default and 10-minute max normalization for MCP calls.
- `packages/agents-mcp/src/types.ts` — update timeout config comments.
- `packages/agents-mcp/test/transports/timeout.test.ts` — verify MCP timeout constants and normalization.
