### PR TITLE
Open new agent form when splitting tiles

### DIFF
--- a/.changeset/tidy-splits-open.md
+++ b/.changeset/tidy-splits-open.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-server-ui': patch
+---
+
+Open the new agent/entity form when using the generic split action instead of cloning the current route.

--- a/packages/agents-server-ui/src/components/workspace/SplitMenu.tsx
+++ b/packages/agents-server-ui/src/components/workspace/SplitMenu.tsx
@@ -139,8 +139,8 @@ const TILE_MENU_PERMISSIONS: ReadonlyArray<EntityPermission> = [
  *                                 (swap in place); the trailing two icon
  *                                 buttons split the tile to the side
  *                                 ([→]) or below ([↓]) with that view.
- * - **Split right / down**        duplicate the active tile into a new
- *                                 split (current view, right / down).
+ * - **Split right / down**        open the new agent/entity form in a new
+ *                                 split (right / down).
  * - **Copy URL · Copy layout link · Pin · Fork**  entity-level actions.
  * - **Close tile**                remove this tile (collapses parent split).
  * - **Kill entity**               (destructive) confirmation-gated.

--- a/packages/agents-server-ui/src/hooks/useWorkspace.tsx
+++ b/packages/agents-server-ui/src/hooks/useWorkspace.tsx
@@ -63,7 +63,7 @@ export type WorkspaceHelpers = {
     viewId: ViewId,
     direction: SplitDirection
   ) => void
-  /** Convenience: split a tile, copying its current view into the new one. */
+  /** Convenience: split a tile with a standalone new-session form in the new pane. */
   splitTile: (tileId: string, direction: SplitDirection) => void
   resizeSplit: (splitId: string, sizes: Array<number>) => void
   replaceWorkspace: (workspace: Workspace) => void
@@ -146,16 +146,9 @@ export function WorkspaceProvider({
 
   const splitTile = useCallback<WorkspaceHelpers[`splitTile`]>(
     (tileId, direction) => {
-      const tile = findTile(workspace.root, tileId)
-      if (!tile) return
-      dispatch({
-        type: `split-tile-with-view`,
-        tileId,
-        viewId: tile.viewId,
-        direction,
-      })
+      dispatch({ type: `split-tile-new-session`, tileId, direction })
     },
-    [workspace.root]
+    []
   )
 
   const resizeSplit = useCallback<WorkspaceHelpers[`resizeSplit`]>(

--- a/packages/agents-server-ui/src/lib/workspace/workspaceReducer.test.ts
+++ b/packages/agents-server-ui/src/lib/workspace/workspaceReducer.test.ts
@@ -202,6 +202,35 @@ describe(`workspaceReducer`, () => {
     })
   })
 
+  describe(`split-tile-new-session`, () => {
+    it(`opens the new-session form in the new split and leaves the existing tile unchanged`, () => {
+      let ws = run(EMPTY_WORKSPACE, {
+        type: `open-tile`,
+        tile: { entityUrl: `/horton/foo`, viewId: `chat` },
+      })
+      const tileId = rootAsTile(ws).id
+      ws = workspaceReducer(ws, {
+        type: `split-tile-new-session`,
+        tileId,
+        direction: `right`,
+      })
+      const tiles = listTiles(ws.root)
+      expect(tiles).toHaveLength(2)
+      expect(tiles).toContainEqual(
+        expect.objectContaining({
+          id: tileId,
+          entityUrl: `/horton/foo`,
+          viewId: `chat`,
+        })
+      )
+      const newSessionTile = tiles.find((t) => t.entityUrl === null)
+      expect(newSessionTile).toEqual(
+        expect.objectContaining({ viewId: `new-session` })
+      )
+      expect(ws.activeTileId).toBe(newSessionTile?.id)
+    })
+  })
+
   describe(`split-tile-with-view`, () => {
     it(`opens a different view of the same entity in a new split`, () => {
       let ws = run(EMPTY_WORKSPACE, {

--- a/packages/agents-server-ui/src/lib/workspace/workspaceReducer.ts
+++ b/packages/agents-server-ui/src/lib/workspace/workspaceReducer.ts
@@ -55,6 +55,11 @@ export type WorkspaceAction =
       direction: `right` | `down` | `left` | `up`
     }
   | {
+      type: `split-tile-new-session`
+      tileId: string
+      direction: `right` | `down` | `left` | `up`
+    }
+  | {
       type: `resize-split`
       splitId: string
       sizes: Array<number>
@@ -89,6 +94,8 @@ export function workspaceReducer(
         action.viewId,
         action.direction
       )
+    case `split-tile-new-session`:
+      return splitTileNewSession(state, action.tileId, action.direction)
     case `resize-split`:
       return resizeSplit(state, action.splitId, action.sizes)
     case `replace-workspace`:
@@ -352,6 +359,19 @@ function splitTileWithView(
   )
   // Focus follows split.
   return { ...next, activeTileId: newTile.id }
+}
+
+function splitTileNewSession(
+  state: Workspace,
+  tileId: string,
+  direction: `right` | `down` | `left` | `up`
+): Workspace {
+  if (!findTile(state.root, tileId)) return state
+  return openTile(
+    state,
+    { entityUrl: null, viewId: NEW_SESSION_VIEW_ID },
+    { tileId, position: `split-${direction}` }
+  )
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- change the generic tile split action to open the standalone new agent/entity form instead of cloning the current route/view
- add a reducer action for splitting directly to a new-session tile while preserving the original tile
- add reducer coverage for the new split behavior

## Tests
- pnpm exec vitest run src/lib/workspace/workspaceReducer.test.ts
- pnpm --filter @electric-ax/agents-server-ui typecheck