### PR TITLE
feat(agents): embedder docker-sandbox options + modelCatalog on AgentHandlerResult

### DIFF
--- a/.changeset/openfactory-sandbox-options.md
+++ b/.changeset/openfactory-sandbox-options.md
@@ -6,4 +6,4 @@ Embedder customization hooks for the built-in agents:
 
 - `BuiltinAgentHandlerOptions.dockerSandbox` ({ image, allowFloatingTag, env, extraMounts }) threads into the built-in `docker` sandbox profile. These are embedder/operator-trust inputs: `extraMounts` is subject to the runtime's docker-socket guard and `env` is passed verbatim into the container.
 - `AgentHandlerResult.modelCatalog` exposes the resolved model catalog so embedders can register sibling agent types with the same model resolution.
-- New exports: `resolveBuiltinModelConfig`, `resolveDockerSandboxOpts`, and types `BuiltinModelCatalog`, `BuiltinAgentModelConfig`, `BuiltinDockerSandboxOptions`, `BuiltinDockerSandboxMount`.
+- New exports: `resolveBuiltinModelConfig`, and types `BuiltinModelCatalog`, `BuiltinAgentModelConfig`, `BuiltinDockerSandboxOptions`, `BuiltinDockerSandboxMount`.

--- a/.changeset/openfactory-sandbox-options.md
+++ b/.changeset/openfactory-sandbox-options.md
@@ -2,4 +2,8 @@
 '@electric-ax/agents': minor
 ---
 
-Embedder customization for built-in agents: `BuiltinAgentHandlerOptions.dockerSandbox` ({ image, env, extraMounts, allowFloatingTag }) threads into the built-in `docker` sandbox profile, `AgentHandlerResult.modelCatalog` exposes the resolved model catalog, and `resolveBuiltinModelConfig` (+ `BuiltinModelCatalog`, `BuiltinAgentModelConfig`, docker-option types) are now exported so embedders can register sibling agent types with the same model resolution.
+Embedder customization hooks for the built-in agents:
+
+- `BuiltinAgentHandlerOptions.dockerSandbox` ({ image, allowFloatingTag, env, extraMounts }) threads into the built-in `docker` sandbox profile. These are embedder/operator-trust inputs: `extraMounts` is subject to the runtime's docker-socket guard and `env` is passed verbatim into the container.
+- `AgentHandlerResult.modelCatalog` exposes the resolved model catalog so embedders can register sibling agent types with the same model resolution.
+- New exports: `resolveBuiltinModelConfig`, `resolveDockerSandboxOpts`, and types `BuiltinModelCatalog`, `BuiltinAgentModelConfig`, `BuiltinDockerSandboxOptions`, `BuiltinDockerSandboxMount`.

--- a/.changeset/openfactory-sandbox-options.md
+++ b/.changeset/openfactory-sandbox-options.md
@@ -1,5 +1,5 @@
 ---
-'@electric-ax/agents': minor
+'@electric-ax/agents': patch
 ---
 
 Embedder customization hooks for the built-in agents:

--- a/.changeset/openfactory-sandbox-options.md
+++ b/.changeset/openfactory-sandbox-options.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents': minor
+---
+
+Embedder customization for built-in agents: `BuiltinAgentHandlerOptions.dockerSandbox` ({ image, env, extraMounts, allowFloatingTag }) threads into the built-in `docker` sandbox profile, `AgentHandlerResult.modelCatalog` exposes the resolved model catalog, and `resolveBuiltinModelConfig` (+ `BuiltinModelCatalog`, `BuiltinAgentModelConfig`, docker-option types) are now exported so embedders can register sibling agent types with the same model resolution.

--- a/packages/agents/src/bootstrap.ts
+++ b/packages/agents/src/bootstrap.ts
@@ -23,6 +23,7 @@ import { serverLog } from './log'
 import { registerHorton } from './agents/horton'
 import { registerWorker } from './agents/worker'
 import { createBuiltinModelCatalog } from './model-catalog'
