### PR TITLE
feat(agents): context-usage ring gauge + composition breakdown

### DIFF
--- a/.changeset/context-usage-breakdown.md
+++ b/.changeset/context-usage-breakdown.md
@@ -1,0 +1,13 @@
+---
+'@electric-ax/agents-runtime': minor
+'@electric-ax/agents-server-ui': patch
+---
+
+Context-usage indicator: a circular ring gauge plus a hover breakdown popover
+showing how the prompt decomposes across system prompt, tools, messages, and
+free space (à la Claude Code's `/context`). The runtime now persists an
+approximate `context_breakdown` of the stable request parts (system + tools) on
+each step alongside the cache-inclusive total, and exports new
+`computeContextBreakdown` / `parseContextBreakdown` helpers from the client
+entry; the UI derives the "messages" bucket as the real remainder so the
+segments always sum to the gauge.

--- a/.changeset/context-usage-breakdown.md
+++ b/.changeset/context-usage-breakdown.md
@@ -1,5 +1,5 @@
 ---
-'@electric-ax/agents-runtime': minor
+'@electric-ax/agents-runtime': patch
 '@electric-ax/agents-server-ui': patch
 ---
 

--- a/packages/agents-runtime/src/client.ts
+++ b/packages/agents-runtime/src/client.ts
@@ -50,6 +50,8 @@ export {
   CONTEXT_USAGE_BACKGROUND_START,
   CONTEXT_USAGE_HARD_CEILING,
   computeContextUsage,
+  computeContextBreakdown,
+  parseContextBreakdown,
   contextUsageLevel,
   formatContextUsagePercent,
 } from './token-accountant'
@@ -57,6 +59,9 @@ export type {
   ContextUsage,
   ContextUsageInput,
   ContextUsageLevel,
+  ContextBreakdownKey,
+  ContextBreakdownParts,
+  ContextBreakdownSegment,
 } from './token-accountant'
 export type { GoalCommand } from './goal-command'
 

--- a/packages/agents-runtime/src/entity-schema.ts
+++ b/packages/agents-runtime/src/entity-schema.ts
@@ -165,11 +165,8 @@ type StepValue = {
   context_input_tokens?: number
   // The model's context window for this step.
   context_window?: number
-  // JSON-encoded estimate of how the prompt decomposes across the stable
-  // request parts — `{ system, tools }` token counts (approximate; char/4).
-  // The UI derives the remaining "messages" bucket as the real cache-inclusive
-  // total minus these, so the breakdown always sums to the gauge. Optional and
-  // additive; older events without it stay valid.
+  // JSON estimate of the prompt's stable parts — `{ system, tools }` token
+  // counts (char/4). The UI derives "messages" as the real total minus these.
   context_breakdown?: string
 }
 type TextValue = {

--- a/packages/agents-runtime/src/entity-schema.ts
+++ b/packages/agents-runtime/src/entity-schema.ts
@@ -165,6 +165,12 @@ type StepValue = {
   context_input_tokens?: number
   // The model's context window for this step.
   context_window?: number
+  // JSON-encoded estimate of how the prompt decomposes across the stable
+  // request parts — `{ system, tools }` token counts (approximate; char/4).
+  // The UI derives the remaining "messages" bucket as the real cache-inclusive
+  // total minus these, so the breakdown always sums to the gauge. Optional and
+  // additive; older events without it stay valid.
+  context_breakdown?: string
 }
 type TextValue = {
   key?: string
@@ -522,6 +528,7 @@ function createStepSchema(): Schema<StepValue> {
     duration_ms: z.number().int().optional(),
     input_tokens: z.number().int().nonnegative().optional(),
     output_tokens: z.number().int().nonnegative().optional(),
+    context_breakdown: z.string().optional(),
   })
 }
 

--- a/packages/agents-runtime/src/outbound-bridge.ts
+++ b/packages/agents-runtime/src/outbound-bridge.ts
@@ -163,6 +163,9 @@ export interface OutboundBridge {
     // Model context window for this step, persisted as `context_window`.
     contextWindow?: number
     durationMs?: number
+    // Approx token decomposition of the stable request parts (system + tools),
+    // persisted as `context_breakdown` for the usage-details popover.
+    tokenBreakdown?: { system: number; tools: number }
   }) => void
   onTextStart: () => void
   onTextDelta: (delta: string) => void
@@ -332,6 +335,8 @@ export function createOutboundBridge(
       tokenContext?: number
       contextWindow?: number
       durationMs?: number
+      /** Approximate token decomposition of the stable request parts. */
+      tokenBreakdown?: { system: number; tools: number }
     }) {
       if (!currentStepKey) return
       writeEvent(
@@ -356,6 +361,9 @@ export function createOutboundBridge(
             }),
             ...(opts?.contextWindow !== undefined && {
               context_window: opts.contextWindow,
+            }),
+            ...(opts?.tokenBreakdown !== undefined && {
+              context_breakdown: JSON.stringify(opts.tokenBreakdown),
             }),
           } as never,
         }) as ChangeEvent

