### PR TITLE
feat(agents-desktop): give pull-wake runner a distinguishable label

### DIFF
--- a/.changeset/desktop-unique-runner-label.md
+++ b/.changeset/desktop-unique-runner-label.md
@@ -1,0 +1,13 @@
+---
+"@electric-ax/agents-desktop": patch
+---
+
+Give the desktop pull-wake runner a distinguishable label instead of the
+hardcoded `Electric Agents Desktop`, so multiple runners are easy to tell
+apart in the mobile/desktop runner picker. The label now defaults to
+`<identity> · <hostname>`, where identity is the signed-in Cloud name
+(falling back to email, then `Electric Desktop`). It can be overridden via
+the `pullWakeRunnerLabel` setting in `settings.json` or the
+`ELECTRIC_DESKTOP_PULL_WAKE_RUNNER_LABEL` env var. Existing runners pick up
+the new label automatically on next launch (registration upserts on the
+stable runner id).

--- a/packages/agents-desktop/src/runtime/lifecycle.ts
+++ b/packages/agents-desktop/src/runtime/lifecycle.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import os from 'node:os'
 import { app, powerSaveBlocker } from 'electron'
 import { AGENT_SKILLS_DIR } from '../shared/paths'
 import {
@@ -6,6 +7,7 @@ import {
   PULL_WAKE_OWNER_PRINCIPAL,
   PULL_WAKE_REGISTER_RUNNER,
   PULL_WAKE_RUNNER_ID,
+  PULL_WAKE_RUNNER_LABEL,
   RECONNECT_BASE_MS,
   RECONNECT_MAX_MS,
 } from '../shared/constants'
@@ -36,6 +38,7 @@ export type RuntimeLifecycleDeps = {
     workingDirectory?: string | null
     mcp?: { servers: Array<McpServerConfig> }
     pullWakeRunnerId?: string | null
+    pullWakeRunnerLabel?: string
     preventAppSuspension?: boolean
     enabledModelValues?: Array<string>
   }
@@ -266,13 +269,13 @@ export async function startRuntime(
 
   const serverWithPrincipal = deps.injectDevPrincipalHeaders(activeServer)
   const runtimeHeaders = mergeHeaders(serverWithPrincipal.headers)
-  const cloudAuthUserId =
-    activeServer.source === `electric-cloud`
-      ? (deps.getCloudAuthState()?.userId ?? null)
-      : null
+  const cloudAuthState =
+    activeServer.source === `electric-cloud` ? deps.getCloudAuthState() : null
   const runnerOwnerPrincipal =
-    runnerOwnerPrincipalFromUserId(cloudAuthUserId) ??
+    runnerOwnerPrincipalFromUserId(cloudAuthState?.userId ?? null) ??
     runnerOwnerPrincipalFromHeaders(runtimeHeaders, PULL_WAKE_OWNER_PRINCIPAL)
+  const runnerLabelPrefix =
+    cloudAuthState?.name ?? cloudAuthState?.email ?? `Electric Desktop`
   console.info(
     `[agents-desktop] Starting built-in agents runtime for server ${activeServer.url}`
   )
@@ -318,7 +321,10 @@ export async function startRuntime(
       ownerPrincipal: PULL_WAKE_REGISTER_RUNNER
         ? runnerOwnerPrincipal
         : undefined,
-      label: `Electric Agents Desktop`,
+      label:
+        PULL_WAKE_RUNNER_LABEL ??
+        deps.settings.pullWakeRunnerLabel ??
+        `${runnerLabelPrefix} · ${os.hostname()}`,
       headers: runtimeHeaders,
       claimHeaders: runtimeHeaders,
       claimTokenHeader:

--- a/packages/agents-desktop/src/runtime/lifecycle.ts
+++ b/packages/agents-desktop/src/runtime/lifecycle.ts
@@ -275,7 +275,9 @@ export async function startRuntime(
     runnerOwnerPrincipalFromUserId(cloudAuthState?.userId ?? null) ??
     runnerOwnerPrincipalFromHeaders(runtimeHeaders, PULL_WAKE_OWNER_PRINCIPAL)
   const runnerLabelPrefix =
-    cloudAuthState?.name ?? cloudAuthState?.email ?? `Electric Desktop`
+    cloudAuthState?.name?.trim() ||
+    cloudAuthState?.email?.trim() ||
+    `Electric Desktop`
   console.info(
     `[agents-desktop] Starting built-in agents runtime for server ${activeServer.url}`
   )

--- a/packages/agents-desktop/src/settings/store.ts
+++ b/packages/agents-desktop/src/settings/store.ts
@@ -179,6 +179,11 @@ export async function loadDesktopSettings(
           )
         : undefined,
       pullWakeRunnerId,
+      pullWakeRunnerLabel:
+        typeof parsed.pullWakeRunnerLabel === `string` &&
+        parsed.pullWakeRunnerLabel.trim()
+          ? parsed.pullWakeRunnerLabel.trim()
+          : undefined,
     })
     if (parsed.apiKeys !== undefined) {
       Object.assign(deps.apiKeys, normalizeApiKeys(parsed.apiKeys))

--- a/packages/agents-desktop/src/shared/constants.ts
+++ b/packages/agents-desktop/src/shared/constants.ts
@@ -44,6 +44,8 @@ export const BACKGROUND_LAUNCH_ARG = `--electric-background-launch`
 
 export const PULL_WAKE_RUNNER_ID =
   process.env.ELECTRIC_DESKTOP_PULL_WAKE_RUNNER_ID?.trim() || null
+export const PULL_WAKE_RUNNER_LABEL =
+  process.env.ELECTRIC_DESKTOP_PULL_WAKE_RUNNER_LABEL?.trim() || null
 export const PULL_WAKE_REGISTER_RUNNER =
   process.env.ELECTRIC_DESKTOP_PULL_WAKE_REGISTER_RUNNER === undefined
     ? true

--- a/packages/agents-desktop/src/shared/types.ts
+++ b/packages/agents-desktop/src/shared/types.ts
@@ -135,6 +135,7 @@ export type DesktopSettings = {
   mcp?: { servers: Array<McpServerConfig> }
   seededDefaultMcpServerNames?: Array<string>
   pullWakeRunnerId?: string
+  pullWakeRunnerLabel?: string
 }
 
 export type LaunchAtLoginStatus = {


### PR DESCRIPTION
## What

The agents-desktop app registers itself as a pull-wake "runner" that shows up in the mobile/desktop runner picker. Every desktop instance registered with the same hardcoded label `Electric Agents Desktop`, making it impossible to tell runners apart when selecting where to run an agent.

This makes the label distinguishable. It now defaults to:

```
<identity> · <hostname>
```

where `<identity>` is the signed-in Electric Cloud **name**, falling back to **email** (available earlier, before `whoami` resolves), then to `Electric Desktop` for local/manual servers. Examples:

- `Stefanos · stefs-mbp.local` (Cloud, signed in)
- `stef@example.com · stefs-mbp.local` (Cloud, name not yet resolved)
- `Electric Desktop · stefs-mbp.local` (local/manual server)

## Overrides

Resolution precedence (mirrors the existing `pullWakeRunnerId` pattern):

1. `ELECTRIC_DESKTOP_PULL_WAKE_RUNNER_LABEL` env var
2. `pullWakeRunnerLabel` in `settings.json`
3. auto `<identity> · <hostname>`

## Notes

- No schema/server/UI changes — registration already upserts the `label` on the stable runner id, so existing runners pick up the new label automatically on next launch. The selection UIs already render `label`, so the improvement flows straight through to both mobile and desktop pickers.
- Cloud auth state is now captured once in `startRuntime` and reused for both owner-principal derivation and the label (no extra `getCloudAuthState()` call); owner-principal behavior is unchanged.

## Test plan

- [x] `tsc --noEmit`, prettier, eslint pass
- [ ] Launch desktop signed into Cloud → runner appears as `<name> · <hostname>` in the picker
- [ ] Launch against a local server → runner appears as `Electric Desktop · <hostname>`
- [ ] Set `pullWakeRunnerLabel` / `ELECTRIC_DESKTOP_PULL_WAKE_RUNNER_LABEL` → overrides win on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)