### PR TITLE
feat(agents-mobile): bring fork capability to parity with desktop

### DIFF
--- a/.changeset/agents-mobile-fork.md
+++ b/.changeset/agents-mobile-fork.md
@@ -1,0 +1,12 @@
+---
+"@electric-ax/agents-mobile": patch
+"@electric-ax/agents-server-ui": patch
+---
+
+Bring the fork capability to mobile at parity with desktop:
+
+- **Whole-subtree fork.** A gated **Fork subtree** item in the session kebab (`SessionMenu`) — root-only (`!entity.parent`), disabled when the session is stopped/killed or the caller lacks the `fork` permission, with a single-flight guard, a pending spinner, and an inline error; on success it navigates to the new root. Backed by a native `forkEntity` in `agentsClient` (POST `…/fork`, empty body = whole-subtree HEAD clone) built on the shared `entityApiUrl` helper and exposed through `AgentsProvider`. `SESSION_PERMISSIONS` gains `fork`, and a `git-fork` glyph is added to the native icon set.
+- **Per-message "Fork from here".** The pointer fork already rendered via the shared `ChatLogView` embed; its mutation now runs through native RN networking instead of the WebView's `fetch`. `createForkEntity` gains an optional transport and the embed injects a marshalled `onRequestForkEntity`, so the embed's only mutation uses the same native path every other mobile mutation already uses (mirroring desktop's Electron IPC routing), while keeping the shared failure-toast behaviour.
+- **Embedded button hardening.** Extracted a tested `singleFlight` primitive, added a spinner + disabled state to the embedded fork button, and mounted a `ToastProvider` inside the embed so fork failures surface in the WebView instead of vanishing into a listener-less bus.
+
+No server API changes.

--- a/packages/agents-mobile/app/session.tsx
+++ b/packages/agents-mobile/app/session.tsx
@@ -36,6 +36,12 @@ type SessionDomEmbedProps = {
   inlineQueuedMessages?: Array<OptimisticInboxMessage>
   bottomInset?: number
   onRequestOpenEntity: (entityUrl: string) => Promise<void>
+  // Marshalled so the per-message fork runs over native networking; pointer
+  // shape matches the runtime's `EventPointer`.
+  onRequestForkEntity?: (
+    entityUrl: string,
+    opts?: { pointer?: { offset: string | null; subOffset: number } }
+  ) => Promise<{ url: string }>
   style?: StyleProp<ViewStyle>
   matchContents?: boolean
   serverHeaders?: { url: string; headers: Record<string, string> } | null
@@ -68,7 +74,7 @@ function SessionRouteInner({
   }
   router: ReturnType<typeof useRouter>
 }): React.ReactElement {
-  const { serverUrl } = useAgents()
+  const { serverUrl, forkEntity } = useAgents()
   const tokens = useTokens()
   const scheme = useColorSchemeMode()
   const insets = useSafeAreaInsets()
@@ -153,6 +159,9 @@ function SessionRouteInner({
             bottomInset={composerInset}
             serverHeaders={serverHeaders}
             onRequestOpenEntity={async (target) => openSession(target)}
+            onRequestForkEntity={(targetUrl, opts) =>
+              forkEntity({ entityUrl: targetUrl, pointer: opts?.pointer })
+            }
             dom={domOptions(styles, embedSize, tokens.bg)}
           />
         ) : (
@@ -186,6 +195,7 @@ function SessionRouteInner({
           entityUrl={entityUrl}
           onBack={goBack}
           onSetView={setView}
+          onOpenEntity={openSession}
           onShare={openShare}
         />
       )}

--- a/packages/agents-mobile/app/session.tsx
+++ b/packages/agents-mobile/app/session.tsx
@@ -12,6 +12,7 @@ import {
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useAgents } from '../src/lib/AgentsProvider'
+import type { ForkPointer } from '../src/lib/agentsClient'
 import { useAgentsRouteGuard } from '../src/lib/useAgentsRouteGuard'
 import { useColorSchemeMode, useTokens } from '../src/lib/ThemeProvider'
 import {
@@ -36,11 +37,10 @@ type SessionDomEmbedProps = {
   inlineQueuedMessages?: Array<OptimisticInboxMessage>
   bottomInset?: number
   onRequestOpenEntity: (entityUrl: string) => Promise<void>
-  // Marshalled so the per-message fork runs over native networking; pointer
-  // shape matches the runtime's `EventPointer`.
+  // Marshalled so the per-message fork runs over native networking.
   onRequestForkEntity?: (
     entityUrl: string,
-    opts?: { pointer?: { offset: string | null; subOffset: number } }
+    opts?: { pointer?: ForkPointer }
   ) => Promise<{ url: string }>
   style?: StyleProp<ViewStyle>
   matchContents?: boolean

--- a/packages/agents-mobile/src/components/Icon.tsx
+++ b/packages/agents-mobile/src/components/Icon.tsx
@@ -47,6 +47,7 @@ export type IconName =
   | `share`
   | `eye`
   | `shield`
+  | `git-fork`
 
 const PATHS: Record<IconName, string> = {
   back: `M15 18l-6-6 6-6`,
@@ -87,6 +88,8 @@ const PATHS: Record<IconName, string> = {
   // desktop share dialog's View/Manage segments.
   eye: `M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7ZM12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z`,
   shield: `M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1 1 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1ZM9 12l2 2 4-4`,
+  // Lucide `git-fork` — trunk only; the three nodes render as <Circle>s below.
+  'git-fork': `M18 9v2c0 .6-.4 1-1 1H7c-.6 0-1-.4-1-1V9M12 12v3`,
   github: `M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4M9 18c-4.51 2-5-2-7-2`,
   // Official Google "G" mark, rendered in a single fill colour. Google's
   // brand guidelines permit monochrome use in CTA contexts where the
@@ -119,6 +122,45 @@ export function Icon({
     return (
       <Svg width={size} height={size} viewBox="0 0 24 24">
         <Path d={PATHS[name]} fill={color} />
+      </Svg>
+    )
+  }
+
+  if (name === `git-fork`) {
+    return (
+      <Svg width={size} height={size} viewBox="0 0 24 24">
+        <Circle
+          cx={12}
+          cy={18}
+          r={3}
+          stroke={color}
+          strokeWidth={strokeWidth}
+          fill="none"
+        />
+        <Circle
+          cx={6}
+          cy={6}
+          r={3}
+          stroke={color}
+          strokeWidth={strokeWidth}
+          fill="none"
+        />
+        <Circle
+          cx={18}
+          cy={6}
+          r={3}
+          stroke={color}
+          strokeWidth={strokeWidth}
+          fill="none"
+        />
+        <Path
+          d={PATHS[name]}
+          stroke={color}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
       </Svg>
     )
   }

--- a/packages/agents-mobile/src/components/SessionMenu.tsx
+++ b/packages/agents-mobile/src/components/SessionMenu.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from 'react'
-import { Animated, Pressable, StyleSheet, Text, View } from 'react-native'
+import {
+  ActivityIndicator,
+  Animated,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
 import {
   BottomSheet,
   BottomSheetItem,
@@ -123,6 +130,10 @@ export function SessionMenu({
   onStopImmediately,
   onShare,
   signalDisabled = false,
+  onFork,
+  forkError,
+  forkPending = false,
+  forkDisabled = false,
 }: {
   open: boolean
   onClose: () => void
@@ -135,6 +146,11 @@ export function SessionMenu({
   /** Opens the share & access screen. */
   onShare?: () => void
   signalDisabled?: boolean
+  /** Forks the whole subtree (HEAD clone); root entities only. */
+  onFork?: () => void
+  forkError?: string | null
+  forkPending?: boolean
+  forkDisabled?: boolean
 }): React.ReactElement {
   const tokens = useTokens()
   const { copiedKey, copy } = useCopyFeedback()
@@ -146,6 +162,11 @@ export function SessionMenu({
     drill,
     reset: resetDrill,
   } = useDrillTransition()
+
+  const entityTerminal =
+    entity?.status === `stopped` || entity?.status === `killed`
+  // Root-only, matching desktop's tile menu.
+  const showFork = entity !== null && !entity.parent && Boolean(onFork)
 
   const dotKey = entity ? (STATUS_DOT_COLORS[entity.status] ?? `gray`) : `gray`
   const dotColor =
@@ -399,6 +420,48 @@ export function SessionMenu({
                       }}
                     />
                   )}
+                  {showFork && (
+                    <BottomSheetItem
+                      label={forkPending ? `Forking…` : `Fork subtree`}
+                      subtitle={
+                        forkDisabled && !forkPending
+                          ? `Fork permission required`
+                          : undefined
+                      }
+                      icon={
+                        <Icon
+                          name="git-fork"
+                          size={18}
+                          color={tokens.text2}
+                          strokeWidth={2}
+                        />
+                      }
+                      trailing={
+                        forkPending ? (
+                          <ActivityIndicator
+                            size="small"
+                            color={tokens.text3}
+                          />
+                        ) : undefined
+                      }
+                      disabled={forkDisabled || forkPending || entityTerminal}
+                      // Sheet stays open; the screen closes it on success and
+                      // keeps it open to show `forkError` on failure.
+                      onPress={() => onFork?.()}
+                    />
+                  )}
+                  {showFork && forkError ? (
+                    <Text
+                      style={{
+                        color: tokens.red11,
+                        fontSize: 12,
+                        paddingHorizontal: 12,
+                        paddingBottom: 8,
+                      }}
+                    >
+                      {forkError}
+                    </Text>
+                  ) : null}
                 </BottomSheetSection>
               </>
             )}

--- a/packages/agents-mobile/src/lib/AgentsProvider.tsx
+++ b/packages/agents-mobile/src/lib/AgentsProvider.tsx
@@ -5,11 +5,13 @@ import {
   createEntityEffectivePermissionsCollection,
   createRunnersCollection,
   createUsersCollection,
+  forkEntity,
   signalEntity,
   type EntitiesCollection,
   type EntityEffectivePermissionsCollection,
   type EntityTypesCollection,
   type EntitySignal,
+  type ForkPointer,
   type RunnersCollection,
   type UsersCollection,
 } from './agentsClient'
@@ -27,6 +29,10 @@ type AgentsContextValue = {
     reason?: string
     payload?: unknown
   }) => Promise<void>
+  forkEntity: (input: {
+    entityUrl: string
+    pointer?: ForkPointer
+  }) => Promise<{ url: string }>
 }
 
 const AgentsContext = createContext<AgentsContextValue | null>(null)
@@ -48,6 +54,7 @@ export function AgentsProvider({
       entityEffectivePermissionsCollection:
         createEntityEffectivePermissionsCollection(serverUrl),
       signalEntity: (input) => signalEntity({ baseUrl: serverUrl, ...input }),
+      forkEntity: (input) => forkEntity({ baseUrl: serverUrl, ...input }),
     }
   }, [serverUrl])
 

--- a/packages/agents-mobile/src/lib/agentsClient.test.ts
+++ b/packages/agents-mobile/src/lib/agentsClient.test.ts
@@ -105,6 +105,72 @@ describe(`spawnEntity`, () => {
   })
 })
 
+describe(`forkEntity`, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.serverFetch.mockResolvedValue(
+      new Response(JSON.stringify({ root: { url: `/horton/x-fork` } }), {
+        status: 200,
+      })
+    )
+  })
+
+  function lastRequestUrl(): string {
+    return mocks.serverFetch.mock.calls.at(-1)![0] as string
+  }
+
+  it(`posts an empty body to fork the whole subtree`, async () => {
+    const { forkEntity } = await import(`./agentsClient`)
+    const result = await forkEntity({
+      baseUrl: `http://server`,
+      entityUrl: `/horton/x`,
+    })
+
+    const [, init] = mocks.serverFetch.mock.calls.at(-1)!
+    expect((init as RequestInit).method).toBe(`POST`)
+    expect(lastRequestUrl()).toBe(
+      `http://server/_electric/entities/horton/x/fork`
+    )
+    expect(lastRequestBody()).toEqual({})
+    expect(result).toEqual({ url: `/horton/x-fork` })
+  })
+
+  it(`sends a snake_case fork_pointer when forking from a point`, async () => {
+    const { forkEntity } = await import(`./agentsClient`)
+    await forkEntity({
+      baseUrl: `http://server`,
+      entityUrl: `/horton/x`,
+      pointer: { offset: `0000000003_0`, subOffset: 1 },
+    })
+
+    expect(lastRequestBody()).toEqual({
+      fork_pointer: { offset: `0000000003_0`, sub_offset: 1 },
+    })
+  })
+
+  it(`throws the server message when the fork is rejected`, async () => {
+    mocks.serverFetch.mockResolvedValue(
+      new Response(JSON.stringify({ message: `Fork permission required` }), {
+        status: 403,
+      })
+    )
+    const { forkEntity } = await import(`./agentsClient`)
+    await expect(
+      forkEntity({ baseUrl: `http://server`, entityUrl: `/horton/x` })
+    ).rejects.toThrow(`Fork permission required`)
+  })
+
+  it(`throws when the response omits the new root url`, async () => {
+    mocks.serverFetch.mockResolvedValue(
+      new Response(JSON.stringify({ root: {} }), { status: 200 })
+    )
+    const { forkEntity } = await import(`./agentsClient`)
+    await expect(
+      forkEntity({ baseUrl: `http://server`, entityUrl: `/horton/x` })
+    ).rejects.toThrow()
+  })
+})
+
 describe(`schemas`, () => {
   it(`parses runner rows with advertised sandbox profiles`, async () => {
     const { runnerSchema } = await import(`./agentsClient`)

--- a/packages/agents-mobile/src/lib/agentsClient.ts
+++ b/packages/agents-mobile/src/lib/agentsClient.ts
@@ -3,6 +3,7 @@ import { electricCollectionOptions } from '@tanstack/electric-db-collection'
 import { appendPathToUrl } from '@electric-ax/agents-runtime/client'
 import type { ComposerInputPayload } from '@electric-ax/agents-runtime/client'
 import { serverFetch } from '@electric-ax/agents-server-ui/src/lib/auth-fetch'
+import { entityApiUrl } from '@electric-ax/agents-server-ui/src/lib/entity-api'
 import { z } from 'zod'
 
 export type EntityStatus =
@@ -422,6 +423,42 @@ export async function signalEntity({
   if (!res.ok) {
     throw new Error(await responseMessage(res, `Signal failed`))
   }
+}
+
+// Structurally matches agents-runtime's `EventPointer` so the re-routed
+// per-message fork can cross the DOM bridge without a runtime dependency.
+export type ForkPointer = { offset: string | null; subOffset: number }
+
+// No `pointer` clones the whole subtree (kebab "Fork subtree"); a pointer
+// forks from that point ("Fork from here"). Mirrors desktop `createForkEntity`.
+export async function forkEntity({
+  baseUrl,
+  entityUrl,
+  pointer,
+}: {
+  baseUrl: string
+  entityUrl: string
+  pointer?: ForkPointer
+}): Promise<{ url: string }> {
+  const body = pointer
+    ? {
+        fork_pointer: { offset: pointer.offset, sub_offset: pointer.subOffset },
+      }
+    : {}
+
+  const res = await serverFetch(entityApiUrl(baseUrl, entityUrl, `/fork`), {
+    method: `POST`,
+    headers: { 'content-type': `application/json` },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    throw new Error(await responseMessage(res, `Fork failed`))
+  }
+  const data = (await res.json()) as { root?: { url?: string } }
+  if (!data.root?.url) {
+    throw new Error(`Fork returned an invalid response`)
+  }
+  return { url: data.root.url }
 }
 
 export function getEntityDisplayTitle(entity: ElectricEntity): string {

--- a/packages/agents-mobile/src/screens/SessionScreen.tsx
+++ b/packages/agents-mobile/src/screens/SessionScreen.tsx
@@ -67,7 +67,11 @@ export const CHAT_COMPOSER_OVERLAP = 20
 const COMPOSER_INPUT_MIN_HEIGHT = 34
 const COMPOSER_INPUT_MAX_HEIGHT = 200
 const INLINE_QUEUED_TIMEOUT_MS = 15_000
-const SESSION_PERMISSIONS: ReadonlyArray<EntityPermission> = [`write`, `signal`]
+const SESSION_PERMISSIONS: ReadonlyArray<EntityPermission> = [
+  `write`,
+  `signal`,
+  `fork`,
+]
 
 type EntityStreamState = ReturnType<typeof useEntityTimeline>
 type EntityStreamDB = EntityStreamState[`db`]
@@ -116,11 +120,14 @@ export function StateInspectorSessionScreen({
   entityUrl,
   onBack,
   onSetView,
+  onOpenEntity,
   onShare,
 }: {
   entityUrl: string
   onBack: () => void
   onSetView: (view: EmbedViewId) => void
+  // So the kebab "Fork subtree" can navigate from the state view too.
+  onOpenEntity?: (entityUrl: string) => void
   onShare?: () => void
 }): React.ReactElement {
   return (
@@ -129,6 +136,7 @@ export function StateInspectorSessionScreen({
       view="state-explorer"
       onBack={onBack}
       onSetView={onSetView}
+      onOpenEntity={onOpenEntity}
       onShare={onShare}
     />
   )
@@ -168,7 +176,8 @@ export function SessionScreen({
   ) => void
   onShare?: () => void
 }): React.ReactElement {
-  const { entitiesCollection, serverUrl, signalEntity } = useAgents()
+  const { entitiesCollection, serverUrl, signalEntity, forkEntity } =
+    useAgents()
   const tokens = useTokens()
   const styles = useMemo(() => createStyles(tokens), [tokens])
   const [menuOpen, setMenuOpen] = useState(false)
@@ -177,6 +186,11 @@ export function SessionScreen({
   >(() => new Map())
   const [stopPending, setStopPending] = useState(false)
   const [signalError, setSignalError] = useState<string | null>(null)
+  const [forkPending, setForkPending] = useState(false)
+  const [forkError, setForkError] = useState<string | null>(null)
+  // Synchronous re-entry latch: `forkPending` (state) only disables the item
+  // after a re-render, so a same-tick double-tap could fire two forks.
+  const forkInFlightRef = useRef(false)
   const inlineQueuedKeysRef = useRef(new Set<string>())
   const inlineTimeoutsRef = useRef(
     new Map<string, ReturnType<typeof setTimeout>>()
@@ -193,6 +207,7 @@ export function SessionScreen({
   const permissions = useEntityPermissions(entity, SESSION_PERMISSIONS)
   const canWrite = permissions.write
   const canSignal = permissions.signal
+  const canFork = permissions.fork
   const streamEntityUrl =
     view === `chat` && entity?.status !== `spawning` ? entityUrl : null
   const { timelineRows, pendingInbox, db, generationActive } =
@@ -315,6 +330,7 @@ export function SessionScreen({
   useEffect(() => {
     setStopPending(false)
     setSignalError(null)
+    setForkError(null)
   }, [entityUrl])
 
   const sendSignal = useCallback(
@@ -371,6 +387,27 @@ export function SessionScreen({
     },
     [canSignal, sendSignal]
   )
+
+  // Whole-subtree fork (HEAD clone) — the kebab counterpart to desktop's
+  // tile-menu "Fork subtree". Root-only; navigates to the new root on success.
+  const forkSubtree = useCallback(async (): Promise<void> => {
+    if (!entity || !canFork || forkInFlightRef.current) return
+    if (entity.parent) return
+    if (entity.status === `stopped` || entity.status === `killed`) return
+    forkInFlightRef.current = true
+    setForkPending(true)
+    setForkError(null)
+    try {
+      const { url } = await forkEntity({ entityUrl })
+      setMenuOpen(false)
+      onOpenEntity?.(url)
+    } catch (err) {
+      setForkError(err instanceof Error ? err.message : String(err))
+    } finally {
+      forkInFlightRef.current = false
+      setForkPending(false)
+    }
+  }, [canFork, entity, entityUrl, forkEntity, onOpenEntity])
 
   const title = entity
     ? getEntityDisplayTitle(entity)
@@ -443,6 +480,10 @@ export function SessionScreen({
         onStopImmediately={() => void stopImmediately()}
         onShare={onShare}
         signalDisabled={!canSignal}
+        onFork={() => void forkSubtree()}
+        forkError={forkError}
+        forkPending={forkPending}
+        forkDisabled={!canFork}
       />
     </Screen>
   )

--- a/packages/agents-server-ui/src/components/AgentResponse.module.css
+++ b/packages/agents-server-ui/src/components/AgentResponse.module.css
@@ -48,3 +48,13 @@
 .metaActionButton:hover {
   opacity: 1;
 }
+
+.spin {
+  animation: meta-action-spin 0.7s linear infinite;
+}
+
+@keyframes meta-action-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/agents-server-ui/src/components/AgentResponse.tsx
+++ b/packages/agents-server-ui/src/components/AgentResponse.tsx
@@ -1,4 +1,11 @@
-import { Check, Copy, CircleAlert, GitFork, Reply } from 'lucide-react'
+import {
+  Check,
+  CircleAlert,
+  Copy,
+  GitFork,
+  LoaderCircle,
+  Reply,
+} from 'lucide-react'
 import {
   memo,
   useCallback,
@@ -32,6 +39,7 @@ import { ReasoningBlock, type ReasoningEntry } from './ReasoningSection'
 import { TokenUsage } from './TokenUsage'
 
 import { formatElapsedDuration, toMillis } from '../lib/formatTime'
+import { singleFlight } from '../lib/singleFlight'
 import styles from './AgentResponse.module.css'
 import toolBlock from './toolBlock.module.css'
 import type { ForkFromHereAction } from './UserMessage'
@@ -778,10 +786,32 @@ function ResponseMetaActions({
   onReply?: () => void
 }): React.ReactElement | null {
   const showFork = forkFromHere !== undefined
+
+  // Single-flight + spinner so repeat taps don't spawn duplicate forks.
+  const [forking, setForking] = useState(false)
+  const onForkRef = useRef(forkFromHere?.onFork)
+  onForkRef.current = forkFromHere?.onFork
+  const mountedRef = useRef(true)
+  useEffect(() => () => void (mountedRef.current = false), [])
+  const forkFlight = useMemo(
+    () =>
+      singleFlight(
+        () => onForkRef.current?.(),
+        (pending) => {
+          if (mountedRef.current) setForking(pending)
+        }
+      ),
+    []
+  )
+
   if (!showCopy && !showFork && !onReply) return null
 
   const forkDisabled = forkFromHere?.disabled === true || !forkFromHere?.onFork
-  const forkLabel = forkDisabled ? `Fork permission required` : `Fork from here`
+  const forkLabel = forking
+    ? `Forking…`
+    : forkDisabled
+      ? `Fork permission required`
+      : `Fork from here`
 
   return (
     <span className={styles.metaActions}>
@@ -808,12 +838,16 @@ function ResponseMetaActions({
               variant="ghost"
               tone="neutral"
               className={styles.metaActionButton}
-              disabled={forkDisabled}
-              onClick={forkFromHere?.onFork}
+              disabled={forkDisabled || forking}
+              onClick={forkFlight.invoke}
               aria-label="Fork from here"
               title={forkLabel}
             >
-              <Icon icon={GitFork} size={1} />
+              <Icon
+                icon={forking ? LoaderCircle : GitFork}
+                size={1}
+                className={forking ? styles.spin : undefined}
+              />
             </IconButton>
           </span>
         </Tooltip>

--- a/packages/agents-server-ui/src/components/UserMessage.tsx
+++ b/packages/agents-server-ui/src/components/UserMessage.tsx
@@ -39,7 +39,8 @@ export type UserMessageAttachment = {
 
 export type ForkFromHereAction = {
   disabled?: boolean
-  onFork?: () => void
+  // Returns the in-flight fork promise so the trigger can track pending state.
+  onFork?: () => void | Promise<unknown>
 }
 
 export const UserMessage = memo(function UserMessage({

--- a/packages/agents-server-ui/src/embed/EmbedApp.tsx
+++ b/packages/agents-server-ui/src/embed/EmbedApp.tsx
@@ -3,6 +3,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   type CSSProperties,
   type ReactElement,
 } from 'react'
@@ -18,11 +19,13 @@ import { eq } from '@tanstack/db'
 import {
   ElectricAgentsProvider,
   useElectricAgents,
+  type ForkEntityFn,
 } from '../lib/ElectricAgentsProvider'
 import { WorkspaceProvider } from '../hooks/useWorkspace'
 import { ThemeProvider } from '../ui/ThemeProvider'
 import { ChatLogView, ChatView } from '../components/views/ChatView'
 import { StateExplorerView } from '../components/views/StateExplorerView'
+import { ToastProvider } from '../components/ToastViewport'
 import { registerActiveServerHeaders } from '../lib/auth-fetch'
 import styles from './EmbedApp.module.css'
 import type { OptimisticInboxMessage } from '../lib/sendMessage'
@@ -34,10 +37,14 @@ type EmbedTheme = `light` | `dark`
 
 export type EmbedSessionProps = EmbedState & {
   onNavigatePathname?: (pathname: string) => void | Promise<void>
+  // Marshalled native fork transport — when present (mobile), the embed's
+  // fork runs over native RN networking instead of the WebView's fetch.
+  onRequestForkEntity?: ForkEntityFn
 }
 
 export function EmbedSessionRoot({
   onNavigatePathname,
+  onRequestForkEntity,
   ...state
 }: EmbedSessionProps): ReactElement {
   // Register the Cloud auth headers in THIS context's auth-fetch
@@ -49,19 +56,39 @@ export function EmbedSessionRoot({
   } else {
     registerActiveServerHeaders(null)
   }
+  // Keep a stable wrapper so the provider's action memo doesn't rebuild on
+  // every render (the marshalled prop's identity isn't guaranteed stable).
+  const forkRef = useRef(onRequestForkEntity)
+  forkRef.current = onRequestForkEntity
+  const hasNativeFork = Boolean(onRequestForkEntity)
+  const forkEntityImpl = useMemo<ForkEntityFn | undefined>(
+    () =>
+      hasNativeFork
+        ? (entityUrl, opts) => forkRef.current!(entityUrl, opts)
+        : undefined,
+    [hasNativeFork]
+  )
   return (
     <ThemeProvider appearance={state.theme}>
-      <ElectricAgentsProvider baseUrl={state.serverUrl}>
-        {/* The state-explorer view calls `useWorkspace`; the native shell owns
-            navigation, so this just satisfies the context (tile dispatches are
-            inert against the embed's fixed view). */}
-        <WorkspaceProvider>
-          <EmbeddedRouter
-            state={state}
-            onNavigatePathname={onNavigatePathname}
-          />
-        </WorkspaceProvider>
-      </ElectricAgentsProvider>
+      {/* The full app mounts the toast viewport in its router; the embed has
+          its own entry, so mount one here too — otherwise fork (and other)
+          failures fire into a bus with no listener and vanish in the WebView. */}
+      <ToastProvider>
+        <ElectricAgentsProvider
+          baseUrl={state.serverUrl}
+          forkEntityImpl={forkEntityImpl}
+        >
+          {/* The state-explorer view calls `useWorkspace`; the native shell owns
+              navigation, so this just satisfies the context (tile dispatches are
+              inert against the embed's fixed view). */}
+          <WorkspaceProvider>
+            <EmbeddedRouter
+              state={state}
+              onNavigatePathname={onNavigatePathname}
+            />
+          </WorkspaceProvider>
+        </ElectricAgentsProvider>
+      </ToastProvider>
     </ThemeProvider>
   )
 }

--- a/packages/agents-server-ui/src/hooks/useForkFromHere.ts
+++ b/packages/agents-server-ui/src/hooks/useForkFromHere.ts
@@ -45,18 +45,17 @@ export function useForkFromHere({
           capturedRunKey,
           canFork
             ? {
-                onFork: () => {
-                  // forkEntity surfaces failures via a danger toast before
-                  // rejecting, so the caller just needs to swallow the rejection.
-                  void forkEntity(entityUrl, { pointer: capturedAnchor })
+                // Return the chain so the trigger can track in-flight state;
+                // forkEntity already toasts on failure, so swallow the rejection.
+                onFork: () =>
+                  forkEntity(entityUrl, { pointer: capturedAnchor })
                     .then((res) =>
                       navigate({
                         to: `/entity/$`,
                         params: { _splat: res.url.replace(/^\//, ``) },
                       })
                     )
-                    .catch(() => {})
-                },
+                    .catch(() => {}),
               }
             : { disabled: true }
         )

--- a/packages/agents-server-ui/src/lib/ElectricAgentsProvider.tsx
+++ b/packages/agents-server-ui/src/lib/ElectricAgentsProvider.tsx
@@ -747,11 +747,30 @@ function createSignalAction(
   })
 }
 
-function createForkEntity(baseUrl: string) {
+export type ForkEntityFn = (
+  entityUrl: string,
+  opts?: { pointer?: EventPointer }
+) => Promise<{ url: string }>
+
+function createForkEntity(
+  baseUrl: string,
+  // Optional transport override (mobile routes the fork over native RN
+  // networking). The failure toast lives here so both paths surface errors
+  // identically.
+  forkRequest?: ForkEntityFn
+): ForkEntityFn {
   return async (
     entityUrl: string,
     opts?: { pointer?: EventPointer }
   ): Promise<{ url: string }> => {
+    if (forkRequest) {
+      try {
+        return await forkRequest(entityUrl, opts)
+      } catch (err) {
+        showForkFailureToast({ entityUrl, error: err })
+        throw err
+      }
+    }
     // Wire convention is snake_case; in-code TS is camelCase.
     const body = opts?.pointer
       ? {
@@ -824,9 +843,13 @@ const ElectricAgentsContext = createContext<ElectricAgentsState>({
 export function ElectricAgentsProvider({
   baseUrl,
   children,
+  forkEntityImpl,
 }: {
   baseUrl: string | null
   children: ReactNode
+  // Optional fork transport (see `createForkEntity`); must be referentially
+  // stable, as it feeds the `state` memo below. Undefined in the full app.
+  forkEntityImpl?: ForkEntityFn
 }): React.ReactElement {
   const previousBaseUrlRef = useRef<string | null>(null)
 
@@ -893,9 +916,9 @@ export function ElectricAgentsProvider({
       signalEntity: createSignalAction(baseUrl, entities),
       setEntityTitle: createSetEntityTitleAction(baseUrl, entities),
       killEntity: createKillAction(baseUrl, entities),
-      forkEntity: createForkEntity(baseUrl),
+      forkEntity: createForkEntity(baseUrl, forkEntityImpl),
     }
-  }, [baseUrl])
+  }, [baseUrl, forkEntityImpl])
 
   return (
     <ElectricAgentsContext.Provider value={state}>

--- a/packages/agents-server-ui/src/lib/singleFlight.test.ts
+++ b/packages/agents-server-ui/src/lib/singleFlight.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+import { singleFlight } from './singleFlight'
+
+function deferred<T = void>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+const tick = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0))
+
+describe(`singleFlight`, () => {
+  it(`runs the action once and ignores re-invocation while it is in flight`, async () => {
+    const gate = deferred()
+    const fn = vi.fn(() => gate.promise)
+    const flight = singleFlight(fn)
+
+    flight.invoke()
+    flight.invoke()
+    flight.invoke()
+
+    // The repeated taps that motivated this guard issue no extra calls.
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(flight.isPending()).toBe(true)
+
+    gate.resolve()
+    await tick()
+
+    expect(flight.isPending()).toBe(false)
+    flight.invoke()
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it(`reports pending transitions through onPendingChange`, async () => {
+    const gate = deferred()
+    const changes: Array<boolean> = []
+    const flight = singleFlight(
+      () => gate.promise,
+      (pending) => changes.push(pending)
+    )
+
+    flight.invoke()
+    expect(changes).toEqual([true])
+
+    gate.resolve()
+    await tick()
+    expect(changes).toEqual([true, false])
+  })
+
+  it(`clears pending after the action rejects`, async () => {
+    const gate = deferred()
+    const fn = vi.fn(() => gate.promise)
+    const flight = singleFlight(fn)
+
+    flight.invoke()
+    gate.reject(new Error(`fork failed`))
+    await tick()
+
+    expect(flight.isPending()).toBe(false)
+    flight.invoke()
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it(`clears pending when the action throws synchronously`, () => {
+    const flight = singleFlight(() => {
+      throw new Error(`boom`)
+    })
+
+    expect(() => flight.invoke()).not.toThrow()
+    expect(flight.isPending()).toBe(false)
+  })
+})

--- a/packages/agents-server-ui/src/lib/singleFlight.ts
+++ b/packages/agents-server-ui/src/lib/singleFlight.ts
@@ -1,0 +1,35 @@
+/**
+ * Wrap an async action so re-invocations are dropped while a prior call is
+ * still in flight (e.g. to stop a button firing a duplicate fork). The guard
+ * is synchronous, so it holds on the very next click before any re-render;
+ * `onPendingChange` mirrors the in-flight flag out to a React `setState`.
+ */
+export function singleFlight(
+  fn: () => unknown,
+  onPendingChange?: (pending: boolean) => void
+): { invoke: () => void; isPending: () => boolean } {
+  let pending = false
+  const update = (next: boolean): void => {
+    if (pending === next) return
+    pending = next
+    onPendingChange?.(next)
+  }
+  return {
+    isPending: () => pending,
+    invoke: () => {
+      if (pending) return
+      update(true)
+      try {
+        const result = fn()
+        Promise.resolve(result).then(
+          () => update(false),
+          () => update(false)
+        )
+      } catch {
+        // Synchronous throw: the action never went in flight, so clear
+        // immediately rather than latching the trigger forever.
+        update(false)
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Brings the **fork** capability on agents-mobile to parity with desktop. Mobile previously had no native fork action, and the embedded per-message "Fork from here" button rode the WebView's `fetch` (slow, and double-tappable into multiple stray forks). This PR adds both desktop fork affordances to mobile and hardens the existing button.

## What changed

**1. Native whole-subtree fork (the kebab "Fork subtree")**
- `agentsClient.ts`: `forkEntity` (POST `…/fork`, empty body = whole-subtree HEAD clone) + a `ForkPointer` type, built on the shared `entityApiUrl` helper. Exposed through `AgentsProvider`. `SESSION_PERMISSIONS` gains `fork`.
- `SessionScreen`/`SessionMenu`: a gated **Fork subtree** kebab item — root-only (`!entity.parent`), disabled when terminal (stopped/killed) or lacking the `fork` permission, with a single-flight guard, a pending spinner, an inline error, and navigation to the new root on success. Adds a `git-fork` glyph to the native `Icon` set.

**2. Route the embedded per-message button through native**
- `createForkEntity` gains an optional transport; the embed injects a marshalled `onRequestForkEntity` so the per-message fork's POST runs over native RN networking instead of the WebView's `fetch`. The shared failure-toast behaviour is preserved by keeping the wrapper in `createForkEntity`.

**3. Harden the embedded button**
- Extracted a small, tested `singleFlight` primitive; added a spinner + disabled state on the button; mounted a `ToastProvider` inside the embed so fork failures surface in the WebView (previously they fired into a bus with no listener and vanished).

## Key decisions

- **One mobile kebab covers both desktop whole-subtree entry points.** Desktop exposes whole-subtree fork from the tile menu *and* the ⌘K command palette; mobile has neither concept, so the single kebab "Fork subtree" provides the capability. The per-message pointer fork comes free via the shared timeline embed.
- **Why route the embed fork through native at all?** The mobile timeline is the *same* `agents-server-ui` `ChatLogView` rendered in an Expo DOM WebView; the per-message fork is the **only** mutation that originates *inside* the WebView. Every other mobile mutation (send, signal/stop, steer/edit/delete/reorder, spawn, and the kebab fork) originates in native chrome and already runs over RN networking. So routing the button native makes the embed's lone write *consistent* with everything else (and mirrors how desktop routes embed POSTs through Electron IPC) — leaving it on WebView `fetch` would be the inconsistent split. This was the conclusion of an explicit altitude review; it holds independent of the (locally-shaky) latency argument.
- **Failure UX** matches each surface's convention: the per-message button shows a toast (desktop parity); the kebab shows an inline error, consistent with how mobile already surfaces `signalError`.
- **Reuse over re-implementation**: `forkEntity` uses the shared `entityApiUrl` (matching desktop `createForkEntity` and mobile `entityGrants.ts`); `singleFlight` is extracted and shared with the desktop button.
- Mobile adds a **single-flight guard the desktop fork lacks**, since the whole-subtree fork can take several seconds (it waits for descendants to idle).

## Architecture notes (for future sessions)

- **Mobile = native chrome + a timeline-only WebView.** `SessionScreen` (RN) owns the header, composer, and kebab; the WebView embed (`SessionChatLogDomEmbed` → `EmbedApp` → `ChatLogView`) renders only the timeline. Message *rendering* (bubbles, reasoning, tool calls, attachment previews, token usage) is shared and free on mobile.
- **`serverFetch` in the RN context is just native `fetch`** (no `electronAPI`), so native-chrome mutations are already off the WebView transport.
- **Expo DOM marshalled function props support return values and error propagation** (verified in `expo/src/dom/marshal.tsx` — `invokeNativeAction` resolves with `result`, rejects with the reconstructed error). That is what lets the embed get `{ url }` back and keep its existing `.then(navigate)` chain.

## Testing

- New: `forkEntity` wire tests (`agentsClient.test.ts`) and `singleFlight` unit tests.
- Full suites green (88 agents-mobile, 92 agents-server-ui), `tsc --noEmit` clean both packages, eslint clean.
- ⚠️ **Caveat:** the native-transport round-trip is verified from the Expo DOM source + types, but should be confirmed once on a device/simulator build.

## Follow-up parity gaps (out of scope here)

A broader mobile↔desktop audit surfaced these for separate PRs: **rename / `setEntityTitle`** (no mobile equivalent — closest analog to this work), **kill confirmation** (mobile kill via SIGKILL fires with no confirm dialog), attachment-manifest preview in the context drawer, and session-list refinements (group-by/filter by runner/workingDir, list-row actions). Fork itself is fully at parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)