--- a/packages/agents-runtime/src/pi-adapter.ts
+++ b/packages/agents-runtime/src/pi-adapter.ts
@@ -318,6 +318,15 @@ export function createPiAgentAdapter(
     const modelContextWindow =
       typeof model.contextWindow === `number` ? model.contextWindow : 0
 
+    // Approximate token cost of the stable, non-message request parts. These
+    // are constant for the whole call, so estimate once and persist on each
+    // step; the UI derives the "messages" bucket as the real cache-inclusive
+    // total minus these (see token-accountant computeContextBreakdown).
+    const tokenBreakdown = {
+      system: approxTokens(opts.systemPrompt),
+      tools: approxTokens(opts.tools),
+    }
+
     const transformContext =
       opts.onCompactContext && modelContextWindow > 0
         ? async (
@@ -627,6 +636,7 @@ export function createPiAgentAdapter(
                     tokenContext: usageContext,
                   }),
                   ...(contextWindow !== undefined && { contextWindow }),
+                  tokenBreakdown,
                 })
 
                 if (isError) {

--- a/packages/agents-runtime/src/pi-adapter.ts
+++ b/packages/agents-runtime/src/pi-adapter.ts
@@ -322,10 +322,6 @@ export function createPiAgentAdapter(
     // per step; the UI derives "messages" as the real total minus these.
     const tokenBreakdown = {
       system: approxTokens(opts.systemPrompt),
-      // Serialize first: approxTokens' array branch charges a flat ~64 per
-      // non-text block, so the raw AgentTool[] would estimate ~64×toolCount
-      // regardless of real schema size. JSON.stringify captures each tool's
-      // name + description + parameter schema, which is what fills the prompt.
       tools: approxTokens(JSON.stringify(opts.tools)),
     }
 

--- a/packages/agents-runtime/src/pi-adapter.ts
+++ b/packages/agents-runtime/src/pi-adapter.ts
@@ -318,17 +318,14 @@ export function createPiAgentAdapter(
     const modelContextWindow =
       typeof model.contextWindow === `number` ? model.contextWindow : 0
 
-    // Approximate token cost of the stable, non-message request parts. These
-    // are constant for the whole call, so estimate once and persist on each
-    // step; the UI derives the "messages" bucket as the real cache-inclusive
-    // total minus these (see token-accountant computeContextBreakdown).
+    // Stable request parts (constant for the call), estimated once and persisted
+    // per step; the UI derives "messages" as the real total minus these.
     const tokenBreakdown = {
       system: approxTokens(opts.systemPrompt),
       // Serialize first: approxTokens' array branch charges a flat ~64 per
-      // non-text block, so passing the AgentTool[] directly would estimate
-      // ~64×toolCount regardless of the real schema size. JSON.stringify
-      // captures each tool's name + description + parameter schema (functions
-      // drop out), which is what actually occupies the prompt.
+      // non-text block, so the raw AgentTool[] would estimate ~64×toolCount
+      // regardless of real schema size. JSON.stringify captures each tool's
+      // name + description + parameter schema, which is what fills the prompt.
       tools: approxTokens(JSON.stringify(opts.tools)),
     }
 

--- a/packages/agents-runtime/src/pi-adapter.ts
+++ b/packages/agents-runtime/src/pi-adapter.ts
@@ -324,7 +324,12 @@ export function createPiAgentAdapter(
     // total minus these (see token-accountant computeContextBreakdown).
     const tokenBreakdown = {
       system: approxTokens(opts.systemPrompt),
-      tools: approxTokens(opts.tools),
+      // Serialize first: approxTokens' array branch charges a flat ~64 per
+      // non-text block, so passing the AgentTool[] directly would estimate
+      // ~64×toolCount regardless of the real schema size. JSON.stringify
+      // captures each tool's name + description + parameter schema (functions
+      // drop out), which is what actually occupies the prompt.
+      tools: approxTokens(JSON.stringify(opts.tools)),
     }
 
     const transformContext =

--- a/packages/agents-runtime/src/token-accountant.ts
+++ b/packages/agents-runtime/src/token-accountant.ts
@@ -65,6 +65,80 @@ export function computeContextUsage(
   return { usedTokens, contextWindow: input.contextWindow, ratio }
 }
 
+export type ContextBreakdownKey = `system` | `tools` | `messages` | `free`
+
+export interface ContextBreakdownSegment {
+  key: ContextBreakdownKey
+  label: string
+  tokens: number
+  /** Fraction of the whole context window, [0, 1]. */
+  ratio: number
+}
+
+/** Estimated token cost of the stable request parts (from `context_breakdown`). */
+export interface ContextBreakdownParts {
+  systemTokens?: number
+  toolsTokens?: number
+}
+
+const CONTEXT_BREAKDOWN_LABELS: Record<ContextBreakdownKey, string> = {
+  system: `System prompt`,
+  tools: `Tools`,
+  messages: `Messages`,
+  free: `Free space`,
+}
+
+/**
+ * Decompose a step's context usage into display segments: the *estimated*
+ * stable parts (system prompt + tools, char/4 approximations persisted on the
+ * step) plus the real "messages" remainder and the free space. The used
+ * segments (everything but `free`) sum to `usage.usedTokens` and all four sum
+ * to the window — so the breakdown always agrees with the gauge even though the
+ * part estimates are approximate. Modelled on Claude Code's `/context` view.
+ */
+export function computeContextBreakdown(
+  usage: ContextUsage,
+  parts: ContextBreakdownParts = {}
+): Array<ContextBreakdownSegment> {
+  const window = usage.contextWindow
+  const used = Math.max(0, Math.min(usage.usedTokens, window))
+  const system = Math.max(0, Math.min(parts.systemTokens ?? 0, used))
+  const tools = Math.max(0, Math.min(parts.toolsTokens ?? 0, used - system))
+  const messages = Math.max(0, used - system - tools)
+  const free = Math.max(0, window - used)
+  const segment = (
+    key: ContextBreakdownKey,
+    tokens: number
+  ): ContextBreakdownSegment => ({
+    key,
+    label: CONTEXT_BREAKDOWN_LABELS[key],
+    tokens,
+    ratio: window > 0 ? tokens / window : 0,
+  })
+  return [
+    segment(`system`, system),
+    segment(`tools`, tools),
+    segment(`messages`, messages),
+    segment(`free`, free),
+  ]
+}
+
+/** Parse the persisted `context_breakdown` JSON into estimate parts (tolerant). */
+export function parseContextBreakdown(
+  raw: string | undefined | null
+): ContextBreakdownParts {
+  if (!raw) return {}
+  try {
+    const obj = JSON.parse(raw) as { system?: unknown; tools?: unknown }
+    return {
+      ...(typeof obj.system === `number` && { systemTokens: obj.system }),
+      ...(typeof obj.tools === `number` && { toolsTokens: obj.tools }),
+    }
+  } catch {
+    return {}
+  }
+}
+
 export type ContextUsageLevel = `normal` | `warning` | `critical`
 
 /**

--- a/packages/agents-runtime/src/token-accountant.ts
+++ b/packages/agents-runtime/src/token-accountant.ts
@@ -89,12 +89,10 @@ const CONTEXT_BREAKDOWN_LABELS: Record<ContextBreakdownKey, string> = {
 }
 
 /**
- * Decompose a step's context usage into display segments: the *estimated*
- * stable parts (system prompt + tools, char/4 approximations persisted on the
- * step) plus the real "messages" remainder and the free space. The used
- * segments (everything but `free`) sum to `usage.usedTokens` and all four sum
- * to the window — so the breakdown always agrees with the gauge even though the
- * part estimates are approximate. Modelled on Claude Code's `/context` view.
+ * Decompose a step's usage into display segments: the estimated stable parts
+ * (system + tools) plus the real "messages" remainder and free space. The used
+ * segments sum to `usedTokens` and all four to the window, so the breakdown
+ * always agrees with the gauge. Modelled on Claude Code's `/context`.
  */
 export function computeContextBreakdown(
   usage: ContextUsage,

--- a/packages/agents-runtime/test/token-accountant.test.ts
+++ b/packages/agents-runtime/test/token-accountant.test.ts
@@ -53,9 +53,8 @@ describe(`computeContextBreakdown`, () => {
 
   it(`clamps usedTokens to the window when the step is over the window`, () => {
     const segs = computeContextBreakdown(
-      // A step can report usage above the window; usedTokens stays un-clamped on
-      // ContextUsage but the breakdown must clamp it so the segments still sum to
-      // the window and `free` doesn't go negative.
+      // A step can report usage above the window; the breakdown clamps `used` so
+      // the segments still sum to the window and `free` can't go negative.
       { usedTokens: 120_000, contextWindow: 100_000, ratio: 1 },
       { systemTokens: 5_000, toolsTokens: 15_000 }
     )

--- a/packages/agents-runtime/test/token-accountant.test.ts
+++ b/packages/agents-runtime/test/token-accountant.test.ts
@@ -51,6 +51,24 @@ describe(`computeContextBreakdown`, () => {
     expect(segs.every((s) => s.tokens >= 0)).toBe(true)
   })
 
+  it(`clamps usedTokens to the window when the step is over the window`, () => {
+    const segs = computeContextBreakdown(
+      // A step can report usage above the window; usedTokens stays un-clamped on
+      // ContextUsage but the breakdown must clamp it so the segments still sum to
+      // the window and `free` doesn't go negative.
+      { usedTokens: 120_000, contextWindow: 100_000, ratio: 1 },
+      { systemTokens: 5_000, toolsTokens: 15_000 }
+    )
+    const tokens = Object.fromEntries(segs.map((s) => [s.key, s.tokens]))
+    expect(tokens).toEqual({
+      system: 5_000,
+      tools: 15_000,
+      messages: 80_000, // window (100k) − system − tools
+      free: 0,
+    })
+    expect(segs.reduce((n, s) => n + s.tokens, 0)).toBe(100_000)
+  })
+
   it(`parseContextBreakdown reads persisted JSON and tolerates junk`, () => {
     expect(parseContextBreakdown(`{"system":12,"tools":34}`)).toEqual({
       systemTokens: 12,

--- a/packages/agents-runtime/test/token-accountant.test.ts
+++ b/packages/agents-runtime/test/token-accountant.test.ts
@@ -3,6 +3,8 @@ import {
   CONTEXT_USAGE_BACKGROUND_START,
   CONTEXT_USAGE_HARD_CEILING,
   computeContextUsage,
+  computeContextBreakdown,
+  parseContextBreakdown,
   contextUsageLevel,
   formatContextUsagePercent,
   formatContextBudgetNotice,
@@ -12,6 +14,52 @@ import {
   truncateOversizedToolResults,
 } from '../src/token-accountant'
 import type { LLMMessage } from '../src/types'
+
+describe(`computeContextBreakdown`, () => {
+  const usage = { usedTokens: 50_000, contextWindow: 100_000, ratio: 0.5 }
+
+  it(`splits into system / tools / messages / free that sum to the window`, () => {
+    const segs = computeContextBreakdown(usage, {
+      systemTokens: 5_000,
+      toolsTokens: 15_000,
+    })
+    expect(segs.map((s) => [s.key, s.tokens])).toEqual([
+      [`system`, 5_000],
+      [`tools`, 15_000],
+      [`messages`, 30_000], // used (50k) − system − tools
+      [`free`, 50_000], // window − used
+    ])
+    // Used segments sum to usedTokens; all four sum to the window.
+    expect(segs.slice(0, 3).reduce((n, s) => n + s.tokens, 0)).toBe(50_000)
+    expect(segs.reduce((n, s) => n + s.tokens, 0)).toBe(100_000)
+    expect(segs[2].ratio).toBeCloseTo(0.3)
+  })
+
+  it(`defaults missing parts to zero (messages absorbs the whole used total)`, () => {
+    const segs = computeContextBreakdown(usage)
+    expect(segs.find((s) => s.key === `messages`)?.tokens).toBe(50_000)
+    expect(segs.find((s) => s.key === `system`)?.tokens).toBe(0)
+  })
+
+  it(`never produces negative messages when estimates exceed the real total`, () => {
+    const segs = computeContextBreakdown(
+      { usedTokens: 1_000, contextWindow: 100_000, ratio: 0.01 },
+      { systemTokens: 5_000, toolsTokens: 15_000 }
+    )
+    // System is capped at used; tools/messages can't go below zero.
+    expect(segs.find((s) => s.key === `messages`)?.tokens).toBe(0)
+    expect(segs.every((s) => s.tokens >= 0)).toBe(true)
+  })
+
+  it(`parseContextBreakdown reads persisted JSON and tolerates junk`, () => {
+    expect(parseContextBreakdown(`{"system":12,"tools":34}`)).toEqual({
+      systemTokens: 12,
+      toolsTokens: 34,
+    })
+    expect(parseContextBreakdown(undefined)).toEqual({})
+    expect(parseContextBreakdown(`not json`)).toEqual({})
+  })
+})
 
 describe(`computeContextUsage`, () => {
   it(`sums input + output against the window`, () => {

--- a/packages/agents-server-ui/src/components/ContextUsageDetails.module.css
+++ b/packages/agents-server-ui/src/components/ContextUsageDetails.module.css
@@ -1,0 +1,113 @@
+.panel {
+  min-width: 230px;
+  max-width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text, inherit);
+}
+
+.headline {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text, inherit);
+}
+
+.subhead {
+  font-size: 0.72rem;
+  color: var(--text-muted, rgba(0, 0, 0, 0.55));
+  margin-top: -0.25rem;
+}
+
+/* Stacked composition bar. */
+.bar {
+  display: flex;
+  width: 100%;
+  height: 8px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--surface-sunken, rgba(0, 0, 0, 0.06));
+}
+
+.barSeg {
+  height: 100%;
+  display: block;
+}
+
+.legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.legendRow {
+  display: grid;
+  grid-template-columns: 0.6rem 1fr auto auto;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.72rem;
+}
+
+.swatch {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.legendLabel {
+  color: var(--text, inherit);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.legendTokens {
+  color: var(--text-muted, rgba(0, 0, 0, 0.55));
+  text-align: right;
+}
+
+.legendPercent {
+  color: var(--text-muted, rgba(0, 0, 0, 0.55));
+  text-align: right;
+  min-width: 2.4rem;
+}
+
+.note {
+  font-size: 0.66rem;
+  color: var(--text-muted, rgba(0, 0, 0, 0.45));
+  font-style: italic;
+}
+
+/* Per-segment colours, shared by the bar fills and the legend swatches. */
+.system {
+  background: var(--accent-9, #4c6ef5);
+}
+
+.tools {
+  background: var(--violet-9, #7048e8);
+}
+
+.messages {
+  background: var(--teal-9, #0ca678);
+}
+
+.free {
+  background: var(--surface-sunken, rgba(0, 0, 0, 0.12));
+}

--- a/packages/agents-server-ui/src/components/ContextUsageDetails.tsx
+++ b/packages/agents-server-ui/src/components/ContextUsageDetails.tsx
@@ -26,17 +26,12 @@ export function ContextUsageDetails({
   segments,
   modelId,
 }: ContextUsageDetailsProps): React.ReactElement {
-  const usedRatio =
-    usage.contextWindow > 0
-      ? Math.min(1, usage.usedTokens / usage.contextWindow)
-      : 0
-
   return (
     <div className={styles.panel}>
       <div className={styles.header}>
         <span className={styles.title}>Context usage</span>
         <span className={styles.headline}>
-          {formatContextUsagePercent(usedRatio)}
+          {formatContextUsagePercent(usage.ratio)}
         </span>
       </div>
       <div className={styles.subhead}>

--- a/packages/agents-server-ui/src/components/ContextUsageDetails.tsx
+++ b/packages/agents-server-ui/src/components/ContextUsageDetails.tsx
@@ -1,0 +1,85 @@
+import {
+  formatContextUsagePercent,
+  formatTokenCount,
+} from '@electric-ax/agents-runtime/client'
+import type {
+  ContextBreakdownSegment,
+  ContextUsage,
+} from '@electric-ax/agents-runtime/client'
+import styles from './ContextUsageDetails.module.css'
+
+interface ContextUsageDetailsProps {
+  usage: ContextUsage
+  segments: ReadonlyArray<ContextBreakdownSegment>
+  modelId?: string
+}
+
+/**
+ * The hover/click popover body for the context-usage indicator — a stacked
+ * composition bar plus a legend of how each part of the prompt fills the
+ * window (à la Claude Code's `/context`). System-prompt and tools figures are
+ * approximate; the "Messages" bucket is the real cache-inclusive remainder, so
+ * the segments always sum to the gauge.
+ */
+export function ContextUsageDetails({
+  usage,
+  segments,
+  modelId,
+}: ContextUsageDetailsProps): React.ReactElement {
+  const usedRatio =
+    usage.contextWindow > 0
+      ? Math.min(1, usage.usedTokens / usage.contextWindow)
+      : 0
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.header}>
+        <span className={styles.title}>Context usage</span>
+        <span className={styles.headline}>
+          {formatContextUsagePercent(usedRatio)}
+        </span>
+      </div>
+      <div className={styles.subhead}>
+        {formatTokenCount(usage.usedTokens)} /{` `}
+        {formatTokenCount(usage.contextWindow)} tokens
+        {modelId ? ` · ${modelId}` : ``}
+      </div>
+
+      <div
+        className={styles.bar}
+        role="img"
+        aria-label="Context composition by part"
+      >
+        {segments.map((seg) =>
+          seg.ratio > 0 ? (
+            <span
+              key={seg.key}
+              className={`${styles.barSeg} ${styles[seg.key]}`}
+              style={{ width: `${seg.ratio * 100}%` }}
+            />
+          ) : null
+        )}
+      </div>
+
+      <ul className={styles.legend}>
+        {segments.map((seg) => (
+          <li key={seg.key} className={styles.legendRow}>
+            <span
+              className={`${styles.swatch} ${styles[seg.key]}`}
+              aria-hidden="true"
+            />
+            <span className={styles.legendLabel}>{seg.label}</span>
+            <span className={styles.legendTokens}>
+              {formatTokenCount(seg.tokens)}
+            </span>
+            <span className={styles.legendPercent}>
+              {formatContextUsagePercent(seg.ratio)}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <div className={styles.note}>System &amp; tools are estimates.</div>
+    </div>
+  )
+}

--- a/packages/agents-server-ui/src/components/ContextUsageDetails.tsx
+++ b/packages/agents-server-ui/src/components/ContextUsageDetails.tsx
@@ -15,6 +15,16 @@ interface ContextUsageDetailsProps {
 }
 
 /**
+ * Percent label for a legend row. A non-zero segment that would round to `0%`
+ * shows `<1%` instead, so a visibly-coloured swatch/bar isn't labelled "0%".
+ */
+function formatSegmentPercent(ratio: number): string {
+  return ratio > 0 && Math.round(ratio * 100) === 0
+    ? `<1%`
+    : formatContextUsagePercent(ratio)
+}
+
+/**
  * The hover/click popover body for the context-usage indicator — a stacked
  * composition bar plus a legend of how each part of the prompt fills the
  * window (à la Claude Code's `/context`). System-prompt and tools figures are
@@ -68,7 +78,7 @@ export function ContextUsageDetails({
               {formatTokenCount(seg.tokens)}
             </span>
             <span className={styles.legendPercent}>
-              {formatContextUsagePercent(seg.ratio)}
+              {formatSegmentPercent(seg.ratio)}
             </span>
           </li>
         ))}

--- a/packages/agents-server-ui/src/components/ContextUsageDetails.tsx
+++ b/packages/agents-server-ui/src/components/ContextUsageDetails.tsx
@@ -25,11 +25,9 @@ function formatSegmentPercent(ratio: number): string {
 }
 
 /**
- * The hover/click popover body for the context-usage indicator — a stacked
- * composition bar plus a legend of how each part of the prompt fills the
- * window (à la Claude Code's `/context`). System-prompt and tools figures are
- * approximate; the "Messages" bucket is the real cache-inclusive remainder, so
- * the segments always sum to the gauge.
+ * Popover body for the context-usage indicator: a stacked composition bar +
+ * legend (à la Claude Code's `/context`). System/tools are estimates; "Messages"
+ * is the real remainder, so the segments always sum to the gauge.
  */
 export function ContextUsageDetails({
   usage,

--- a/packages/agents-server-ui/src/components/ContextUsageDetails.tsx
+++ b/packages/agents-server-ui/src/components/ContextUsageDetails.tsx
@@ -67,21 +67,25 @@ export function ContextUsageDetails({
       </div>
 
       <ul className={styles.legend}>
-        {segments.map((seg) => (
-          <li key={seg.key} className={styles.legendRow}>
-            <span
-              className={`${styles.swatch} ${styles[seg.key]}`}
-              aria-hidden="true"
-            />
-            <span className={styles.legendLabel}>{seg.label}</span>
-            <span className={styles.legendTokens}>
-              {formatTokenCount(seg.tokens)}
-            </span>
-            <span className={styles.legendPercent}>
-              {formatSegmentPercent(seg.ratio)}
-            </span>
-          </li>
-        ))}
+        {/* Omit empty buckets (e.g. system/tools for older steps with no
+            persisted breakdown), matching the stacked bar above. */}
+        {segments
+          .filter((seg) => seg.tokens > 0)
+          .map((seg) => (
+            <li key={seg.key} className={styles.legendRow}>
+              <span
+                className={`${styles.swatch} ${styles[seg.key]}`}
+                aria-hidden="true"
+              />
+              <span className={styles.legendLabel}>{seg.label}</span>
+              <span className={styles.legendTokens}>
+                {formatTokenCount(seg.tokens)}
+              </span>
+              <span className={styles.legendPercent}>
+                {formatSegmentPercent(seg.ratio)}
+              </span>
+            </li>
+          ))}
       </ul>
 
       <div className={styles.note}>System &amp; tools are estimates.</div>

--- a/packages/agents-server-ui/src/components/ContextUsageIndicator.module.css
+++ b/packages/agents-server-ui/src/components/ContextUsageIndicator.module.css
@@ -15,13 +15,20 @@
   color: inherit;
 }
 
-.dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: currentColor;
-  opacity: 0.6;
+.ring {
+  display: block;
   flex-shrink: 0;
+  overflow: visible;
+}
+
+.ringTrack {
+  stroke: currentColor;
+  opacity: 0.22;
+}
+
+.ringProgress {
+  stroke: currentColor;
+  transition: stroke-dasharray 0.3s ease;
 }
 
 /* Levels mirror the compaction thresholds: warning once background

--- a/packages/agents-server-ui/src/components/ContextUsageIndicator.tsx
+++ b/packages/agents-server-ui/src/components/ContextUsageIndicator.tsx
@@ -6,6 +6,7 @@ import {
   parseContextBreakdown,
   contextUsageLevel,
   formatContextUsagePercent,
+  formatTokenCount,
 } from '@electric-ax/agents-runtime/client'
 import type { EntityStreamDBWithActions } from '@electric-ax/agents-runtime/client'
 import { HoverCard } from '../ui/HoverCard'
@@ -82,6 +83,15 @@ export function ContextUsageIndicator({
 
   const level = contextUsageLevel(usage.ratio)
   const percent = formatContextUsagePercent(usage.ratio)
+  // Keep the essential numbers in the trigger's own label: the breakdown popover
+  // is hover-only (Base UI PreviewCard), so keyboard/screen-reader users would
+  // otherwise get only the percent from the trigger.
+  const tokensLabel = `${formatTokenCount(usage.usedTokens)} / ${formatTokenCount(
+    usage.contextWindow
+  )} tokens`
+  const ariaLabel = `Context used: ${percent} (${tokensLabel}${
+    usage.modelId ? ` · ${usage.modelId}` : ``
+  }) — hover for breakdown`
 
   return (
     <HoverCard.Root>
@@ -91,7 +101,7 @@ export function ContextUsageIndicator({
             className={[styles.indicator, styles[level]]
               .filter(Boolean)
               .join(` `)}
-            aria-label={`Context used: ${percent} — hover for breakdown`}
+            aria-label={ariaLabel}
           >
             <ContextUsageRing ratio={usage.ratio} />
             <span className={styles.percent}>{percent}</span>

--- a/packages/agents-server-ui/src/components/ContextUsageIndicator.tsx
+++ b/packages/agents-server-ui/src/components/ContextUsageIndicator.tsx
@@ -8,6 +8,7 @@ import {
 } from '@electric-ax/agents-runtime/client'
 import type { EntityStreamDBWithActions } from '@electric-ax/agents-runtime/client'
 import { Tooltip } from '../ui/Tooltip'
+import { ContextUsageRing } from './ContextUsageRing'
 import styles from './ContextUsageIndicator.module.css'
 
 /**
@@ -83,7 +84,7 @@ export function ContextUsageIndicator({
         className={[styles.indicator, styles[level]].filter(Boolean).join(` `)}
         aria-label={`Context used: ${percent} (${tooltip})`}
       >
-        <span className={styles.dot} aria-hidden="true" />
+        <ContextUsageRing ratio={usage.ratio} />
         <span className={styles.percent}>{percent}</span>
       </span>
     </Tooltip>

--- a/packages/agents-server-ui/src/components/ContextUsageIndicator.tsx
+++ b/packages/agents-server-ui/src/components/ContextUsageIndicator.tsx
@@ -2,19 +2,21 @@ import { useMemo } from 'react'
 import { useLiveQuery } from '@tanstack/react-db'
 import {
   computeContextUsage,
+  computeContextBreakdown,
+  parseContextBreakdown,
   contextUsageLevel,
   formatContextUsagePercent,
-  formatTokenCount,
 } from '@electric-ax/agents-runtime/client'
 import type { EntityStreamDBWithActions } from '@electric-ax/agents-runtime/client'
-import { Tooltip } from '../ui/Tooltip'
+import { HoverCard } from '../ui/HoverCard'
 import { ContextUsageRing } from './ContextUsageRing'
+import { ContextUsageDetails } from './ContextUsageDetails'
 import styles from './ContextUsageIndicator.module.css'
 
 /**
- * Context-window gauge for the composer footer ("X% used"). Reads the same
- * numbers the runtime persists for compaction (the latest step's cache-inclusive
- * prompt size and the model's window) through `computeContextUsage`.
+ * Context-window gauge for the composer footer ("X% used") — a ring + percent
+ * over the latest step's usage (computeContextUsage). Hovering reveals a
+ * per-part composition breakdown.
  */
 
 interface StepRow {
@@ -23,6 +25,7 @@ interface StepRow {
   context_window?: number
   output_tokens?: number
   model_id?: string
+  context_breakdown?: string
 }
 
 interface ContextUsageIndicatorProps {
@@ -64,29 +67,44 @@ export function ContextUsageIndicator({
       outputTokens: latest.output_tokens,
       contextWindow: latest.context_window as number,
     })
-    return computed ? { ...computed, modelId: latest.model_id } : null
+    if (!computed) return null
+    return {
+      ...computed,
+      modelId: latest.model_id,
+      segments: computeContextBreakdown(
+        computed,
+        parseContextBreakdown(latest.context_breakdown)
+      ),
+    }
   }, [steps])
 
   if (!usage) return null
 
   const level = contextUsageLevel(usage.ratio)
   const percent = formatContextUsagePercent(usage.ratio)
-  const tokensLabel = `${formatTokenCount(usage.usedTokens)} / ${formatTokenCount(
-    usage.contextWindow
-  )} tokens`
-  const tooltip = usage.modelId
-    ? `${tokensLabel} · ${usage.modelId}`
-    : tokensLabel
 
   return (
-    <Tooltip content={`Context used — ${tooltip}`} side="top">
-      <span
-        className={[styles.indicator, styles[level]].filter(Boolean).join(` `)}
-        aria-label={`Context used: ${percent} (${tooltip})`}
-      >
-        <ContextUsageRing ratio={usage.ratio} />
-        <span className={styles.percent}>{percent}</span>
-      </span>
-    </Tooltip>
+    <HoverCard.Root>
+      <HoverCard.Trigger
+        render={
+          <span
+            className={[styles.indicator, styles[level]]
+              .filter(Boolean)
+              .join(` `)}
+            aria-label={`Context used: ${percent} — hover for breakdown`}
+          >
+            <ContextUsageRing ratio={usage.ratio} />
+            <span className={styles.percent}>{percent}</span>
+          </span>
+        }
+      />
+      <HoverCard.Content side="top" align="end">
+        <ContextUsageDetails
+          usage={usage}
+          segments={usage.segments}
+          modelId={usage.modelId}
+        />
+      </HoverCard.Content>
+    </HoverCard.Root>
   )
 }

--- a/packages/agents-server-ui/src/components/ContextUsageRing.tsx
+++ b/packages/agents-server-ui/src/components/ContextUsageRing.tsx
@@ -1,0 +1,58 @@
+import styles from './ContextUsageIndicator.module.css'
+
+interface ContextUsageRingProps {
+  /** Fraction of the context window used, 0–1. */
+  ratio: number
+  /** Outer diameter in px. */
+  size?: number
+  /** Ring thickness in px. */
+  strokeWidth?: number
+}
+
+/**
+ * A tiny circular gauge ("donut") whose arc fills proportionally to `ratio`.
+ * Both the track and the progress arc use `currentColor`, so the surrounding
+ * indicator's level colour (normal/warning/critical) tints it for free.
+ */
+export function ContextUsageRing({
+  ratio,
+  size = 14,
+  strokeWidth = 2.5,
+}: ContextUsageRingProps): React.ReactElement {
+  const clamped = Math.min(1, Math.max(0, ratio))
+  const radius = (size - strokeWidth) / 2
+  const circumference = 2 * Math.PI * radius
+  const filled = circumference * clamped
+  const center = size / 2
+
+  return (
+    <svg
+      className={styles.ring}
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      aria-hidden="true"
+    >
+      <circle
+        className={styles.ringTrack}
+        cx={center}
+        cy={center}
+        r={radius}
+        fill="none"
+        strokeWidth={strokeWidth}
+      />
+      <circle
+        className={styles.ringProgress}
+        cx={center}
+        cy={center}
+        r={radius}
+        fill="none"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeDasharray={`${filled} ${circumference - filled}`}
+        // Start the arc at 12 o'clock and sweep clockwise.
+        transform={`rotate(-90 ${center} ${center})`}
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
Improves the composer-footer context-usage indicator (built on the Phase 0 gauge from the base branch). Two commits:

### 1. Circular ring gauge
Replaces the flat dot before the `X%` label with a small SVG donut whose arc fills proportionally to context-window usage. Track + progress arc both use `currentColor`, so the existing normal/warning/critical level colour tints it for free.

### 2. Composition breakdown popover
Hovering the indicator reveals a per-part breakdown of the prompt — a stacked bar + legend showing how much of the window the **system prompt**, **tool definitions**, **conversation messages**, and **free space** each occupy (modelled on Claude Code's `/context`).

**How the data works:**
- The runtime estimates the *stable* request parts (`{ system, tools }`, char/4 via `approxTokens`) once per model call and persists them on the step as a new additive `context_breakdown` column, next to the real cache-inclusive `context_input_tokens`.
- The UI derives the **Messages** bucket as `real total − system − tools`, and **Free** as `window − total`, so the segments always sum to the gauge even though the system/tools figures are approximations (the panel notes this).
- Shared, testable helpers `computeContextBreakdown` / `parseContextBreakdown` keep the math in `token-accountant` and out of the component.

### Files
- `entity-schema`: additive `context_breakdown` string column on steps.
- `outbound-bridge` / `pi-adapter`: compute + persist the estimate.
- `token-accountant`: breakdown helpers + types, exported from the client entry (+ 4 unit tests).
- UI: `ContextUsageRing`, `ContextUsageDetails` (HoverCard popover), wired into `ContextUsageIndicator`.

### Testing
- Full runtime suite green (1024 passed); UI `tsc` clean.
- Verified live in the desktop app — ring fills correctly and the hover breakdown renders.

### Note on base
Targets `feat/context-compaction` because it extends the Phase 0 gauge that only exists there. Re-target to `main` once the compaction PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)