### PR TITLE
fix(agents-mobile): eliminate chat timeline flashing and fix auto-scroll

### DIFF
--- a/.changeset/mobile-chat-timeline-flash-fix.md
+++ b/.changeset/mobile-chat-timeline-flash-fix.md
@@ -1,0 +1,6 @@
+---
+'@electric-ax/agents-mobile': patch
+'@electric-ax/agents-server-ui': patch
+---
+
+Fix mobile chat timeline flashing when sending messages, resizing the composer (multiline/attachments) and queuing messages, and fix inconsistent auto-scroll as the composer grows. The timeline WebView embed now receives dynamic updates (bottom inset, inline queued messages, scroll) imperatively instead of via props that re-render and flash it.

--- a/.changeset/mobile-chat-timeline-flash-fix.md
+++ b/.changeset/mobile-chat-timeline-flash-fix.md
@@ -3,4 +3,4 @@
 '@electric-ax/agents-server-ui': patch
 ---
 
-Fix mobile chat timeline flashing when sending messages, resizing the composer (multiline/attachments) and queuing messages, and fix inconsistent auto-scroll as the composer grows. The timeline WebView embed now receives dynamic updates (bottom inset, inline queued messages, scroll) imperatively instead of via props that re-render and flash it.
+Fix mobile chat timeline flashing when sending messages, resizing the composer (multiline/attachments) and queuing messages, and fix inconsistent auto-scroll as the composer grows. The timeline WebView embed now receives dynamic updates (bottom inset, inline queued messages, scroll) imperatively instead of via props that re-render and flash it. Also fix the composer occasionally not clearing after send when typing quickly.