+import type { BuiltinModelCatalog } from './model-catalog'
 import { createSkillsRegistry } from '@electric-ax/agents-runtime'
 import type {
   AgentTool,
@@ -51,11 +52,36 @@ export interface AgentHandlerResult {
    * die with the process, which would leave containers running.
    */
   shutdownSandboxes: (() => Promise<void>) | null
+  /**
+   * Model catalog the built-in agents resolve `model` args against — lets
+   * embedders register sibling agent types with the same model resolution.
+   */
+  modelCatalog: BuiltinModelCatalog
 }
 
 export type BuiltinElectricToolsFactory = NonNullable<
   ProcessWakeConfig[`createElectricTools`]
 >
+
+/** Mount spec mirroring `DockerSandboxOpts['extraMounts']` items. */
+export interface BuiltinDockerSandboxMount {
+  hostPath: string
+  containerPath: string
+  readOnly?: boolean
+}
+
+/**
+ * Embedder customization for the built-in `docker` sandbox profile.
+ * Threads straight into `dockerSandbox()` (which already supports these);
+ * custom `extraMounts` are appended after the working-directory mount.
+ */
+export interface BuiltinDockerSandboxOptions {
+  /** Digest-pinned image unless `allowFloatingTag` is set. */
+  image?: string
+  allowFloatingTag?: boolean
+  env?: Record<string, string>
+  extraMounts?: Array<BuiltinDockerSandboxMount>
+}
 
 export interface BuiltinAgentHandlerOptions {
   agentServerUrl: string
@@ -72,6 +98,8 @@ export interface BuiltinAgentHandlerOptions {
     typeName: string
   ) => DispatchPolicy | undefined
   createElectricTools?: BuiltinElectricToolsFactory
+  /** Customize the built-in `docker` sandbox profile (image, env, mounts). */
+  dockerSandbox?: BuiltinDockerSandboxOptions
 }
 
 function toolName(tool: AgentTool): string | null {
@@ -120,6 +148,7 @@ export async function createBuiltinAgentHandler(
     baseSkillsDir: baseSkillsDirOverride,
     serverHeaders,
     defaultDispatchPolicyForType,
+    dockerSandbox: dockerSandboxOpts,
   } = options
 
   const modelCatalog = await createBuiltinModelCatalog({
@@ -169,7 +198,7 @@ export async function createBuiltinAgentHandler(
   typeNames.push(`worker`)
 
   const { profiles: sandboxProfiles, shutdownSandboxes } =
-    await buildBuiltinSandboxProfiles(cwd)
+    await buildBuiltinSandboxProfiles(cwd, dockerSandboxOpts)
 
   const runtime = createRuntimeHandler({
     baseUrl: agentServerUrl,
@@ -192,6 +221,7 @@ export async function createBuiltinAgentHandler(
     typeNames,
     skillsRegistry,
     shutdownSandboxes,
+    modelCatalog,
   }
 }
 
@@ -256,6 +286,33 @@ function sweepOrphanedDockerSandboxesOnce(
 }
 
 /**
+ * Merge the profile's working-directory mount with embedder docker options
+ * into the option fragment spread into `dockerSandbox()`. Exported for tests.
+ */
+export function resolveDockerSandboxOpts(
+  cwdMount: BuiltinDockerSandboxMount | undefined,
+  custom: BuiltinDockerSandboxOptions | undefined
+): {
+  image?: string
+  allowFloatingTag?: boolean
+  env?: Record<string, string>
+  extraMounts?: Array<BuiltinDockerSandboxMount>
+} {
+  const extraMounts = [
+    ...(cwdMount ? [cwdMount] : []),
+    ...(custom?.extraMounts ?? []),
+  ]
+  return {
+    ...(custom?.image !== undefined && { image: custom.image }),
+    ...(custom?.allowFloatingTag !== undefined && {
+      allowFloatingTag: custom.allowFloatingTag,
+    }),
+    ...(custom?.env !== undefined && { env: custom.env }),
+    ...(extraMounts.length > 0 && { extraMounts }),
+  }
+}
+
+/**
  * Built-in sandbox profiles. `local` is always available. `docker` is
  * gated on Docker being reachable so a user without Docker installed
  * sees only what works — the UI never offers a non-functional choice.
@@ -265,7 +322,10 @@ function sweepOrphanedDockerSandboxesOnce(
  * server must run on shutdown (the providers' debounced idle teardowns die
  * with the process).
  */
-async function buildBuiltinSandboxProfiles(workingDirectory: string): Promise<{
+async function buildBuiltinSandboxProfiles(
+  workingDirectory: string,
+  dockerOpts?: BuiltinDockerSandboxOptions
+): Promise<{
   profiles: Array<SandboxProfile>
   shutdownSandboxes: (() => Promise<void>) | null
 }> {
@@ -327,9 +387,12 @@ async function buildBuiltinSandboxProfiles(workingDirectory: string): Promise<{
                 // fully-isolated rather than splitting into `docker-permissive`
                 // / `docker-isolated`.
                 initialNetworkPolicy: { mode: `allow-all` },
-                extraMounts: cwd
-                  ? [{ hostPath: cwd, containerPath: `/work`, readOnly: false }]
-                  : undefined,
+                ...resolveDockerSandboxOpts(
+                  cwd
+                    ? { hostPath: cwd, containerPath: `/work`, readOnly: false }
+                    : undefined,
+                  dockerOpts
+                ),
                 // The container is always named-by-key and reattachable;
                 // `persistent` chooses idle teardown (stop vs remove) and
                 // `owner` gates creation (an attacher reattaches only). All

--- a/packages/agents/src/bootstrap.ts
+++ b/packages/agents/src/bootstrap.ts
@@ -74,6 +74,9 @@ export interface BuiltinDockerSandboxMount {
  * Embedder customization for the built-in `docker` sandbox profile.
  * Threads straight into `dockerSandbox()` (which already supports these);
  * custom `extraMounts` are appended after the working-directory mount.
+ * These are embedder/operator-trust inputs: `extraMounts` is subject to the
+ * runtime's docker-socket guard, and `env` is passed verbatim into the
+ * container.
  */
 export interface BuiltinDockerSandboxOptions {
   /** Digest-pinned image unless `allowFloatingTag` is set. */

--- a/packages/agents/src/bootstrap.ts
+++ b/packages/agents/src/bootstrap.ts
@@ -78,8 +78,10 @@ export interface BuiltinDockerSandboxMount {
 type _AssignableTo<A extends B, B> = A
 type _AssertMountCompat = _AssignableTo<
   BuiltinDockerSandboxMount,
-  // eslint-disable-next-line quotes -- type-position import() requires a string literal
-  NonNullable<import('@electric-ax/agents-runtime/sandbox/docker').DockerSandboxOpts['extraMounts']>[number]
+  NonNullable<
+    // eslint-disable-next-line quotes -- type-position import() requires a string literal
+    import('@electric-ax/agents-runtime/sandbox/docker').DockerSandboxOpts['extraMounts']
+  >[number]
 >
 
 /**

--- a/packages/agents/src/bootstrap.ts
+++ b/packages/agents/src/bootstrap.ts
@@ -70,6 +70,18 @@ export interface BuiltinDockerSandboxMount {
   readOnly?: boolean
 }
 
+// Compile-time drift guard: keep `BuiltinDockerSandboxMount` (intentionally
+// duplicated to keep the runtime docker subpath out of the import graph)
+// assignable to the runtime's mount shape. The constrained generic errors at
+// instantiation if the shapes drift; the inline `import(...)` type is fully
+// erased, so this adds no runtime dependency.
+type _AssignableTo<A extends B, B> = A
+type _AssertMountCompat = _AssignableTo<
+  BuiltinDockerSandboxMount,
+  // eslint-disable-next-line quotes -- type-position import() requires a string literal
+  NonNullable<import('@electric-ax/agents-runtime/sandbox/docker').DockerSandboxOpts['extraMounts']>[number]
+>
+
 /**
  * Embedder customization for the built-in `docker` sandbox profile.
  * Threads straight into `dockerSandbox()` (which already supports these);
@@ -77,6 +89,10 @@ export interface BuiltinDockerSandboxMount {
  * These are embedder/operator-trust inputs: `extraMounts` is subject to the
  * runtime's docker-socket guard, and `env` is passed verbatim into the
  * container.
+ *
+ * Note: custom `extraMounts` must not target the working-directory container
+ * path (`/work`) — it collides with the cwd mount and fails at container-create
+ * time with an opaque docker error.
  */
 export interface BuiltinDockerSandboxOptions {
   /** Digest-pinned image unless `allowFloatingTag` is set. */
@@ -290,7 +306,9 @@ function sweepOrphanedDockerSandboxesOnce(
 
 /**
  * Merge the profile's working-directory mount with embedder docker options
- * into the option fragment spread into `dockerSandbox()`. Exported for tests.
+ * into the option fragment spread into `dockerSandbox()`. An internal helper:
+ * exported from this module so the unit test can import it, but intentionally
+ * not re-exported from `index.ts` (not part of the package's public API).
  */
 export function resolveDockerSandboxOpts(
   cwdMount: BuiltinDockerSandboxMount | undefined,

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -5,11 +5,14 @@ export {
   createAgentHandler,
   registerBuiltinAgentTypes,
   registerAgentTypes,
+  resolveDockerSandboxOpts,
 } from './bootstrap.js'
 export type {
   AgentHandlerResult,
   BuiltinElectricToolsFactory,
   BuiltinAgentHandlerOptions,
+  BuiltinDockerSandboxMount,
+  BuiltinDockerSandboxOptions,
 } from './bootstrap.js'
 
 export { BuiltinAgentsServer } from './server.js'
@@ -47,11 +50,14 @@ export {
 export {
   builtinModelProviderLabel,
   listBuiltinModelChoices,
+  resolveBuiltinModelConfig,
 } from './model-catalog.js'
 export type {
   BuiltinModelCatalogOptions,
   BuiltinModelChoice,
   BuiltinModelProvider,
+  BuiltinAgentModelConfig,
+  BuiltinModelCatalog,
 } from './model-catalog.js'
 export { registerWorker } from './agents/worker.js'
 export {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -5,7 +5,6 @@ export {
   createAgentHandler,
   registerBuiltinAgentTypes,
   registerAgentTypes,
-  resolveDockerSandboxOpts,
 } from './bootstrap.js'
 export type {
   AgentHandlerResult,

--- a/packages/agents/test/docker-sandbox-options.test.ts
+++ b/packages/agents/test/docker-sandbox-options.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { resolveDockerSandboxOpts } from '../src/bootstrap'
+
+const cwdMount = {
+  hostPath: `/home/u/project`,
+  containerPath: `/work`,
+  readOnly: false,
+}
+
+describe(`resolveDockerSandboxOpts`, () => {
+  it(`returns only the cwd mount when no custom options are given`, () => {
+    expect(resolveDockerSandboxOpts(cwdMount, undefined)).toEqual({
+      extraMounts: [cwdMount],
+    })
+  })
+
+  it(`threads image, allowFloatingTag, and env through`, () => {
+    expect(
+      resolveDockerSandboxOpts(undefined, {
+        image: `ghcr.io/acme/sandbox@sha256:abc`,
+        allowFloatingTag: false,
+        env: { FOO: `bar` },
+      })
+    ).toEqual({
+      image: `ghcr.io/acme/sandbox@sha256:abc`,
+      allowFloatingTag: false,
+      env: { FOO: `bar` },
+    })
+  })
+
+  it(`appends custom mounts after the cwd mount`, () => {
+    const custom = {
+      extraMounts: [
+        {
+          hostPath: `/secrets/key.pem`,
+          containerPath: `/secrets/key.pem`,
+          readOnly: true,
+        },
+      ],
+    }
+    expect(resolveDockerSandboxOpts(cwdMount, custom)).toEqual({
+      extraMounts: [cwdMount, custom.extraMounts[0]],
+    })
+  })
+
+  it(`returns an empty object when there is nothing to apply`, () => {
+    expect(resolveDockerSandboxOpts(undefined, undefined)).toEqual({})
+  })
+})


### PR DESCRIPTION
## What

- `BuiltinAgentHandlerOptions.dockerSandbox?: { image, allowFloatingTag, env, extraMounts }` — threads into the built-in `docker` sandbox profile's `dockerSandbox()` call (which already supports all of these). Custom mounts append after the working-directory mount.
- `AgentHandlerResult.modelCatalog` — exposes the catalog `createBuiltinAgentHandler` already builds.
- Exports: `resolveBuiltinModelConfig`, `resolveDockerSandboxOpts`, and types `BuiltinModelCatalog`, `BuiltinAgentModelConfig`, `BuiltinDockerSandboxOptions`, `BuiltinDockerSandboxMount`.

## Why

OpenFactory registers a custom Discord-facing agent entity alongside horton/worker. It needs (a) a sandbox image with git + gh + a GitHub-App token helper baked in, plus the GH_APP env/key mount inside the container, and (b) the same model-arg resolution the built-in agents use, without re-implementing the catalog.

## Tests

`packages/agents/test/docker-sandbox-options.test.ts` covers the option merge (cwd-mount only, full passthrough, mount append, empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Notes for reviewers

- `BuiltinDockerSandboxMount` intentionally duplicates the runtime's mount item shape instead of importing `DockerSandboxOpts` — that type only exists on the `@electric-ax/agents-runtime/sandbox/docker` subpath, which this package deliberately keeps out of its top-level import graph (docker code is reached via dynamic import only).
- `env` / `extraMounts` extend the existing embedder/operator trust boundary: same trust level as the embedder process itself, and `extraMounts` stays behind the runtime's docker-socket guard.
