### PR TITLE
fix(agents): keep Codex reasoning payloads stateless

### DIFF
--- a/.changeset/codex-store-false.md
+++ b/.changeset/codex-store-false.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents': patch
+---
+
+Stop forcing `store: true` on OpenAI Codex reasoning payloads. The ChatGPT-login Codex endpoint is stateless-only and rejects stateful requests with `{"detail":"Store must be set to false"}`, which broke every Codex (`gpt-5.x`) run. The stateful default now applies to the regular OpenAI Responses API only.

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -270,8 +270,12 @@ function withProviderPayloadDefaults(
         // OpenAI Responses reasoning/tool-call continuations replay rs_*
         // reasoning items. With store:false, OpenAI does not persist those
         // items server-side, which can make follow-up requests fail with
-        // "Item with id ... not found". Keep Responses stateful for built-ins.
-        store: true,
+        // "Item with id ... not found". Keep Responses stateful for the
+        // regular API. The ChatGPT-login Codex endpoint is the opposite:
+        // it is stateless-only and rejects any stateful request with
+        // `{"detail":"Store must be set to false"}`, so it must keep the
+        // upstream store:false default.
+        ...(choice.provider === `openai` && { store: true }),
         reasoning: {
           ...existingReasoning,
           effort,

--- a/packages/agents/test/model-catalog.test.ts
+++ b/packages/agents/test/model-catalog.test.ts
@@ -191,6 +191,38 @@ describe(`model catalog`, () => {
     expect(deepseekConfig.onPayload).toBeUndefined()
   })
 
+  it(`keeps Codex reasoning model payloads stateless`, async () => {
+    // The ChatGPT-login Codex endpoint rejects stateful requests with
+    // `{"detail":"Store must be set to false"}` — the openai branch's
+    // store:true override must not leak into openai-codex payloads.
+    delete process.env.OPENAI_API_KEY
+    process.env.ELECTRIC_CODEX_ACCESS_TOKEN = `test-codex-token`
+
+    const catalog = await createBuiltinModelCatalog()
+    const config = resolveBuiltinModelConfig(catalog!, {
+      model: `openai-codex:gpt-5.4`,
+    })
+
+    expect(config).toMatchObject({
+      provider: `openai-codex`,
+      model: `gpt-5.4`,
+    })
+    expect(config.onPayload).toBeTypeOf(`function`)
+
+    const payload = config.onPayload!(
+      { store: false, reasoning: { effort: `none` } },
+      {} as any
+    )
+
+    expect(payload).toEqual({
+      store: false,
+      reasoning: { effort: `low` },
+    })
+    expect(
+      config.onPayload!({ reasoning: { effort: `none` } }, {} as any)
+    ).not.toHaveProperty(`store`)
+  })
+
   it(`does not expose providers whose keys are rejected`, async () => {
     vi.stubGlobal(
       `fetch`,


### PR DESCRIPTION
## Summary

#4557 forced `store: true` on built-in reasoning payloads for **both** `openai` and `openai-codex` so OpenAI Responses continuations can replay `rs_*` reasoning items. But the ChatGPT-login Codex endpoint is stateless-only and hard-rejects any stateful request:

```
pi-adapter message_end ERROR stopReason=error errorMessage={"detail":"Store must be set to false"}
```

Since #4557 merged, **every Codex (gpt-5.x via ChatGPT login) run fails immediately**, even a plain "Hi" with no tool calls.

## Fix

Scope the stateful default to the regular OpenAI Responses API only — the `openai-codex` payload keeps the upstream `store: false` default (pre-#4557 behavior). This means the `rs_* not found` continuation issue #4557 addressed remains possible on Codex, but stateful requests can never work against that endpoint anyway; a stateless fix there would need the encrypted reasoning-content replay path (explicitly a non-goal in #4557).

## Test plan

- [x] `pnpm exec vitest run test/model-catalog.test.ts` in `packages/agents` (15 passed) — adds a regression test that `openai-codex` payloads get no `store` override (and an incoming `store: false` survives), while the existing `openai` store-true coverage still passes
- [x] `pnpm typecheck` clean in `packages/agents`
- [x] Manually reproduced against the desktop app: `gpt-5.5` runs failed with the store error before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)