### PR TITLE
Fix same-table subquery dependency deduplication

### DIFF
--- a/.changeset/fix-subquery-dependency-dedup.md
+++ b/.changeset/fix-subquery-dependency-dedup.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix subquery dependency deduplication for same-table subqueries that project different columns, preventing plain snapshots from silently dropping one arm of an `OR` filter.

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -33,7 +33,7 @@ defmodule Electric.ShapeCache.ShapeStatus do
         }
 
   # MUST be updated when Shape.comparable/1 changes.
-  @version 8
+  @version 9
 
   # Tuple format: {handle, hash, snapshot_started, last_read_time, generation}
   @shape_last_used_time_pos 4

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -113,6 +113,7 @@ defmodule Electric.Shapes.Shape do
   def comparable(%__MODULE__{} = shape) do
     {:shape, {shape.root_table_id, shape.root_table}, shape.root_pk,
      Comparable.comparable(shape.where), shape.selected_columns,
+     shape.explicitly_selected_columns,
      Enum.flat_map(shape.flags, fn {k, v} -> if(v, do: [k], else: []) end) |> Enum.sort(),
      shape.replica, shape.log_mode}
   end

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -983,6 +983,41 @@ defmodule Electric.Shapes.ShapeTest do
     end
   end
 
+  describe "subquery dependency construction" do
+    test "does not deduplicate subqueries with different projected columns" do
+      inspector =
+        Support.StubInspector.new(%{
+          "item" => [
+            %{name: "id", pk_position: 0}
+          ],
+          "rel" => [
+            %{name: "a", pk_position: 0},
+            %{name: "b", pk_position: 1},
+            %{name: "kind", pk_position: 2}
+          ]
+        })
+
+      assert {:ok, %Shape{where: where, shape_dependencies: dependencies}} =
+               Shape.new("item",
+                 inspector: inspector,
+                 feature_flags: ["allow_subqueries"],
+                 where:
+                   "id IN (SELECT a FROM rel WHERE kind = 'k') OR id IN (SELECT b FROM rel WHERE kind = 'k')"
+               )
+
+      assert Enum.map(dependencies, & &1.explicitly_selected_columns) == [["a"], ["b"]]
+
+      assert where.query ==
+               "id IN (SELECT a FROM public.rel WHERE kind = 'k') OR id IN (SELECT b FROM public.rel WHERE kind = 'k')"
+
+      assert where.used_refs == %{
+               ["id"] => :text,
+               ["$sublink", "0"] => {:array, :text},
+               ["$sublink", "1"] => {:array, :text}
+             }
+    end
+  end
+
   describe "new!/2" do
     import Support.DbSetup
     import Support.DbStructureSetup


### PR DESCRIPTION
This PR fixes the bugs with where clauses such as `id IN (SELECT a FROM rel ...) OR id IN (SELECT b FROM rel ...)` where both subqueries are treated as the same even though there selected columns differ, as raised by [vibl](https://github.com/electric-sql/electric/issues/3675#issuecomment-4701113417)

## Summary
- include explicitly selected columns in shape comparability so same-table subqueries projecting different PK columns remain distinct dependencies
- bump the shape status version because shape hash semantics changed
