### PR TITLE
ci(mobile): make Android EAS builds manual-only

### DIFF
--- a/.github/workflows/agents_mobile_canary.yml
+++ b/.github/workflows/agents_mobile_canary.yml
@@ -1,33 +1,29 @@
-name: Agents Mobile Canary
+name: Agents Mobile Build (manual)
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'packages/agents-mobile/**'
-      - 'packages/agents-server-ui/**'
-      - 'packages/agents-runtime/**'
-      - '.github/workflows/agents_mobile_*.yml'
-      - 'scripts/ci/mobile-affected.mjs'
-      - '.npmrc'
-      - '.tool-versions'
-      - 'package.json'
-      - 'patches/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'tsconfig.base.json'
-      - 'tsconfig.build.json'
   workflow_dispatch:
+    inputs:
+      profile:
+        description: EAS build profile (canary-store submits to the Play internal track)
+        type: choice
+        options:
+          - canary
+          - canary-store
+          - preview
+        default: canary
+      git_ref:
+        description: Git ref to build (defaults to the branch you run from)
+        required: false
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.git_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
   actions: read
   contents: read
-  # Declared (but unused in canary mode) so the reusable
+  # Declared (but unused for manual builds) so the reusable
   # `agents_mobile_build.yml` job, which requests these to write PR
   # comments in `channel == 'pr'`, can load. GitHub refuses to start a
   # reusable workflow whose declared permissions exceed the caller's.
@@ -35,54 +31,14 @@ permissions:
   pull-requests: write
 
 jobs:
-  detect:
-    name: Detect mobile impact
-    runs-on: ubuntu-latest
-    outputs:
-      should_build: ${{ steps.detect.outputs.should_build }}
-      reason: ${{ steps.detect.outputs.reason }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5.0.0
-        with:
-          fetch-depth: 0
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.tool-versions'
-
-      - name: Detect mobile impact
-        id: detect
-        env:
-          BASE_SHA: ${{ github.event.before }}
-        run: node scripts/ci/mobile-affected.mjs
-
   build:
-    needs: detect
-    if: ${{ needs.detect.outputs.should_build == 'true' }}
     uses: ./.github/workflows/agents_mobile_build.yml
     secrets: inherit
     with:
       channel: canary
-      version: canary-${{ github.run_number }}-${{ github.sha }}
-      git_ref: ${{ github.sha }}
+      version: canary-${{ github.run_number }}-${{ inputs.git_ref || github.sha }}
+      git_ref: ${{ inputs.git_ref || github.sha }}
       platform: android
-      profile: canary
-      submit: false
-
-  submit-play-internal:
-    needs: detect
-    if: ${{ needs.detect.outputs.should_build == 'true' }}
-    uses: ./.github/workflows/agents_mobile_build.yml
-    secrets: inherit
-    with:
-      channel: canary
-      version: canary-store-${{ github.run_number }}-${{ github.sha }}
-      git_ref: ${{ github.sha }}
-      platform: android
-      profile: canary-store
-      submit: true
+      profile: ${{ inputs.profile }}
+      # Only canary-store has a submit config and produces a store AAB.
+      submit: ${{ inputs.profile == 'canary-store' }}


### PR DESCRIPTION
## Why

We're being billed for far too many Expo Android builds — **22 in a single day** recently.

Root cause: `agents_mobile_canary.yml` ran on every push to `main` and fired **two** full EAS Android builds per qualifying push (`canary` + `canary-store` via the `submit-play-internal` job). On top of that, the `paths:` trigger and the `mobile-affected.mjs` global-change patterns include monorepo-wide files (`pnpm-lock.yaml`, root `package.json`, `tsconfig.*`, `patches/**`) that change constantly from unrelated work — so unrelated dependency bumps triggered mobile builds.

The math checks out exactly: yesterday had 11 qualifying pushes × 2 builds = 22.

## What

Convert the canary workflow into a **manual** `workflow_dispatch` build:

- **Remove the `push:` trigger** — nothing builds automatically on merge to `main`.
- **Drop the `detect` job** — the affected-detection only existed to gate automatic builds; a manual trigger is already a deliberate decision.
- **One configurable build instead of two** — pick the EAS `profile` from a dropdown (`canary` / `canary-store` / `preview`). `submit` is inferred (`profile == 'canary-store'`) since that's the only profile with a submit config / store AAB, so the invalid "submit an APK" combo is unrepresentable.

The PR workflow (`agents_mobile_pr.yml`, label-gated `preview` builds) is **left untouched**.

## How to trigger after this

UI: Actions → *Agents Mobile Build (manual)* → Run workflow.

CLI:
```bash
gh workflow run agents_mobile_canary.yml -f profile=canary               # installable APK
gh workflow run agents_mobile_canary.yml -f profile=canary-store         # store AAB + Play internal submit
gh workflow run agents_mobile_canary.yml --ref my-branch -f profile=canary
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)