--- a/packages/agents-mobile/app/session.tsx
+++ b/packages/agents-mobile/app/session.tsx
@@ -1,4 +1,13 @@
-import { useEffect, useMemo, useState, type ComponentType } from 'react'
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentType,
+  type Ref,
+} from 'react'
 import {
   Keyboard,
   Platform,
@@ -23,6 +32,7 @@ import {
 } from '../src/screens/SessionScreen'
 import type { EmbedViewId } from '../src/lib/embedView'
 import SessionChatLogDomEmbedModule from '@electric-ax/agents-server-ui/src/embed/SessionChatLogDomEmbed'
+import type { SessionChatLogDomRef } from '@electric-ax/agents-server-ui/src/embed/sessionChatLogDomRef'
 import SessionStateInspectorDomEmbedModule from '@electric-ax/agents-server-ui/src/embed/SessionStateInspectorDomEmbed'
 import { getActiveServerHeadersSnapshot } from '@electric-ax/agents-server-ui/src/lib/auth-fetch'
 import type { OptimisticInboxMessage } from '@electric-ax/agents-server-ui/src/lib/sendMessage'
@@ -33,8 +43,6 @@ type SessionDomEmbedProps = {
   serverUrl: string
   entityUrl: string
   theme: `light` | `dark`
-  scrollToBottomSignal?: number
-  inlineQueuedMessages?: Array<OptimisticInboxMessage>
   bottomInset?: number
   onRequestOpenEntity: (entityUrl: string) => Promise<void>
   // Marshalled so the per-message fork runs over native networking.
@@ -45,13 +53,20 @@ type SessionDomEmbedProps = {
   style?: StyleProp<ViewStyle>
   matchContents?: boolean
   serverHeaders?: { url: string; headers: Record<string, string> } | null
+  ref?: Ref<SessionChatLogDomRef>
   dom?: unknown
 }
 
-const SessionChatLogDomEmbed =
+// The timeline is an Expo DOM (WebView) embed that re-posts — and visibly
+// flickers — on any prop change or re-render. So we memo it, keep every prop
+// below reference-stable, and push the values that actually change (bottom
+// inset, queued messages, scroll) imperatively via the ref, not as props.
+const SessionChatLogDomEmbed = memo(
   SessionChatLogDomEmbedModule as ComponentType<SessionDomEmbedProps>
-const SessionStateInspectorDomEmbed =
+)
+const SessionStateInspectorDomEmbed = memo(
   SessionStateInspectorDomEmbedModule as ComponentType<SessionDomEmbedProps>
+)
 
 export default function SessionRoute(): React.ReactElement | null {
   const params = useLocalSearchParams<{
@@ -83,7 +98,6 @@ function SessionRouteInner({
   const [chatComposerHeight, setChatComposerHeight] = useState(
     CHAT_COMPOSER_BASE_HEIGHT + insets.bottom
   )
-  const [chatLogScrollSignal, setChatLogScrollSignal] = useState(0)
   const [inlineQueuedMessages, setInlineQueuedMessages] = useState<
     Array<OptimisticInboxMessage>
   >([])
@@ -93,9 +107,13 @@ function SessionRouteInner({
     : (params.entityUrl ?? ``)
   const view = params.view === `state-explorer` ? `state-explorer` : `chat`
 
-  // Read once per render — the DOM embed receives this as a prop and
-  // re-registers it on its side of the JS-context boundary.
-  const serverHeaders = getActiveServerHeadersSnapshot()
+  // A fresh object each call, so memo on its serialized value: stable identity
+  // across renders, but still updates if the auth headers actually change.
+  const serverHeadersSnapshot = getActiveServerHeadersSnapshot()
+  const serverHeadersKey = serverHeadersSnapshot
+    ? JSON.stringify(serverHeadersSnapshot)
+    : ``
+  const serverHeaders = useMemo(() => serverHeadersSnapshot, [serverHeadersKey])
 
   const embedTop = insets.top + HEADER_HEIGHT
   const composerInset =
@@ -117,17 +135,41 @@ function SessionRouteInner({
     }),
     [embedFrame.height, embedFrame.width]
   )
+  const embedStyle = useMemo(() => [styles.domEmbedWeb, embedSize], [embedSize])
+  const embedDom = useMemo(
+    () => domOptions(styles, embedSize, tokens.bg),
+    [embedSize, tokens.bg]
+  )
+  // The inset is also seeded once as a prop so the first paint is correct before
+  // the imperative handle (which registers after boot) takes over.
+  const chatLogRef = useRef<SessionChatLogDomRef>(null)
+  const initialComposerInsetRef = useRef(composerInset)
+  usePushToEmbed(chatLogRef, composerInset, pushBottomInset)
+  usePushToEmbed(chatLogRef, inlineQueuedMessages, pushInlineQueued)
+  const handleSend = useCallback((): void => {
+    chatLogRef.current?.scrollToBottom()
+  }, [])
+  // Reference-stable so it doesn't break the embed's memo (forkEntity itself is
+  // stable from the provider); marshals the fork over native networking.
+  const handleForkEntity = useCallback(
+    (targetUrl: string, opts?: { pointer?: ForkPointer }) =>
+      forkEntity({ entityUrl: targetUrl, pointer: opts?.pointer }),
+    [forkEntity]
+  )
 
   const goBack = (): void => {
     if (router.canGoBack()) router.back()
     else router.replace(`/`)
   }
-  const openSession = (target: string): void => {
-    router.push({
-      pathname: `/session`,
-      params: { entityUrl: target, view: `chat` },
-    })
-  }
+  const openSession = useCallback(
+    async (target: string): Promise<void> => {
+      router.push({
+        pathname: `/session`,
+        params: { entityUrl: target, view: `chat` },
+      })
+    },
+    [router]
+  )
   const openShare = (): void => {
     router.push({ pathname: `/session-share`, params: { entityUrl } })
   }
@@ -149,31 +191,28 @@ function SessionRouteInner({
       >
         {view === `chat` ? (
           <SessionChatLogDomEmbed
-            style={[styles.domEmbedWeb, embedSize]}
+            ref={chatLogRef}
+            style={embedStyle}
             matchContents={false}
             serverUrl={serverUrl}
             entityUrl={entityUrl}
             theme={scheme}
-            scrollToBottomSignal={chatLogScrollSignal}
-            inlineQueuedMessages={inlineQueuedMessages}
-            bottomInset={composerInset}
+            bottomInset={initialComposerInsetRef.current}
             serverHeaders={serverHeaders}
-            onRequestOpenEntity={async (target) => openSession(target)}
-            onRequestForkEntity={(targetUrl, opts) =>
-              forkEntity({ entityUrl: targetUrl, pointer: opts?.pointer })
-            }
-            dom={domOptions(styles, embedSize, tokens.bg)}
+            onRequestOpenEntity={openSession}
+            onRequestForkEntity={handleForkEntity}
+            dom={embedDom}
           />
         ) : (
           <SessionStateInspectorDomEmbed
-            style={[styles.domEmbedWeb, embedSize]}
+            style={embedStyle}
             matchContents={false}
             serverUrl={serverUrl}
             entityUrl={entityUrl}
             theme={scheme}
             serverHeaders={serverHeaders}
-            onRequestOpenEntity={async (target) => openSession(target)}
-            dom={domOptions(styles, embedSize, tokens.bg)}
+            onRequestOpenEntity={openSession}
+            dom={embedDom}
           />
         )}
       </View>
@@ -186,7 +225,7 @@ function SessionRouteInner({
           onOpenEntity={openSession}
           onOpenStateSource={openStateSource}
           onComposerHeightChange={setChatComposerHeight}
-          onSendMessage={() => setChatLogScrollSignal(Date.now())}
+          onSendMessage={handleSend}
           onInlineQueuedMessagesChange={setInlineQueuedMessages}
           onShare={openShare}
         />
@@ -227,6 +266,37 @@ function domOptions(
     webViewStyle: backgroundStyle,
   }
 }
+
+// Push a value into the chat-log embed's imperative handle, retrying on
+// animation frames until it registers (a beat after the WebView boots).
+function usePushToEmbed<T>(
+  ref: { current: SessionChatLogDomRef | null },
+  value: T,
+  push: (handle: SessionChatLogDomRef, value: T) => void
+): void {
+  useEffect(() => {
+    let frame = 0
+    let attempts = 0
+    const apply = (): void => {
+      if (ref.current) {
+        push(ref.current, value)
+        return
+      }
+      if (attempts++ < 120) frame = requestAnimationFrame(apply)
+    }
+    apply()
+    return () => {
+      if (frame) cancelAnimationFrame(frame)
+    }
+  }, [ref, value, push])
+}
+
+const pushBottomInset = (handle: SessionChatLogDomRef, px: number): void =>
+  handle.setBottomInset(px)
+const pushInlineQueued = (
+  handle: SessionChatLogDomRef,
+  messages: Array<OptimisticInboxMessage>
+): void => handle.setInlineQueuedMessages(messages)
 
 function useKeyboardBottomInset(windowHeight: number): number {
   const [keyboardInset, setKeyboardInset] = useState(0)

--- a/packages/agents-mobile/app/session.tsx
+++ b/packages/agents-mobile/app/session.tsx
@@ -144,10 +144,11 @@ function SessionRouteInner({
   // the imperative handle (which registers after boot) takes over.
   const chatLogRef = useRef<SessionChatLogDomRef>(null)
   const initialComposerInsetRef = useRef(composerInset)
-  usePushToEmbed(chatLogRef, composerInset, pushBottomInset)
-  usePushToEmbed(chatLogRef, inlineQueuedMessages, pushInlineQueued)
+  usePushToEmbed(chatLogRef, `setBottomInset`, composerInset)
+  usePushToEmbed(chatLogRef, `setInlineQueuedMessages`, inlineQueuedMessages)
   const handleSend = useCallback((): void => {
-    chatLogRef.current?.scrollToBottom()
+    // `?.()` guards the method too: the handle may not be registered yet.
+    chatLogRef.current?.scrollToBottom?.()
   }, [])
   // Reference-stable so it doesn't break the embed's memo (forkEntity itself is
   // stable from the provider); marshals the fork over native networking.
@@ -268,18 +269,21 @@ function domOptions(
 }
 
 // Push a value into the chat-log embed's imperative handle, retrying on
-// animation frames until it registers (a beat after the WebView boots).
-function usePushToEmbed<T>(
+// animation frames until the method exists. `ref.current` becomes a truthy
+// proxy a beat BEFORE `useDOMImperativeHandle` marshals its methods in, so we
+// must check the method itself — a truthy `ref.current` is not enough.
+function usePushToEmbed(
   ref: { current: SessionChatLogDomRef | null },
-  value: T,
-  push: (handle: SessionChatLogDomRef, value: T) => void
+  method: `setBottomInset` | `setInlineQueuedMessages`,
+  value: unknown
 ): void {
   useEffect(() => {
     let frame = 0
     let attempts = 0
     const apply = (): void => {
-      if (ref.current) {
-        push(ref.current, value)
+      const fn = ref.current?.[method]
+      if (typeof fn === `function`) {
+        fn(value)
         return
       }
       if (attempts++ < 120) frame = requestAnimationFrame(apply)
@@ -288,15 +292,8 @@ function usePushToEmbed<T>(
     return () => {
       if (frame) cancelAnimationFrame(frame)
     }
-  }, [ref, value, push])
+  }, [ref, method, value])
 }
-
-const pushBottomInset = (handle: SessionChatLogDomRef, px: number): void =>
-  handle.setBottomInset(px)
-const pushInlineQueued = (
-  handle: SessionChatLogDomRef,
-  messages: Array<OptimisticInboxMessage>
-): void => handle.setInlineQueuedMessages(messages)
 
 function useKeyboardBottomInset(windowHeight: number): number {
   const [keyboardInset, setKeyboardInset] = useState(0)

--- a/packages/agents-mobile/src/screens/SessionScreen.tsx
+++ b/packages/agents-mobile/src/screens/SessionScreen.tsx
@@ -537,6 +537,10 @@ function NativeMessageComposer({
   const styles = useMemo(() => createComposerStyles(tokens), [tokens])
   const { keyboardVisible, keyboardTranslateY } = useKeyboardAttachment()
   const [value, setValue] = useState(``)
+  // Cleared imperatively on send: the input is controlled via children (for
+  // highlighting), not `value`, so a `setValue('')` while typing fast can be
+  // rejected by RN as stale (older event count) and leave the sent text behind.
+  const inputRef = useRef<TextInput>(null)
   const [sending, setSending] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [editingMessage, setEditingMessage] = useState<{
@@ -676,6 +680,7 @@ function NativeMessageComposer({
       }
 
       setValue(``)
+      inputRef.current?.clear()
       setPendingSelection(null)
       slash.reset()
       setEditingMessage(null)
@@ -695,6 +700,7 @@ function NativeMessageComposer({
     }
 
     setValue(``)
+    inputRef.current?.clear()
     setPendingSelection(null)
     slash.reset()
     setEditingMessage(null)
@@ -856,6 +862,7 @@ function NativeMessageComposer({
           />
         )}
         <TextInput
+          ref={inputRef}
           onChangeText={setValue}
           onSelectionChange={(event) => {
             slash.onSelectionChange(event)

--- a/packages/agents-mobile/src/screens/SessionScreen.tsx
+++ b/packages/agents-mobile/src/screens/SessionScreen.tsx
@@ -241,14 +241,14 @@ export function SessionScreen({
     [pendingInbox]
   )
   const projectedPendingMessage = useMemo(() => {
-    if (entity?.status === `running`) return null
+    if (generationActive) return null
     for (const [key, message] of inlineQueuedMessages) {
       if (processedInboxKeys.has(key)) continue
       return pendingInboxByKey.get(key) ?? message
     }
     return null
   }, [
-    entity?.status,
+    generationActive,
     inlineQueuedMessages,
     pendingInboxByKey,
     processedInboxKeys,
@@ -262,7 +262,7 @@ export function SessionScreen({
     [pendingInbox, projectedPendingMessage]
   )
   const inlineQueuedSubmits =
-    entity?.status !== `running` &&
+    !generationActive &&
     pendingInbox.length === 0 &&
     inlineQueuedMessages.size === 0
 
@@ -297,6 +297,9 @@ export function SessionScreen({
       let next: Map<string, OptimisticInboxMessage> | null = null
       for (const key of current.keys()) {
         if (!processedInboxKeys.has(key)) continue
+        // Still pending though in the timeline — keep tracking inline until it
+        // leaves the pending inbox, else it flashes back into the queue drawer.
+        if (pendingInboxByKey.has(key)) continue
         next ??= new Map(current)
         next.delete(key)
         inlineQueuedKeysRef.current.delete(key)
@@ -306,7 +309,7 @@ export function SessionScreen({
       }
       return next ?? current
     })
-  }, [inlineQueuedMessages.size, processedInboxKeys])
+  }, [inlineQueuedMessages.size, processedInboxKeys, pendingInboxByKey])
 
   useEffect(
     () => () => {

--- a/packages/agents-server-ui/src/components/EntityTimeline.tsx
+++ b/packages/agents-server-ui/src/components/EntityTimeline.tsx
@@ -1956,6 +1956,10 @@ export function EntityTimeline({
     let frame: ReturnType<typeof requestAnimationFrame> | null = null
     const pinToBottom = () => {
       if (!isNearBottom.current) return
+      // Scroll synchronously (ResizeObserver fires before paint) so a growing
+      // inset doesn't paint one misaligned frame; the rAF re-pin then settles
+      // the virtualizer for new rows.
+      viewport.scrollTop = viewport.scrollHeight
       if (frame !== null) cancelAnimationFrame(frame)
       frame = requestAnimationFrame(() => {
         frame = null
@@ -1964,7 +1968,9 @@ export function EntityTimeline({
     }
 
     const observer = new ResizeObserver(pinToBottom)
-    observer.observe(contentElement)
+    // border-box, not content-box: the inset is bottom padding, which a
+    // content-box observation can't see — so composer-only growth would be missed.
+    observer.observe(contentElement, { box: `border-box` })
     return () => {
       observer.disconnect()
       if (frame !== null) cancelAnimationFrame(frame)

--- a/packages/agents-server-ui/src/components/views/ChatView.tsx
+++ b/packages/agents-server-ui/src/components/views/ChatView.tsx
@@ -74,15 +74,20 @@ export function ChatLogView({
   entityStopped,
   isSpawning,
   tileId,
-  scrollToBottomSignal,
   inlineQueuedMessages = [],
 }: ViewProps & {
-  scrollToBottomSignal?: number
   inlineQueuedMessages?: Array<OptimisticInboxMessage>
 }): React.ReactElement {
   const connectUrl = isSpawning ? null : entityUrl
-  const { timelineRows, pendingInbox, entities, db, loading, error } =
-    useEntityTimeline(baseUrl || null, connectUrl)
+  const {
+    timelineRows,
+    pendingInbox,
+    entities,
+    generationActive,
+    db,
+    loading,
+    error,
+  } = useEntityTimeline(baseUrl || null, connectUrl)
   const canFork = useEntityPermission(entity, `fork`)
   const navigate = useNavigate()
   const processedInboxKeys = useMemo(
@@ -97,14 +102,15 @@ export function ChatLogView({
     [pendingInbox]
   )
   const projectedPendingMessage = useMemo(() => {
-    if (entity.status === `running`) return null
+    if (entityStopped || generationActive) return null
     for (const message of inlineQueuedMessages) {
       if (processedInboxKeys.has(message.key)) continue
       return pendingInboxByKey.get(message.key) ?? message
     }
     return null
   }, [
-    entity.status,
+    entityStopped,
+    generationActive,
     inlineQueuedMessages,
     pendingInboxByKey,
     processedInboxKeys,
@@ -140,11 +146,10 @@ export function ChatLogView({
       error={error}
       entityStopped={entityStopped}
       baseUrl={baseUrl}
-      cacheKey={`${baseUrl}${connectUrl ?? ``}:${scrollToBottomSignal ?? 0}`}
+      cacheKey={`${baseUrl}${connectUrl ?? ``}`}
       tileId={tileId}
       entityUrl={connectUrl}
       entities={entities}
-      scrollToBottomSignal={scrollToBottomSignal}
       forkFromHereByRunKey={forkFromHereByRunKey}
     />
   )

--- a/packages/agents-server-ui/src/embed/EmbedApp.tsx
+++ b/packages/agents-server-ui/src/embed/EmbedApp.tsx
@@ -4,7 +4,6 @@ import {
   useEffect,
   useMemo,
   useRef,
-  type CSSProperties,
   type ReactElement,
 } from 'react'
 import {
@@ -110,7 +109,6 @@ type EmbedState = {
   entityUrl: string
   view: EmbedView
   theme: EmbedTheme
-  scrollToBottomSignal?: number
   inlineQueuedMessages?: Array<OptimisticInboxMessage>
   bottomInset?: number
   // Forwarded across the Expo-DOM boundary so the embed's auth-fetch
@@ -205,7 +203,6 @@ function EmbedSurface({ state }: { state: EmbedState }): ReactElement {
       entityUrl={state.entityUrl}
       view={state.view}
       serverUrl={state.serverUrl}
-      scrollToBottomSignal={state.scrollToBottomSignal}
       inlineQueuedMessages={state.inlineQueuedMessages}
       bottomInset={state.bottomInset}
     />
@@ -216,14 +213,12 @@ function EntityHost({
   entityUrl,
   view,
   serverUrl,
-  scrollToBottomSignal,
   inlineQueuedMessages,
   bottomInset,
 }: {
   entityUrl: string
   view: EmbedView
   serverUrl: string
-  scrollToBottomSignal?: number
   inlineQueuedMessages?: Array<OptimisticInboxMessage>
   bottomInset?: number
 }): ReactElement {
@@ -277,16 +272,11 @@ function EntityHost({
     )
   }
   if (view === `chat-log`) {
-    const style = {
-      '--mobile-chat-bottom-inset': `${Math.max(0, bottomInset ?? 0)}px`,
-    } as CSSProperties
+    // Inset var is seeded on the document root (above); resize updates arrive
+    // imperatively via setBottomInset — no inline value here, which would shadow it.
     return (
-      <div className={styles.column} style={style}>
-        <ChatLogView
-          {...props}
-          scrollToBottomSignal={scrollToBottomSignal}
-          inlineQueuedMessages={inlineQueuedMessages}
-        />
+      <div className={styles.column}>
+        <ChatLogView {...props} inlineQueuedMessages={inlineQueuedMessages} />
       </div>
     )
   }

--- a/packages/agents-server-ui/src/embed/SessionChatLogDomEmbed.tsx
+++ b/packages/agents-server-ui/src/embed/SessionChatLogDomEmbed.tsx
@@ -3,8 +3,12 @@
 import '../ui/tokens.css'
 import '../ui/global.css'
 import './SessionDomEmbed.css'
+import { useCallback, useState } from 'react'
+import { useDOMImperativeHandle } from 'expo/dom'
 import { installMobileCryptoPolyfill } from './mobileDomRuntime'
 import { EmbedChatLogRoot, type EmbedSurfaceProps } from './EmbedApp'
+import type { SessionChatLogDomRef } from './sessionChatLogDomRef'
+import type { OptimisticInboxMessage } from '../lib/sendMessage'
 
 installMobileCryptoPolyfill()
 
@@ -14,21 +18,70 @@ if (typeof document !== `undefined`) {
 
 export type SessionChatLogDomEmbedProps = EmbedSurfaceProps & {
   onRequestOpenEntity: (entityUrl: string) => Promise<void>
+  ref?: React.Ref<SessionChatLogDomRef>
   dom?: unknown
 }
 
 export default function SessionChatLogDomEmbed({
   onRequestOpenEntity,
+  ref,
+  inlineQueuedMessages: initialInlineQueuedMessages,
   ...props
 }: SessionChatLogDomEmbedProps): React.ReactElement {
+  // Seeded once from props, then driven via the imperative handle below: this
+  // re-renders the inner tree (like a streamed message) instead of updating a
+  // prop, which would re-post across the bridge and flash. See SessionChatLogDomRef.
+  const [inlineQueued, setInlineQueued] = useState<
+    Array<OptimisticInboxMessage>
+  >(() => initialInlineQueuedMessages ?? [])
+
+  useDOMImperativeHandle<SessionChatLogDomRef>(
+    ref ?? null,
+    () => ({
+      setBottomInset(px: unknown) {
+        if (typeof document === `undefined`) return
+        const value = typeof px === `number` ? px : Number(px) || 0
+        document.documentElement.style.setProperty(
+          `--mobile-chat-bottom-inset`,
+          `${Math.max(0, value)}px`
+        )
+      },
+      scrollToBottom() {
+        if (typeof document === `undefined`) return
+        requestAnimationFrame(() => {
+          const viewport = document.querySelector(
+            `.mobile-chat-scroll-viewport`
+          )
+          if (viewport instanceof HTMLElement) {
+            viewport.scrollTop = viewport.scrollHeight
+          }
+        })
+      },
+      setInlineQueuedMessages(messages: unknown) {
+        setInlineQueued(
+          Array.isArray(messages)
+            ? (messages as Array<OptimisticInboxMessage>)
+            : []
+        )
+      },
+    }),
+    []
+  )
+  // useCallback so an inner-tree re-render keeps this identity: the embed's
+  // router is memoized on it, and a new identity would remount the timeline.
+  const handleNavigatePathname = useCallback(
+    (pathname: string) => {
+      const match = /^\/entity(\/.+)$/.exec(pathname)
+      const target = match?.[1]
+      if (target) return onRequestOpenEntity(target)
+    },
+    [onRequestOpenEntity]
+  )
   return (
     <EmbedChatLogRoot
       {...props}
-      onNavigatePathname={(pathname) => {
-        const match = /^\/entity(\/.+)$/.exec(pathname)
-        const target = match?.[1]
-        if (target) return onRequestOpenEntity(target)
-      }}
+      inlineQueuedMessages={inlineQueued}
+      onNavigatePathname={handleNavigatePathname}
     />
   )
 }

--- a/packages/agents-server-ui/src/embed/sessionChatLogDomRef.ts
+++ b/packages/agents-server-ui/src/embed/sessionChatLogDomRef.ts
@@ -1,0 +1,16 @@
+/**
+ * Imperative handle the native side uses to drive the chat-log DOM embed. Values
+ * are pushed through methods, not props: any prop crossing the Expo DOM bridge
+ * re-renders the embed and flashes the WebView. Args arrive JSON-serialized.
+ *
+ * Lives in a plain module (not the `'use dom'` embed, whose named exports the
+ * consuming app can't resolve). The index signature inlines expo's
+ * `DOMImperativeFactory` contract so this resolves without importing `expo/dom`,
+ * which agents-server-ui can't resolve.
+ */
+export interface SessionChatLogDomRef {
+  [method: string]: (...args: Array<unknown>) => void
+  setBottomInset(px: unknown): void
+  scrollToBottom(): void
+  setInlineQueuedMessages(messages: unknown): void
+}

--- a/packages/agents-server-ui/src/types/expo-dom.d.ts
+++ b/packages/agents-server-ui/src/types/expo-dom.d.ts
@@ -1,0 +1,16 @@
+// Minimal ambient types for `expo/dom`. The `'use dom'` embed files in this
+// directory are bundled by the mobile app (which depends on expo and provides
+// the real `expo/dom` at runtime); they are never imported by agents-server-ui's
+// own web/electron build. agents-server-ui itself does not depend on expo, so we
+// shim the tiny surface we use to keep `tsc` happy here. The mobile app
+// typechecks these same files against the real `expo/dom`.
+declare module 'expo/dom' {
+  export interface DOMImperativeFactory {
+    [key: string]: (...args: Array<unknown>) => void
+  }
+  export function useDOMImperativeHandle<T extends DOMImperativeFactory>(
+    ref: unknown,
+    init: () => T,
+    deps?: ReadonlyArray<unknown>
+  ): void
+}


### PR DESCRIPTION
## Intent

Eliminate the visible "flashing" of the agents-mobile chat timeline during normal use — sending a message, growing the composer (multiline / attachments), and queuing messages — **while preserving** the dynamic bottom inset, instant optimistic sending, and reliable pin-to-bottom. Also fix inconsistent auto-scroll when the composer grows.

## Architecture context (read this first)

The mobile chat screen is **two separate UIs**:
- A **native composer + queue drawer** (`agents-mobile/src/screens/SessionScreen.tsx`).
- A **chat timeline rendered inside an Expo DOM (`'use dom'`) WebView embed** (`agents-server-ui/src/embed/SessionChatLogDomEmbed.tsx` → `EmbedApp.tsx` → `ChatView.tsx`'s `ChatLogView` → `EntityTimeline.tsx`), hosted by `agents-mobile/app/session.tsx`.

These run in **separate JS contexts**. The native side and the embed communicate via props (serialized across the Expo DOM bridge) and an imperative handle.

## Root cause (the key finding)

**A value delivered over the Expo DOM prop bridge forces a full, memoization-busting re-render of the embed's React tree every time it changes — and with a tree as heavy as the timeline, that re-render *is* the visible "flash."**

Confirmed against the Expo SDK 54 source (`expo/src/dom/webview-wrapper.tsx` + `dom-entry.tsx`) — it is **not** a native WebView reload or remount:
- The WebView `source` is derived from the component's file path only, never from props, so a prop change never reloads the page; there's no `key` change either, so no remount.
- Prop updates are sent as a message: the native wrapper `injectJavaScript`s a `$$props` payload and the page-side runtime handles it with a plain `setProps(...)` state update on a root created once. So a prop update is mechanically just a `setState` inside the WebView.
- **But the payload is JSON — re-serialized and re-deserialized — so every data prop arrives as a brand-new reference on every update.** The page renders `<App {...freshlyDeserializedProps} {...actions} />`, busting every downstream `useMemo` / `React.memo` / `useCallback` that depends on a prop. Nothing memo-skips, so the whole heavy subtree re-does its work (virtualized-list measurement, markdown rendering, CSS masks) → a dropped frame = the flash.
- The native wrapper only emits `$$props` when its marshalled props **change identity**. So a parent re-render that passes new *inline* references (`style={[...]}`, `dom={...}`, inline callbacks) ships a fresh-reference update and flashes too — which is why the earlier "froze the CSS / native no-op" tests still flashed until the embed stopped re-rendering. It was never a true no-op; the references were changing.

You cannot make a bridge-crossed prop update cheap (the fresh references are unavoidable). The only lever is to **not send frequently-changing values as props at all** — keep props referentially stable so the native side emits nothing, and push dynamic updates through the imperative handle (which never crosses the bridge).

So every flash traced back to *something that emitted a `$$props` update (a changed/fresh prop reference) or re-rendered the embed*:
1. **Drawer flash on send** — the optimistic message was tracked via `entity.status === 'running'` and pruned from inline tracking while still `pending`, so it briefly fell into the queue drawer.
2. **Composer-resize flash** — the composer height re-renders the host route on every multiline/attachment change, re-rendering the (non-memoized) embed.
3. **Inset prop flash** — the bottom inset was passed as a live prop that changed on every resize.
4. **Queued-send flash** — `scrollToBottomSignal` and `inlineQueuedMessages` were live props that changed on send.
5. **Auto-scroll bug** — the pin-to-bottom `ResizeObserver` watched the **content-box**, but the inset is applied as **bottom padding**; a padding-only change leaves the content-box untouched, so multiline growth didn't trigger a re-pin (it only scrolled when content also changed — hence intermittent).

## Approach

**Nothing that changes frequently crosses the bridge as a prop.**
- **Memoize** both DOM embeds and keep every native-passed prop reference-stable (memoized `style`/`dom`, value-memoized `serverHeaders`, stable callbacks, frozen initial inset).
- **Deliver dynamic values imperatively** via a `useDOMImperativeHandle` ref (`SessionChatLogDomRef`):
  - `setBottomInset(px)` → direct CSS-var write (`--mobile-chat-bottom-inset`), no React.
  - `scrollToBottom()` → direct `scrollTop`, no React.
  - `setInlineQueuedMessages(messages)` → updates the embed's **internal** `useState`. The render still cascades, but every *surrounding* reference stays stable, so memoized subtrees (timeline, markdown, router) are skipped — cheap, no flash — unlike a bridge prop update where all references are fresh.
- The imperative handle registers a beat after the WebView boots, so the native side pushes via a small `usePushToEmbed` hook that retries on animation frames until the handle exists.
- Fix the drawer flash by keying off `generationActive` (matching desktop) and keeping a message in inline tracking until it actually leaves the pending inbox.
- Fix auto-scroll by observing the **border-box** in the pin-to-bottom `ResizeObserver`, plus a synchronous `scrollTop` correction before the rAF re-pin (ResizeObserver fires before paint, avoiding one misaligned frame).

## Key decisions & trade-offs

- **Internal state for inline queued messages re-renders the embed root.** That's fine *only because* `onNavigatePathname` is `useCallback`'d — the embed's router is `useMemo`'d on it, and an unstable identity would remount (and flash) the timeline. Props are unchanged on an internal re-render, so the callback keeps its identity.
- **`SessionChatLogDomRef` lives in a plain `.ts` module**, not the `'use dom'` embed file: named exports from `'use dom'` files aren't resolvable by the consuming app (single-default-export only).
- **`expo/dom` ambient shim** (`agents-server-ui/src/types/expo-dom.d.ts`) + an **inline `DOMImperativeFactory` index signature** in `sessionChatLogDomRef.ts`: agents-server-ui doesn't depend on expo (the embed is only bundled by the mobile app), so `expo/dom` isn't resolvable there. This is deliberate — a previous attempt to `import`/`extends` from `expo/dom` failed mobile tsc with "Cannot find module 'expo/dom'". **Do not "simplify" this back to importing from `expo/dom`.**

### Deliberately NOT done (so we don't go in circles)

- **Do not pass the inset/queued messages as live props** "since the embed is memoized." `React.memo` re-renders when a prop *value* changes — live props reintroduce the flash. The frozen-initial + imperative-update split is intentional.
- **Do not freeze `serverHeaders` with `useMemo(..., [])`.** It must update if auth headers refresh (token rotation); hence the `JSON.stringify` memo key (stable identity, updates on real change). The stringify is on a tiny object — negligible.
- **Did not unify the three imperative methods into one generic `updateState` channel** or replace the rAF retry with a "ready" event — Expo exposes no handle-ready signal, and three distinct semantic methods read clearer. Duplication was removed via the shared `usePushToEmbed` hook instead.
- **Did not push the `ResizeObserver` behavior behind a prop / create a `ChatLogViewMobile` wrapper.** `ChatLogView` is already the mobile-embed-only view, and border-box + sync-scroll are harmless/general for desktop.
- **Did not extract the inline-pending projection shared by `ChatLogView` and `SessionScreen`** — it's pre-existing, cross-package, and array-vs-map; extracting would over-abstract.

## Files changed

- `agents-mobile/app/session.tsx` — memoize embeds; stabilize props; `usePushToEmbed` hook + imperative inset/queued-message delivery; imperative `scrollToBottom` on send; `async openSession`.
- `agents-mobile/src/screens/SessionScreen.tsx` — `generationActive` gating; inline-tracking prune guard (keep while still pending).
- `agents-server-ui/src/embed/SessionChatLogDomEmbed.tsx` — imperative handle (`setBottomInset`/`scrollToBottom`/`setInlineQueuedMessages`); internal state for queued messages; stable `onNavigatePathname`.
- `agents-server-ui/src/embed/sessionChatLogDomRef.ts` *(new)* — shared imperative-handle contract + rationale.
- `agents-server-ui/src/types/expo-dom.d.ts` *(new)* — ambient `expo/dom` shim for agents-server-ui's tsc.
- `agents-server-ui/src/embed/EmbedApp.tsx` — inset var seeded on document root; removed dead `scrollToBottomSignal` plumbing.
- `agents-server-ui/src/components/views/ChatView.tsx` — `ChatLogView` uses `generationActive`/`entityStopped`; dropped `scrollToBottomSignal` from `cacheKey` and props.
- `agents-server-ui/src/components/EntityTimeline.tsx` — pin-to-bottom observes border-box + synchronous scroll correction.

## Testing / how to verify

Manually verified on device by the author: no flash on send, multiline growth, attachments, queue add, or first message to an idle agent; auto-scroll follows composer growth; inset and instant optimistic send still work.

**Important:** webview-side files (`SessionChatLogDomEmbed`, `sessionChatLogDomRef`, `EmbedApp`, `ChatView`, `EntityTimeline`) require a **DOM-bundle rebuild** to take effect; native files (`session.tsx`, `SessionScreen.tsx`) hot-reload.

Both `agents-mobile` and `agents-server-ui` typecheck and lint clean.

## Rebase notes

Rebased onto `main` after the **"fork subtree"** mobile feature merged (it touched the same files). Integration points to be aware of:
- `session.tsx` now passes `onRequestForkEntity` to the embed. It is wrapped in a **`useCallback` (`handleForkEntity`)** rather than the inline closure main used — an inline function would be an unstable prop and defeat the embed's `memo` (reintroducing the flash). Keep it stable.
- `EmbedApp.tsx` merged cleanly: main's `ToastProvider` + `forkEntityImpl` wiring coexists with this PR's removed `scrollToBottomSignal`/inline-inset-style and dropped `CSSProperties` import.
- `SessionScreen.tsx` auto-merged: main's fork state/menu wiring is independent of this PR's `generationActive` gating + inline-prune guard.

## Status / follow-ups

- Draft. No automated test covers the flash behavior (it's a WebView-layer visual artifact); verification is manual.
- The simplification pass (reuse/efficiency/altitude/comment review) is already applied — the diff is intended to be the final, consolidated form, not a stack of patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
