### PR TITLE
chore: prepare agents 0.6 release

### DIFF
--- a/.changeset/agents-0-5-release.md
+++ b/.changeset/agents-0-5-release.md
@@ -1,0 +1,12 @@
+---
+"@electric-ax/agents": minor
+"@electric-ax/agents-runtime": minor
+"@electric-ax/agents-mcp": minor
+"@electric-ax/agents-server": minor
+"@electric-ax/agents-server-ui": minor
+"@electric-ax/agents-desktop": minor
+"@electric-ax/agents-server-conformance-tests": minor
+"@electric-ax/agents-mobile": minor
+---
+
+Release all Electric Agents packages as 0.6.

--- a/packages/agents-desktop/package.json
+++ b/packages/agents-desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@electric-ax/agents-desktop",
   "productName": "Electric Agents",
   "private": true,
-  "version": "0.1.18",
+  "version": "0.5.0",
   "description": "Desktop app for Electric Agents",
   "author": "ElectricSQL <info@electric-sql.com>",
   "homepage": "https://electric-sql.com",

--- a/packages/agents-mcp/package.json
+++ b/packages/agents-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electric-ax/agents-mcp",
-  "version": "0.2.3",
+  "version": "0.5.0",
   "description": "Model Context Protocol registry, transports, and OAuth bridges for Electric Agents",
   "keywords": [
     "mcp",

--- a/packages/agents-mobile/package.json
+++ b/packages/agents-mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@electric-ax/agents-mobile",
   "private": true,
-  "version": "0.0.17",
+  "version": "0.5.0",
   "main": "index.ts",
   "scripts": {
     "start": "expo start",

--- a/packages/agents-runtime/package.json
+++ b/packages/agents-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electric-ax/agents-runtime",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Electric agent runtime — behavioral stack for agent entities over durable streams",
   "keywords": [
     "tanstack-intent"

--- a/packages/agents-server-conformance-tests/package.json
+++ b/packages/agents-server-conformance-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electric-ax/agents-server-conformance-tests",
-  "version": "0.1.12",
+  "version": "0.5.0",
   "description": "Conformance test suite for Electric Agents server implementations",
   "author": "Durable Stream contributors",
   "license": "Apache-2.0",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electric-ax/agents",
-  "version": "0.4.19",
+  "version": "0.5.0",
   "description": "Built-in Electric Agents runtimes such as Horton and worker",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- set Electric Agents package versions to the current 0.5 line without regressing existing 0.5.1 packages
- add a changeset marking all Electric Agents packages for a minor release to 0.6.0

## Testing
- not run (package metadata and changeset only)