### PR TITLE
Fix Electric Agents quickstart runner registration

### DIFF
--- a/.changeset/quickstart-runner-principal.md
+++ b/.changeset/quickstart-runner-principal.md
@@ -1,0 +1,8 @@
+---
+"electric-ax": patch
+"@electric-ax/agents": patch
+"@electric-ax/agents-runtime": patch
+"@electric-ax/agents-server-ui": patch
+---
+
+Fix Electric Agents quickstart startup by authenticating the built-in pull-wake runner with the same principal it registers as, registering built-in agent types with the local runner as their default dispatch target, and aligning the CLI's default principal with the local quickstart user. Pin the CLI-launched agents-server Docker image to the matching released agents-server version, improve registration fetch errors so startup failures include the endpoint and underlying cause, avoid the CLI observe live-query Collection boundary, and clarify browser-only credentials settings copy.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.12.1",
   "private": true,
   "scripts": {
-    "ci:publish": "pnpm '/^ci:publish:.+/' && pnpm exec changeset tag",
+    "ci:publish": "pnpm run -r --filter './packages/**' build && pnpm '/^ci:publish:.+/' && pnpm exec changeset tag",
     "ci:publish:hex-electric": "pnpm run --dir packages/sync-service publish:hex",
     "ci:publish:hex-electric-client": "pnpm run --dir packages/elixir-client publish:hex",
     "ci:publish:npm": "pnpm publish -r --filter './packages/**' --no-git-checks --access public",

--- a/packages/agents-runtime/src/create-handler.ts
+++ b/packages/agents-runtime/src/create-handler.ts
@@ -561,14 +561,23 @@ export function createRuntimeRouter(
         }
       }
 
-      const typeRes = await fetch(
-        appendPathToUrl(baseUrl, `/_electric/entity-types`),
-        {
+      const registrationUrl = appendPathToUrl(
+        baseUrl,
+        `/_electric/entity-types`
+      )
+      let typeRes: Response
+      try {
+        typeRes = await fetch(registrationUrl, {
           method: `POST`,
           headers: await registrationHeaders(),
           body: JSON.stringify(body),
-        }
-      )
+        })
+      } catch (error) {
+        const message = `Failed to register type "${name}" at ${registrationUrl}: ${formatFetchError(error)}`
+        runtimeLog.error(`[agent-runtime]`, message)
+        failed.push(`${name} (${message})`)
+        return
+      }
 
       if (!typeRes.ok) {
         const err = await typeRes.text()
@@ -748,6 +757,17 @@ function json(body: Record<string, unknown>, status: number): Response {
     status,
     headers: { 'content-type': `application/json` },
   })
+}
+
+function formatFetchError(error: unknown): string {
+  if (error instanceof Error) {
+    const cause =
+      error.cause instanceof Error
+        ? `: ${error.cause.message || error.cause.name}`
+        : ``
+    return `${error.message || error.name || `Unknown error`}${cause}`
+  }
+  return String(error) || `Unknown error`
 }
 
 async function toFetchRequest(req: IncomingMessage): Promise<Request> {

--- a/packages/agents-runtime/src/entity-timeline.ts
+++ b/packages/agents-runtime/src/entity-timeline.ts
@@ -10,12 +10,13 @@ import {
   isNull,
   isUndefined,
   like,
+  min,
   localOnlyCollectionOptions,
   or,
   sum,
   toArray,
 } from '@durable-streams/state/db'
-import { caseWhen } from '@tanstack/db'
+import { BasicIndex, caseWhen } from '@tanstack/db'
 import type {
   Collection,
   InitialQueryBuilder,
@@ -1316,6 +1317,47 @@ const getEntitySignalsCollection = cachedCollectionFactory(
 
 type EntityTimelineQueryBuilder = (q: InitialQueryBuilder) => QueryBuilder<any>
 
+const indexedTimelineDbs = new WeakSet<object>()
+
+type IndexableCollection = {
+  createIndex: (
+    index: (row: any) => unknown,
+    config: { indexType: typeof BasicIndex }
+  ) => void
+}
+
+function hasCreateIndex(value: unknown): value is IndexableCollection {
+  return (
+    !!value &&
+    typeof (value as { createIndex?: unknown }).createIndex === `function`
+  )
+}
+
+function createIndexIfAvailable(
+  collection: unknown,
+  index: (row: any) => unknown
+): void {
+  if (hasCreateIndex(collection)) {
+    collection.createIndex(index, { indexType: BasicIndex })
+  }
+}
+
+export function ensureEntityTimelineIndexes(db: EntityStreamDB): void {
+  if (indexedTimelineDbs.has(db as object)) return
+  indexedTimelineDbs.add(db as object)
+
+  createIndexIfAvailable(db.collections.texts, (row) => row.run_id)
+  createIndexIfAvailable(db.collections.textDeltas, (row) => row.text_id)
+  createIndexIfAvailable(db.collections.toolCalls, (row) => row.run_id)
+  createIndexIfAvailable(db.collections.reasoning, (row) => row.run_id)
+  createIndexIfAvailable(
+    db.collections.reasoningDeltas,
+    (row) => row.reasoning_id
+  )
+  createIndexIfAvailable(db.collections.steps, (row) => row.run_id)
+  createIndexIfAvailable(db.collections.errors, (row) => row.run_id)
+}
+
 /**
  * Builds a live timeline query for an entity stream.
  *
@@ -1339,6 +1381,7 @@ export function createEntityTimelineQuery(
   db: EntityStreamDB,
   opts: EntityTimelineQueryOptions = {}
 ): EntityTimelineQueryBuilder {
+  ensureEntityTimelineIndexes(db)
   return (q: InitialQueryBuilder) => buildEntityTimelineQuery(q, db, opts)
 }
 
@@ -1423,6 +1466,14 @@ function buildEntityTimelineQuery(
       run_id: error.run_id,
     }))
 
+  const textFirstDeltaSource = q
+    .from({ textDelta: db.collections.textDeltas })
+    .groupBy(({ textDelta }) => textDelta.text_id)
+    .select(({ textDelta }) => ({
+      text_id: textDelta.text_id,
+      order: min(coalesce(textDelta._seq, -1)),
+    }))
+
   // Union texts + tool calls into a single ordered stream. The
   // text-delta join lives at this level (vs. inside the consumer's
   // `items.select`) so the correlation key is `text.key` — a field
@@ -1435,13 +1486,16 @@ function buildEntityTimelineQuery(
       text: db.collections.texts,
       toolCall: db.collections.toolCalls,
     })
-    .select(({ text, toolCall }) => ({
-      order: coalesce(text._timeline_order, toolCall._timeline_order, `~`),
+    .leftJoin({ firstDelta: textFirstDeltaSource }, ({ text, firstDelta }) =>
+      eq(text.key, firstDelta.text_id)
+    )
+    .select(({ text, toolCall, firstDelta }) => ({
+      order: coalesce(firstDelta.order, text._seq, toolCall._seq, -1),
       run_id: coalesce(text.run_id, toolCall.run_id, ``),
       text: caseWhen(text.key, {
         key: text.key,
         run_id: text.run_id,
-        order: coalesce(text._timeline_order, `~`),
+        order: coalesce(firstDelta.order, text._seq, -1),
         status: text.status,
       }),
       textContent: concat(
@@ -1449,17 +1503,14 @@ function buildEntityTimelineQuery(
           q
             .from({ textChunk: db.collections.textDeltas })
             .where(({ textChunk }) => eq(textChunk.text_id, text.key))
-            .orderBy(({ textChunk }) =>
-              coalesce(textChunk._timeline_order, `~`)
-            )
-            .orderBy(({ textChunk }) => textChunk.key)
+            .orderBy(({ textChunk }) => coalesce(textChunk._seq, -1))
             .select(({ textChunk }) => textChunk.delta)
         )
       ),
       toolCall: caseWhen(toolCall.key, {
         key: toolCall.key,
         run_id: toolCall.run_id,
-        order: coalesce(toolCall._timeline_order, `~`),
+        order: coalesce(toolCall._seq, -1),
         tool_call_id: toolCall.tool_call_id,
         tool_name: toolCall.tool_name,
         status: toolCall.status,
@@ -1486,7 +1537,7 @@ function buildEntityTimelineQuery(
     .select(({ reasoning }) => ({
       key: reasoning.key,
       run_id: reasoning.run_id,
-      order: coalesce(reasoning._timeline_order, `~`),
+      order: coalesce(reasoning._seq, -1),
       status: reasoning.status,
       summary_title: reasoning.summary_title,
       encrypted: reasoning.encrypted,
@@ -1497,10 +1548,7 @@ function buildEntityTimelineQuery(
             .where(({ reasoningChunk }) =>
               eq(reasoningChunk.reasoning_id, reasoning.key)
             )
-            .orderBy(({ reasoningChunk }) =>
-              coalesce(reasoningChunk._timeline_order, `~`)
-            )
-            .orderBy(({ reasoningChunk }) => reasoningChunk.key)
+            .orderBy(({ reasoningChunk }) => coalesce(reasoningChunk._seq, -1))
             .select(({ reasoningChunk }) => reasoningChunk.delta)
         )
       ),
@@ -1667,6 +1715,7 @@ type EntityQueryBuilder = (q: InitialQueryBuilder) => QueryBuilder<any>
 export function createEntityIncludesQuery(
   db: EntityStreamDB
 ): EntityQueryBuilder {
+  ensureEntityTimelineIndexes(db)
   const seedCollection = getTimelineSeedCollection(db)
   const runsCollection = getEntityRunsCollection(db)
   const inboxCollection = getEntityInboxCollection(db)

--- a/packages/agents-runtime/test/create-handler.test.ts
+++ b/packages/agents-runtime/test/create-handler.test.ts
@@ -648,6 +648,23 @@ describe(`createRuntimeHandler`, () => {
     )
   })
 
+  it(`registerTypes includes URL and cause when registration fetch throws`, async () => {
+    defineEntity(`network-agent`, { handler: async () => {} })
+
+    vi.spyOn(globalThis, `fetch`).mockRejectedValue(
+      new Error(`fetch failed`, { cause: new Error(`ECONNREFUSED 127.0.0.1`) })
+    )
+
+    const handler = createRuntimeHandler({
+      baseUrl: `http://localhost:3000`,
+      handlerUrl: `http://localhost:4000/electric-agents`,
+    })
+
+    await expect(handler.registerTypes()).rejects.toThrow(
+      `Failed to register type "network-agent" at http://localhost:3000/_electric/entity-types: fetch failed: ECONNREFUSED 127.0.0.1`
+    )
+  })
+
   it(`registers entity types with a webhook default dispatch policy`, async () => {
     defineEntity(`schema-agent`, {
       description: `Schema agent`,

--- a/packages/agents-runtime/test/entity-timeline.test.ts
+++ b/packages/agents-runtime/test/entity-timeline.test.ts
@@ -1835,6 +1835,61 @@ describe(`entity includes query`, () => {
       })
     })
 
+    it(`interleaves top-level live timeline rows by runtime timeline order`, async () => {
+      const { collections, sync } = createEntityCollections()
+      const liveQuery = createLiveQueryCollection({
+        query: createEntityTimelineQuery({ collections } as any),
+        startSync: true,
+      })
+      await liveQuery.preload()
+
+      sync.inbox.insert({
+        key: `msg-1`,
+        _timeline_order: order(1),
+        from: `user`,
+        payload: `first`,
+        timestamp: `2026-04-15T18:00:00.000Z`,
+        status: `processed`,
+      })
+      sync.runs.insert({
+        key: `run-1`,
+        _timeline_order: order(2),
+        status: `started`,
+      })
+      sync.texts.insert({
+        key: `text-1`,
+        _timeline_order: order(3),
+        run_id: `run-1`,
+        status: `streaming`,
+      })
+      sync.textDeltas.insert({
+        key: `td-1`,
+        text_id: `text-1`,
+        run_id: `run-1`,
+        delta: `First response`,
+      })
+      sync.inbox.insert({
+        key: `msg-2`,
+        _timeline_order: order(4),
+        from: `user`,
+        payload: `second`,
+        timestamp: `2026-04-15T18:01:00.000Z`,
+        status: `processed`,
+      })
+      await new Promise((r) => setTimeout(r, 50))
+
+      const rows = getData(liveQuery)
+      expect(
+        rows.map((row) =>
+          row.inbox
+            ? `inbox:${row.inbox.key}`
+            : row.run
+              ? `run:${row.run.key}`
+              : `other:${row.$key}`
+        )
+      ).toEqual([`inbox:msg-1`, `run:run-1`, `inbox:msg-2`])
+    })
+
     it(`reacts to toolCall updates`, async () => {
       const { collections, sync } = createEntityCollections()
       const queryFn = createEntityIncludesQuery({ collections } as any)
@@ -2495,6 +2550,91 @@ describe(`entity includes query`, () => {
       const item = items[0]
       expect(item.text?.key).toBe(`msg-0`)
       expect(item.text?.content).toBe(`Hello world`)
+    })
+
+    it(`live items.text.content orders deltas by stream sequence, not key`, async () => {
+      // Production regression: delta keys like `msg-0:10` sort before
+      // `msg-0:2` lexicographically. The live query must use stream
+      // sequence order so streamed text stays in model output order.
+      const { collections, sync } = createTimelineCollections()
+      const liveQuery = createLiveQueryCollection({
+        query: createEntityTimelineQuery({ collections } as any),
+        startSync: true,
+      })
+      await liveQuery.preload()
+
+      sync.runs.insert({ key: `run-0`, status: `started` })
+      sync.texts.insert({
+        key: `msg-0`,
+        run_id: `run-0`,
+        status: `streaming`,
+      })
+      for (let i = 0; i <= 10; i++) {
+        sync.textDeltas.insert({
+          key: `msg-0:${i}`,
+          text_id: `msg-0`,
+          run_id: `run-0`,
+          delta: `[${i}]`,
+        })
+      }
+      sync.texts.update({
+        key: `msg-0`,
+        run_id: `run-0`,
+        status: `completed`,
+      })
+      sync.runs.update({
+        key: `run-0`,
+        status: `completed`,
+        finish_reason: `stop`,
+      })
+      await new Promise((r) => setTimeout(r, 50))
+
+      const rows = getRows(liveQuery)
+      const runRow = rows.find((r) => r.run?.key === `run-0`)
+      expect(runRow).toBeTruthy()
+      const items = Array.from(runRow.run.items.toArray) as Array<any>
+      expect(items).toHaveLength(1)
+      expect(items[0].text?.content).toBe(`[0][1][2][3][4][5][6][7][8][9][10]`)
+    })
+
+    it(`orders live run text items by first delta sequence, not text row creation`, async () => {
+      const { collections, sync } = createTimelineCollections()
+      const liveQuery = createLiveQueryCollection({
+        query: createEntityTimelineQuery({ collections } as any),
+        startSync: true,
+      })
+      await liveQuery.preload()
+
+      sync.runs.insert({ key: `run-0`, status: `started` })
+      sync.texts.insert({
+        key: `msg-0`,
+        run_id: `run-0`,
+        status: `streaming`,
+      })
+      sync.toolCalls.insert({
+        key: `tc-0`,
+        run_id: `run-0`,
+        tool_call_id: `tc-0`,
+        tool_name: `bash`,
+        status: `completed`,
+        result: { content: [{ type: `text`, text: `/private/tmp\n` }] },
+      })
+      sync.textDeltas.insert({
+        key: `msg-0:0`,
+        text_id: `msg-0`,
+        run_id: `run-0`,
+        delta: `We're in /private/tmp.`,
+      })
+      await new Promise((r) => setTimeout(r, 50))
+
+      const rows = getRows(liveQuery)
+      const runRow = rows.find((r) => r.run?.key === `run-0`)
+      expect(runRow).toBeTruthy()
+      const items = Array.from(runRow.run.items.toArray) as Array<any>
+      expect(items.map((item) => item.toolCall?.key ?? item.text?.key)).toEqual(
+        [`tc-0`, `msg-0`]
+      )
+      expect(items[1]?.text?.content).toBe(`We're in /private/tmp.`)
     })
 
     it(`reasoning content survives multiple run-row updates in sequence`, async () => {

--- a/packages/agents-server-ui/src/components/settings/pages/CredentialsPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/CredentialsPage.tsx
@@ -81,13 +81,13 @@ export function CredentialsPage(): React.ReactElement {
         description={
           isDesktop
             ? `Configure model providers for connected local runtimes. Changes save automatically and apply on the next runtime restart.`
-            : `Model providers are configured by the agents-server you're connected to. The web build inherits whatever providers the server was started with.`
+            : `Model providers are configured by the runtime connected to this server. Restart that runtime with provider credentials to change the available models.`
         }
       >
         {!isDesktop ? (
           <SettingsPanel>
             <Text size={2} tone="muted">
-              No editable provider keys in the web build.
+              Provider keys are not editable from the browser UI.
             </Text>
           </SettingsPanel>
         ) : !status ? (

--- a/packages/agents/src/server.ts
+++ b/packages/agents/src/server.ts
@@ -309,6 +309,9 @@ export class BuiltinAgentsServer {
         baseSkillsDir: this.options.baseSkillsDir,
         enabledModelValues: this.options.enabledModelValues,
         serverHeaders: pullWake.headers,
+        defaultDispatchPolicyForType: () => ({
+          targets: [{ type: `runner`, runnerId: pullWake.runnerId }],
+        }),
       })
       if (!this.bootstrap) {
         throw new Error(
@@ -428,9 +431,13 @@ export class BuiltinAgentsServer {
     )
     headers.set(`content-type`, `application/json`)
     const profiles = this.bootstrap?.runtime.sandboxProfileDescriptors ?? []
-    const response = await fetch(
-      appendPathToUrl(this.options.agentServerUrl, `/_electric/runners`),
-      {
+    const registrationUrl = appendPathToUrl(
+      this.options.agentServerUrl,
+      `/_electric/runners`
+    )
+    let response: Response
+    try {
+      response = await fetch(registrationUrl, {
         method: `POST`,
         headers,
         body: JSON.stringify({
@@ -441,8 +448,12 @@ export class BuiltinAgentsServer {
           admin_status: `enabled`,
           sandbox_profiles: profiles,
         }),
-      }
-    )
+      })
+    } catch (error) {
+      throw new Error(
+        `Failed to register pull-wake runner ${pullWake.runnerId} at ${registrationUrl}: ${formatFetchError(error)}`
+      )
+    }
     if (!response.ok) {
       throw new Error(
         `Failed to register pull-wake runner ${pullWake.runnerId}: ${response.status} ${await response.text()}`
@@ -450,4 +461,15 @@ export class BuiltinAgentsServer {
     }
     return (await response.json()) as { wake_stream_offset?: string }
   }
+}
+
+function formatFetchError(error: unknown): string {
+  if (error instanceof Error) {
+    const cause =
+      error.cause instanceof Error
+        ? `: ${error.cause.message || error.cause.name}`
+        : ``
+    return `${error.message || error.name || `Unknown error`}${cause}`
+  }
+  return String(error) || `Unknown error`
 }

--- a/packages/agents/test/builtin-pull-wake-registration.test.ts
+++ b/packages/agents/test/builtin-pull-wake-registration.test.ts
@@ -86,7 +86,7 @@ describe(`BuiltinAgentsServer pull-wake registration`, () => {
     agentsServer = null
   })
 
-  it(`does not store the local pull-wake runner as a type default`, async () => {
+  it(`stores the local pull-wake runner as the built-in type default`, async () => {
     agentsServer = await startRecordingAgentsServer()
     builtinServer = new BuiltinAgentsServer({
       agentServerUrl: agentsServer.url,
@@ -97,11 +97,11 @@ describe(`BuiltinAgentsServer pull-wake registration`, () => {
     await builtinServer.start()
 
     expect(agentsServer.entityTypeBodies.length).toBeGreaterThan(0)
-    expect(
-      agentsServer.entityTypeBodies.some(
-        (body) => body.default_dispatch_policy !== undefined
-      )
-    ).toBe(false)
+    for (const body of agentsServer.entityTypeBodies) {
+      expect(body.default_dispatch_policy).toEqual({
+        targets: [{ type: `runner`, runnerId: `test-runner` }],
+      })
+    }
   })
 
   it(`grants all users default built-in entity type permissions`, async () => {

--- a/packages/electric-ax/package.json
+++ b/packages/electric-ax/package.json
@@ -51,7 +51,7 @@
     "@electric-ax/agents": "workspace:*",
     "@electric-ax/agents-runtime": "workspace:*",
     "@electric-sql/client": "^1.5.21",
-    "@tanstack/db": "^0.6.4",
+    "@tanstack/db": "^0.6.6",
     "@tanstack/react-db": "^0.1.85",
     "commander": "^13.1.0",
     "ink": "^6.8.0",
@@ -66,7 +66,7 @@
     "ink-testing-library": "^4.0.0",
     "tsdown": "^0.9.0",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.0"
   },
   "files": [

--- a/packages/electric-ax/src/entity-stream-db.ts
+++ b/packages/electric-ax/src/entity-stream-db.ts
@@ -7,8 +7,10 @@
  * so we feed them directly to StreamDB without transformation.
  */
 
-import { createStreamDB } from '@durable-streams/state/db'
-import { appendPathToUrl, entityStateSchema } from '@electric-ax/agents-runtime'
+import {
+  appendPathToUrl,
+  createEntityStreamDB as createRuntimeEntityStreamDB,
+} from '@electric-ax/agents-runtime'
 import { entityApiUrl } from './entity-api.js'
 import type { EntityStreamDB } from '@electric-ax/agents-runtime'
 
@@ -57,14 +59,11 @@ export async function createEntityStreamDB(opts: {
   const streamPath = getMainStreamPath(entityUrl, entity)
   const streamUrl = appendPathToUrl(baseUrl, streamPath)
 
-  const db = createStreamDB({
+  const db = createRuntimeEntityStreamDB(streamUrl, undefined, undefined, {
     streamOptions: {
-      url: streamUrl,
       headers: requestHeaders,
-      contentType: `application/json`,
       ...(initialOffset ? { offset: initialOffset } : {}),
     },
-    state: entityStateSchema,
   })
 
   await db.preload()

--- a/packages/electric-ax/src/index.ts
+++ b/packages/electric-ax/src/index.ts
@@ -134,8 +134,8 @@ function getDefaultElectricAgentsIdentity(): string {
   return `${userInfo().username}@${hostname()}`
 }
 
-function getDefaultElectricAgentsPrincipal(): string {
-  return `system:cli-${userInfo().username}`
+function defaultElectricAgentsPrincipalForIdentity(identity: string): string {
+  return `user:${identity}`
 }
 
 function parseElectricAgentsHeaders(
@@ -173,13 +173,15 @@ export function getElectricCliEnv(
   const explicitIdentity = env.ELECTRIC_AGENTS_IDENTITY?.trim()
   const explicitPrincipal = env.ELECTRIC_AGENTS_PRINCIPAL?.trim()
   const headers = parseElectricAgentsHeaders(env.ELECTRIC_AGENTS_SERVER_HEADERS)
+  const electricAgentsIdentity =
+    explicitIdentity || getDefaultElectricAgentsIdentity()
   return {
     electricAgentsUrl: env.ELECTRIC_AGENTS_URL || DEFAULT_ELECTRIC_AGENTS_URL,
-    electricAgentsIdentity:
-      explicitIdentity || getDefaultElectricAgentsIdentity(),
+    electricAgentsIdentity,
     electricAgentsHeaders: mergeElectricPrincipalHeader(
       headers,
-      explicitPrincipal || getDefaultElectricAgentsPrincipal()
+      explicitPrincipal ||
+        defaultElectricAgentsPrincipalForIdentity(electricAgentsIdentity)
     ),
   }
 }
@@ -829,7 +831,7 @@ function getHelpText(commandName: string): string {
 Environment:
   ELECTRIC_AGENTS_URL        Base URL of the server (default: ${DEFAULT_ELECTRIC_AGENTS_URL})
   ELECTRIC_AGENTS_IDENTITY   Sender identity for messages (default: ${getDefaultElectricAgentsIdentity()})
-  ELECTRIC_AGENTS_PRINCIPAL  Principal key sent as the Electric-Principal header (default: ${getDefaultElectricAgentsPrincipal()})
+  ELECTRIC_AGENTS_PRINCIPAL  Principal key sent as the Electric-Principal header (default: user:<ELECTRIC_AGENTS_IDENTITY>)
   ELECTRIC_AGENTS_SERVER_HEADERS  Optional JSON object of additional server headers
   ANTHROPIC_API_KEY          Required for '${agentsCommand} start-builtin' and '${agentsCommand} quickstart'
 

--- a/packages/electric-ax/src/observe-ui.tsx
+++ b/packages/electric-ax/src/observe-ui.tsx
@@ -566,11 +566,11 @@ function AgentRunView({
   isStreaming: boolean
 }): React.ReactElement {
   const { data: items = [] } = useLiveQuery(
-    (q) => (run.items ? q.from({ item: run.items }) : undefined),
+    (q) => (run.items ? q.from({ item: run.items as any }) : undefined),
     [run.items]
   )
   const { data: errors = [] } = useLiveQuery(
-    (q) => (run.errors ? q.from({ error: run.errors }) : undefined),
+    (q) => (run.errors ? q.from({ error: run.errors as any }) : undefined),
     [run.errors]
   )
 
@@ -664,7 +664,7 @@ export function ObserveExitHotkey({
   return null
 }
 
-function ObserveView({
+export function ObserveView({
   db,
   entityUrl,
   baseUrl,
@@ -686,8 +686,11 @@ function ObserveView({
       timelineRowsToDisplayRows(timelineRows as Array<EntityTimelineQueryRow>),
     [timelineRows]
   )
-
-  const closed = db.collections.entityStopped.toArray.length > 0
+  const { data: entityStoppedRows = [] } = useLiveQuery(
+    (q) => q.from({ stopped: db.collections.entityStopped as any }),
+    [db.collections.entityStopped]
+  )
+  const closed = entityStoppedRows.length > 0
 
   const lastAgentIndex = useMemo(() => {
     for (let i = displayRows.length - 1; i >= 0; i--) {

--- a/packages/electric-ax/src/observe-ui.tsx
+++ b/packages/electric-ax/src/observe-ui.tsx
@@ -566,11 +566,11 @@ function AgentRunView({
   isStreaming: boolean
 }): React.ReactElement {
   const { data: items = [] } = useLiveQuery(
-    (q) => (run.items ? q.from({ item: run.items as any }) : undefined),
+    (q) => (run.items ? q.from({ item: run.items }) : undefined),
     [run.items]
   )
   const { data: errors = [] } = useLiveQuery(
-    (q) => (run.errors ? q.from({ error: run.errors as any }) : undefined),
+    (q) => (run.errors ? q.from({ error: run.errors }) : undefined),
     [run.errors]
   )
 
@@ -687,7 +687,7 @@ export function ObserveView({
     [timelineRows]
   )
   const { data: entityStoppedRows = [] } = useLiveQuery(
-    (q) => q.from({ stopped: db.collections.entityStopped as any }),
+    (q) => q.from({ stopped: db.collections.entityStopped }),
     [db.collections.entityStopped]
   )
   const closed = entityStoppedRows.length > 0

--- a/packages/electric-ax/src/observe-ui.tsx
+++ b/packages/electric-ax/src/observe-ui.tsx
@@ -1,18 +1,17 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Box, Newline, Text, render, useInput } from 'ink'
-import { useLiveQuery } from '@tanstack/react-db'
-import { createOptimisticAction } from '@durable-streams/state/db'
+import { createOptimisticAction, useLiveQuery } from '@tanstack/react-db'
 import {
-  buildSections,
-  createEntityIncludesQuery,
-  normalizeEntityTimelineData,
+  createEntityTimelineQuery,
+  createPendingTimelineOrder,
 } from '@electric-ax/agents-runtime'
 import { entityApiUrl } from './entity-api.js'
 import { createEntityStreamDB } from './entity-stream-db'
 import type {
-  EntityStopped,
   EntityTimelineContentItem,
-  EntityTimelineData,
+  EntityTimelineQueryRow,
+  EntityTimelineRunItem,
+  EntityTimelineRunRow,
   EntityTimelineSection,
   MessageReceived,
 } from '@electric-ax/agents-runtime'
@@ -45,6 +44,221 @@ export function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max - 3) + `...` : s
 }
 
+export function createMessageSendBody(
+  text: string,
+  opts?: { key?: string }
+): { key?: string; payload: { text: string } } {
+  return { ...(opts?.key ? { key: opts.key } : {}), payload: { text } }
+}
+
+const OPTIMISTIC_INBOX_ORDER_START = Number.MAX_SAFE_INTEGER - 1_000_000
+const SEND_TXID_TIMEOUT_MS = 10_000
+
+let optimisticInboxOrderIndex = OPTIMISTIC_INBOX_ORDER_START
+
+function nextOptimisticInboxOrderIndex(): number {
+  optimisticInboxOrderIndex += 1
+  if (optimisticInboxOrderIndex >= Number.MAX_SAFE_INTEGER) {
+    optimisticInboxOrderIndex = OPTIMISTIC_INBOX_ORDER_START
+  }
+  return optimisticInboxOrderIndex
+}
+
+function createOptimisticInboxKey(pendingOrderIndex: number): string {
+  return `optimistic-${Date.now()}-${pendingOrderIndex}`
+}
+
+async function readSendTxid(res: Response): Promise<string> {
+  const data = (await res.json().catch(() => null)) as { txid?: unknown } | null
+  const txid = data?.txid
+  if (typeof txid === `string` || typeof txid === `number`) {
+    return String(txid)
+  }
+  throw new Error(`Send response did not include txid`)
+}
+
+function GutterLine({
+  prefix = `│ `,
+  color,
+  dimColor,
+  children,
+}: {
+  prefix?: string
+  color?: string
+  dimColor?: boolean
+  children: string
+}): React.ReactElement {
+  return (
+    <Box width="100%">
+      <Text color={color} dimColor={dimColor}>
+        {prefix}
+      </Text>
+      <Box flexGrow={1} flexShrink={1}>
+        <Text color={color} dimColor={dimColor} wrap="wrap">
+          {children}
+        </Text>
+      </Box>
+    </Box>
+  )
+}
+
+function payloadText(payload: unknown): string {
+  if (typeof payload === `string`) return payload
+  if (typeof payload === `object` && payload !== null) {
+    const record = payload as Record<string, unknown>
+    return typeof record.text === `string`
+      ? record.text
+      : JSON.stringify(payload)
+  }
+  return String(payload ?? ``)
+}
+
+function resultText(result: unknown): string | undefined {
+  if (result === undefined) return undefined
+  return typeof result === `string` ? result : JSON.stringify(result)
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === `object` && value !== null && !Array.isArray(value)
+}
+
+type TimelineDisplayRow =
+  | { kind: `section`; key: string; section: EntityTimelineSection }
+  | { kind: `run`; key: string; run: EntityTimelineRunRow }
+
+function timelineRowsToDisplayRows(
+  rows: Array<EntityTimelineQueryRow>
+): Array<TimelineDisplayRow> {
+  let userMessageCount = 0
+  return rows.flatMap((row): Array<TimelineDisplayRow> => {
+    if (row.inbox) {
+      const section: EntityTimelineSection = {
+        kind: `user_message`,
+        from: row.inbox.from,
+        text: payloadText(row.inbox.payload),
+        timestamp: Date.parse(row.inbox.timestamp || ``) || Date.now(),
+        isInitial: userMessageCount === 0,
+      }
+      userMessageCount++
+      return [{ kind: `section`, key: row.$key, section }]
+    }
+
+    if (row.wake) {
+      const timestamp = Date.parse(row.wake.payload.timestamp)
+      return [
+        {
+          kind: `section`,
+          key: row.$key,
+          section: {
+            kind: `wake`,
+            payload: row.wake.payload,
+            timestamp: Number.isFinite(timestamp) ? timestamp : Date.now(),
+          },
+        },
+      ]
+    }
+
+    if (row.run) {
+      return [{ kind: `run`, key: row.$key, run: row.run }]
+    }
+
+    if (row.error) {
+      return [
+        {
+          kind: `section`,
+          key: row.$key,
+          section: {
+            kind: `agent_response`,
+            items: [],
+            error: row.error.error_code
+              ? `${row.error.error_code}: ${row.error.message}`
+              : row.error.message,
+          },
+        },
+      ]
+    }
+
+    return []
+  })
+}
+
+function textContent(item: { content?: unknown } | null | undefined): string {
+  return typeof item?.content === `string` ? item.content : ``
+}
+
+function compareTimelineOrderValues(
+  left: string | number,
+  right: string | number
+): number {
+  if (typeof left === `number` && typeof right === `number`) {
+    return left - right
+  }
+  return String(left).localeCompare(String(right))
+}
+
+export function runItemKind(item: EntityTimelineRunItem): `text` | `toolCall` {
+  return item.text ? `text` : `toolCall`
+}
+
+export function runItemKey(item: EntityTimelineRunItem): string {
+  return item.text?.key ?? item.toolCall?.key ?? ``
+}
+
+export function compareRunItems(
+  left: EntityTimelineRunItem,
+  right: EntityTimelineRunItem
+): number {
+  const orderCompare = compareTimelineOrderValues(
+    left.text?.order ?? left.toolCall?.order ?? `~`,
+    right.text?.order ?? right.toolCall?.order ?? `~`
+  )
+  if (orderCompare !== 0) return orderCompare
+
+  const kindCompare = runItemKind(left).localeCompare(runItemKind(right))
+  if (kindCompare !== 0) return kindCompare
+
+  return runItemKey(left).localeCompare(runItemKey(right))
+}
+
+export function runItemsToContentItems(
+  items: Array<EntityTimelineRunItem>
+): Array<EntityTimelineContentItem> {
+  const contentItems: Array<EntityTimelineContentItem> = []
+  for (const item of items) {
+    if (item.text) {
+      const content = textContent(item.text)
+      if (content.trim().length > 0) {
+        contentItems.push({ kind: `text`, text: content })
+      }
+      continue
+    }
+
+    if (!item.toolCall) continue
+    contentItems.push({
+      kind: `tool_call`,
+      toolCallId: item.toolCall.tool_call_id ?? item.toolCall.key,
+      toolName: item.toolCall.tool_name,
+      args: isPlainObject(item.toolCall.args) ? item.toolCall.args : {},
+      status: item.toolCall.status,
+      result: resultText(item.toolCall.result),
+      error: item.toolCall.error,
+      isError: item.toolCall.status === `failed`,
+    })
+  }
+  return contentItems
+}
+
+function runErrorsText(
+  errors: EntityTimelineRunRow[`errors`][`toArray`]
+): string | undefined {
+  const messages = errors
+    .map((error) =>
+      error.error_code ? `${error.error_code}: ${error.message}` : error.message
+    )
+    .filter(Boolean)
+  return messages.length > 0 ? messages.join(`; `) : undefined
+}
+
 // ============================================================================
 // Ink components
 // ============================================================================
@@ -71,9 +285,9 @@ export function UserMessageView({
         {time ? <Text dimColor>{`  ${time}`}</Text> : null}
       </Text>
       {text.split(`\n`).map((line, i) => (
-        <Text key={i} color="white">
-          {`│ ${line}`}
-        </Text>
+        <GutterLine key={i} color="white">
+          {line}
+        </GutterLine>
       ))}
     </Box>
   )
@@ -97,9 +311,9 @@ export function AgentTextView({
         <Text bold color="green">{`┌ ${label ?? `assistant`}`}</Text>
       </Text>
       {lines.map((line, i) => (
-        <Text key={i} color="white">
-          {`│ ${line}${i === lines.length - 1 ? cursor : ``}`}
-        </Text>
+        <GutterLine key={i} color="white">
+          {`${line}${i === lines.length - 1 ? cursor : ``}`}
+        </GutterLine>
       ))}
     </Box>
   )
@@ -158,9 +372,9 @@ export function ToolResultView({
   return (
     <Box flexDirection="column">
       {shown.map((line, i) => (
-        <Text key={i} dimColor>
-          {`    │ ${truncate(line, 100)}`}
-        </Text>
+        <GutterLine key={i} prefix="    │ " dimColor>
+          {truncate(line, 100)}
+        </GutterLine>
       ))}
       {remaining > 0 ? (
         <Text dimColor>{`    │ ... ${remaining} more lines`}</Text>
@@ -193,23 +407,33 @@ export function MessageInput({
 
   const sendAction = useMemo(
     () =>
-      createOptimisticAction<{ text: string }>({
-        onMutate: ({ text }) => {
+      createOptimisticAction<{
+        text: string
+        key: string
+        pendingOrderIndex: number
+      }>({
+        onMutate: ({ text, key, pendingOrderIndex }) => {
+          const now = new Date().toISOString()
           db.collections.inbox.insert({
-            key: `optimistic-${Date.now()}`,
+            key,
+            _timeline_order: createPendingTimelineOrder(pendingOrderIndex),
             from: identity,
+            from_principal: identity,
             payload: { text },
-            timestamp: new Date().toISOString(),
+            timestamp: now,
+            mode: `immediate`,
+            status: `processed`,
+            processed_at: now,
           } as any)
         },
-        mutationFn: async ({ text }) => {
+        mutationFn: async ({ text, key }) => {
           const res = await fetch(entityApiUrl(baseUrl, entityUrl, `/send`), {
             method: `POST`,
             headers: {
               'content-type': `application/json`,
               ...headers,
             },
-            body: JSON.stringify({ from: identity, payload: { text } }),
+            body: JSON.stringify(createMessageSendBody(text, { key })),
           })
           if (!res.ok) {
             const body = await res.text().catch(() => ``)
@@ -232,6 +456,10 @@ export function MessageInput({
             }
             throw new Error(message)
           }
+          await db.utils.awaitTxId(
+            await readSendTxid(res),
+            SEND_TXID_TIMEOUT_MS
+          )
         },
       }),
     [db, baseUrl, entityUrl, identity, headers]
@@ -244,7 +472,12 @@ export function MessageInput({
       if (key.return) {
         if (value.trim()) {
           setError(null)
-          const tx = sendAction({ text: value.trim() })
+          const pendingOrderIndex = nextOptimisticInboxOrderIndex()
+          const tx = sendAction({
+            text: value.trim(),
+            key: createOptimisticInboxKey(pendingOrderIndex),
+            pendingOrderIndex,
+          })
           setValue(``)
           tx.isPersisted.promise.catch((err: Error) => {
             setError(err.message)
@@ -289,7 +522,7 @@ function AgentResponseView({
   isStreaming: boolean
 }): React.ReactElement {
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" width="100%">
       {section.items.map((item, i) => {
         if (item.kind === `text`) {
           return (
@@ -320,6 +553,60 @@ function AgentResponseView({
         </Box>
       ) : null}
     </Box>
+  )
+}
+
+function AgentRunView({
+  run,
+  label,
+  isStreaming,
+}: {
+  run: EntityTimelineRunRow
+  label: string
+  isStreaming: boolean
+}): React.ReactElement {
+  const { data: items = [] } = useLiveQuery(
+    (q) => (run.items ? q.from({ item: run.items }) : undefined),
+    [run.items]
+  )
+  const { data: errors = [] } = useLiveQuery(
+    (q) => (run.errors ? q.from({ error: run.errors }) : undefined),
+    [run.errors]
+  )
+
+  const sortedItems = useMemo(
+    () => [...(items as Array<EntityTimelineRunItem>)].sort(compareRunItems),
+    [items]
+  )
+  const runErrors = useMemo(
+    () => runErrorsText(errors as EntityTimelineRunRow[`errors`][`toArray`]),
+    [errors]
+  )
+  const finishReason =
+    run.status === `failed` && run.finish_reason
+      ? `finish_reason=${run.finish_reason}`
+      : undefined
+  const section = useMemo<
+    Extract<EntityTimelineSection, { kind: `agent_response` }>
+  >(
+    () => ({
+      kind: `agent_response`,
+      items: runItemsToContentItems(sortedItems),
+      ...(run.status === `completed` && { done: true as const }),
+      ...(runErrors || finishReason
+        ? { error: runErrors || finishReason }
+        : {}),
+      ...(run.tokens && { tokens: run.tokens }),
+    }),
+    [finishReason, run.status, run.tokens, runErrors, sortedItems]
+  )
+
+  return (
+    <AgentResponseView
+      section={section}
+      label={label}
+      isStreaming={isStreaming}
+    />
   )
 }
 
@@ -390,70 +677,69 @@ function ObserveView({
   identity: string
   headers?: Record<string, string>
 }): React.ReactElement {
-  const timelineQuery = useMemo(
-    () => createEntityIncludesQuery(db as any),
-    [db]
-  )
-
+  const timelineQuery = useMemo(() => createEntityTimelineQuery(db), [db])
   const { data: timelineRows = [] } = useLiveQuery(timelineQuery as any, [
     timelineQuery,
   ])
-  const timelineData = normalizeEntityTimelineData(
-    (timelineRows as Array<EntityTimelineData>)[0] ?? {
-      runs: [],
-      inbox: [],
-      wakes: [],
-      signals: [],
-      contextInserted: [],
-      contextRemoved: [],
-      entities: [],
-    }
+  const displayRows = useMemo(
+    () =>
+      timelineRowsToDisplayRows(timelineRows as Array<EntityTimelineQueryRow>),
+    [timelineRows]
   )
 
-  const typedRuns = timelineData.runs
-  const typedInbox = timelineData.inbox
-  const typedWakes = timelineData.wakes
-
-  const timeline = useMemo(
-    () => buildSections(typedRuns, typedInbox, typedWakes),
-    [typedRuns, typedInbox, typedWakes]
-  )
-
-  const { data: stopped = [] } = useLiveQuery(
-    (q: any) => q.from({ entityStopped: db.collections.entityStopped as any }),
-    [db]
-  )
-
-  const closed = (stopped as Array<EntityStopped>).length > 0
+  const closed = db.collections.entityStopped.toArray.length > 0
 
   const lastAgentIndex = useMemo(() => {
-    for (let i = timeline.length - 1; i >= 0; i--) {
-      if (timeline[i]!.kind === `agent_response`) return i
+    for (let i = displayRows.length - 1; i >= 0; i--) {
+      const row = displayRows[i]!
+      if (
+        row.kind === `run` ||
+        (row.kind === `section` && row.section.kind === `agent_response`)
+      ) {
+        return i
+      }
     }
     return -1
-  }, [timeline])
+  }, [displayRows])
 
   return (
     <Box flexDirection="column">
-      <Box marginBottom={1}>
+      <Box marginBottom={1} width="100%">
         <Text dimColor>
           {`Observing ${entityUrl}${closed ? `` : ` (Ctrl+C to stop)`}`}
         </Text>
       </Box>
       <Box
+        width="100%"
         borderStyle="single"
         borderColor="gray"
         flexDirection="column"
         paddingX={1}
       >
-        {timeline.length === 0 ? (
+        {displayRows.length === 0 ? (
           <Text dimColor>Waiting for events...</Text>
         ) : null}
-        {timeline.map((section, i) => {
+        {displayRows.map((row, i) => {
+          if (row.kind === `run`) {
+            return (
+              <AgentRunView
+                key={row.key}
+                run={row.run}
+                label={entityUrl}
+                isStreaming={
+                  !closed &&
+                  i === lastAgentIndex &&
+                  row.run.status !== `completed`
+                }
+              />
+            )
+          }
+
+          const { section } = row
           if (section.kind === `user_message`) {
             return (
               <UserMessageView
-                key={`msg-${i}`}
+                key={row.key}
                 msg={{
                   key: `timeline-${i}`,
                   from: section.from ?? `user`,
@@ -465,12 +751,12 @@ function ObserveView({
           }
 
           if (section.kind === `wake`) {
-            return <WakeView key={`wake-${i}`} section={section} />
+            return <WakeView key={row.key} section={section} />
           }
 
           return (
             <AgentResponseView
-              key={`agent-${i}`}
+              key={row.key}
               section={section}
               label={entityUrl}
               isStreaming={!closed && i === lastAgentIndex && !section.done}

--- a/packages/electric-ax/src/start.ts
+++ b/packages/electric-ax/src/start.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { hostname, userInfo } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { BuiltinAgentsServer } from '@electric-ax/agents'
 import { mergeElectricPrincipalHeader } from '@electric-ax/agents/server-headers'
@@ -19,8 +20,8 @@ export { readDotEnvFile, resolveAnthropicApiKey } from './env.js'
 const DEFAULT_ELECTRIC_AGENTS_PORT = 4437
 const DEFAULT_COMPOSE_PROJECT_NAME = `electric-agents`
 const DEFAULT_PULL_WAKE_RUNNER_ID = `builtin-agents`
-const DEFAULT_PULL_WAKE_OWNER_PRINCIPAL = `/principal/system%3Abuiltin-agents`
 const PRINCIPAL_URL_PREFIX = `/principal/`
+const PRINCIPAL_KEY_PREFIXES = new Set([`user`, `agent`, `service`, `system`])
 const DOCKER_COMPOSE_FILE = fileURLToPath(
   new URL(`../docker-compose.full.yml`, import.meta.url)
 )
@@ -121,6 +122,20 @@ function principalUrlFromConfig(value: string): string {
     : `${PRINCIPAL_URL_PREFIX}${encodeURIComponent(value)}`
 }
 
+function principalKeyFromIdentity(identity: string): string {
+  const colon = identity.indexOf(`:`)
+  if (colon > 0 && PRINCIPAL_KEY_PREFIXES.has(identity.slice(0, colon))) {
+    return identity
+  }
+  return `user:${identity}`
+}
+
+function defaultPullWakeOwnerPrincipal(): string {
+  return principalUrlFromConfig(
+    principalKeyFromIdentity(`${userInfo().username}@${hostname()}`)
+  )
+}
+
 export function resolvePullWakeRunnerId(
   env: NodeJS.ProcessEnv = process.env,
   fileEnv: Record<string, string> = readDotEnvFile()
@@ -143,8 +158,9 @@ export function resolvePullWakeOwnerPrincipal(
   const principal = readConfigValue(env, fileEnv, [`ELECTRIC_AGENTS_PRINCIPAL`])
   if (principal) return principalUrlFromConfig(principal)
   const identity = readConfigValue(env, fileEnv, [`ELECTRIC_AGENTS_IDENTITY`])
-  if (identity) return principalUrlFromConfig(identity)
-  return DEFAULT_PULL_WAKE_OWNER_PRINCIPAL
+  if (identity)
+    return principalUrlFromConfig(principalKeyFromIdentity(identity))
+  return defaultPullWakeOwnerPrincipal()
 }
 
 function parseAdditionalServerHeaders(
@@ -186,6 +202,17 @@ function resolveServerHeaders(
   return mergeElectricPrincipalHeader(
     parseAdditionalServerHeaders(env, fileEnv),
     readConfigValue(env, fileEnv, [`ELECTRIC_AGENTS_PRINCIPAL`])
+  )
+}
+
+export function resolveBuiltinServerHeaders(
+  env: NodeJS.ProcessEnv,
+  fileEnv: Record<string, string>,
+  ownerPrincipal: string
+): Record<string, string> | undefined {
+  return mergeHeaders(
+    resolveServerHeaders(env, fileEnv),
+    mergeElectricPrincipalHeader(undefined, ownerPrincipal)
   )
 }
 
@@ -396,7 +423,11 @@ export async function startBuiltinAgentsServer(
   const anthropicApiKey = resolveAnthropicApiKey(options, env, fileEnv)
   const runnerId = resolvePullWakeRunnerId(env, fileEnv)
   const ownerPrincipal = resolvePullWakeOwnerPrincipal(env, fileEnv)
-  const serverHeaders = mergeHeaders(resolveServerHeaders(env, fileEnv))
+  const serverHeaders = resolveBuiltinServerHeaders(
+    env,
+    fileEnv,
+    ownerPrincipal
+  )
   const agentServerUrl =
     params.agentServerUrl ??
     env.ELECTRIC_AGENTS_URL?.trim() ??
@@ -409,6 +440,7 @@ export async function startBuiltinAgentsServer(
     agentServerUrl,
     workingDirectory: cwd,
     loadProjectMcpConfig: true,
+    durableStreamsFetchCache: false,
     pullWake: {
       runnerId,
       ownerPrincipal,

--- a/packages/electric-ax/src/version.ts
+++ b/packages/electric-ax/src/version.ts
@@ -2,14 +2,19 @@
  * Default Docker image tags used by the CLI when launching
  * the dev environment via docker compose.
  *
- * For release builds these remain "latest".
+ * For release builds the agents-server image is pinned to the matching
+ * @electric-ax/agents-server version by the tsdown build.
  * The canary CI overwrites them to "canary" before building.
  */
 const injectedCliVersion: string = `__ELECTRIC_AX_CLI_VERSION__`
+const injectedAgentsServerImageTag: string = `__ELECTRIC_AGENTS_SERVER_IMAGE_TAG__`
 export const ELECTRIC_AX_CLI_VERSION = injectedCliVersion.startsWith(
   `__ELECTRIC_AX_`
 )
   ? `0.0.0`
   : injectedCliVersion
 export const ELECTRIC_IMAGE_TAG = `latest`
-export const ELECTRIC_AGENTS_SERVER_IMAGE_TAG = `latest`
+export const ELECTRIC_AGENTS_SERVER_IMAGE_TAG =
+  injectedAgentsServerImageTag.startsWith(`__ELECTRIC_`)
+    ? `latest`
+    : injectedAgentsServerImageTag

--- a/packages/electric-ax/test/cli.test.ts
+++ b/packages/electric-ax/test/cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { mkdtempSync } from 'node:fs'
-import { tmpdir, userInfo } from 'node:os'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   createElectricCliHandlers,
@@ -132,14 +132,14 @@ async function parse(argv: Array<string>, handlers = createHandlers()) {
 }
 
 describe(`createElectricProgram`, () => {
-  it(`uses system cli username as the default principal header`, () => {
+  it(`uses the CLI identity as the default user principal header`, () => {
     const env = getElectricCliEnv({
       ELECTRIC_AGENTS_URL: `https://agents.example.test`,
       ELECTRIC_AGENTS_IDENTITY: `tester@example.com`,
     })
 
     expect(env.electricAgentsHeaders).toEqual({
-      'electric-principal': `system:cli-${userInfo().username}`,
+      'electric-principal': `user:tester@example.com`,
     })
   })
 

--- a/packages/electric-ax/test/entity-stream-db.test.ts
+++ b/packages/electric-ax/test/entity-stream-db.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const runtimeDb = {
+  preload: vi.fn(),
+  close: vi.fn(),
+}
+const createRuntimeEntityStreamDB = vi.fn(() => runtimeDb)
+
+vi.mock(`@electric-ax/agents-runtime`, () => ({
+  appendPathToUrl: (baseUrl: string, path: string) =>
+    `${baseUrl.replace(/\/$/, ``)}/${path.replace(/^\//, ``)}`,
+  createEntityStreamDB: createRuntimeEntityStreamDB,
+}))
+
+describe(`createEntityStreamDB`, () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it(`uses the agents-runtime StreamDB helper so row timeline ordering matches the UI`, async () => {
+    const fetchMock = vi.spyOn(globalThis, `fetch`).mockResolvedValue(
+      new Response(JSON.stringify({ streams: { main: `/horton/demo/main` } }), {
+        status: 200,
+        headers: { 'content-type': `application/json` },
+      })
+    )
+    runtimeDb.preload.mockResolvedValue(undefined)
+
+    const { createEntityStreamDB } = await import(`../src/entity-stream-db`)
+    const result = await createEntityStreamDB({
+      baseUrl: `http://localhost:4437`,
+      entityUrl: `/horton/demo`,
+      initialOffset: `42`,
+      headers: { 'electric-principal': `user:kyle` },
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `http://localhost:4437/_electric/entities/horton/demo`,
+      {
+        headers: {
+          'content-type': `application/json`,
+          'electric-principal': `user:kyle`,
+        },
+      }
+    )
+    expect(createRuntimeEntityStreamDB).toHaveBeenCalledWith(
+      `http://localhost:4437/horton/demo/main`,
+      undefined,
+      undefined,
+      {
+        streamOptions: {
+          headers: {
+            'content-type': `application/json`,
+            'electric-principal': `user:kyle`,
+          },
+          offset: `42`,
+        },
+      }
+    )
+    expect(runtimeDb.preload).toHaveBeenCalledOnce()
+
+    result.close()
+    expect(runtimeDb.close).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/electric-ax/test/observe-ui.test.tsx
+++ b/packages/electric-ax/test/observe-ui.test.tsx
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render } from 'ink-testing-library'
+import { createCollection, localOnlyCollectionOptions } from '@tanstack/db'
 import {
   AgentTextView,
+  ObserveView,
   ObserveExitHotkey,
   ToolCallView,
   ToolResultView,
@@ -13,9 +15,36 @@ import {
   truncate,
 } from '../src/observe-ui'
 
+const runtimeMocks = vi.hoisted(() => ({
+  timelineRows: undefined as any,
+}))
+
+vi.mock(`@electric-ax/agents-runtime`, async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import(`@electric-ax/agents-runtime`)>()
+  return {
+    ...actual,
+    createEntityTimelineQuery: () => (q: any) =>
+      q.from({ row: runtimeMocks.timelineRows }),
+  }
+})
+
 // ============================================================================
 // Helper functions
 // ============================================================================
+
+function createLocalCollection<TRow extends object>(
+  id: string,
+  getKey: (row: TRow) => string
+): any {
+  return createCollection(
+    localOnlyCollectionOptions({
+      id: `test-${id}-${Math.random().toString(36).slice(2)}`,
+      getKey: getKey as any,
+      initialData: [],
+    })
+  )
+}
 
 describe(`formatTime`, () => {
   it(`returns empty string for undefined`, () => {
@@ -63,6 +92,47 @@ describe(`ObserveExitHotkey`, () => {
     await new Promise<void>((resolve) => setImmediate(resolve))
 
     expect(onExit).toHaveBeenCalledOnce()
+  })
+})
+
+describe(`ObserveView`, () => {
+  it(`rerenders when an entity stopped event arrives without timeline events`, async () => {
+    runtimeMocks.timelineRows = createLocalCollection(
+      `timeline`,
+      (row: Record<string, unknown>) => String(row.$key ?? row.key ?? ``)
+    )
+    const entityStopped = createLocalCollection(
+      `stopped`,
+      (row: Record<string, unknown>) => String(row.key)
+    )
+    const db = {
+      collections: {
+        entityStopped,
+      },
+    } as any
+    const { lastFrame, unmount } = render(
+      <ObserveView
+        db={db}
+        entityUrl="/chat/closed"
+        baseUrl="http://localhost:4437"
+        identity="user"
+      />
+    )
+
+    expect(lastFrame()).toContain(`Waiting for events...`)
+    expect(lastFrame()).not.toContain(`Stream closed`)
+
+    entityStopped.insert({
+      key: `stop-1`,
+      timestamp: new Date().toISOString(),
+      reason: `done`,
+    })
+
+    await expect
+      .poll(() => lastFrame(), { timeout: 1000 })
+      .toContain(`Stream closed`)
+
+    unmount()
   })
 })
 

--- a/packages/electric-ax/test/observe-ui.test.tsx
+++ b/packages/electric-ax/test/observe-ui.test.tsx
@@ -5,6 +5,9 @@ import {
   ObserveExitHotkey,
   ToolCallView,
   ToolResultView,
+  compareRunItems,
+  createMessageSendBody,
+  runItemsToContentItems,
   UserMessageView,
   formatTime,
   truncate,
@@ -60,6 +63,70 @@ describe(`ObserveExitHotkey`, () => {
     await new Promise<void>((resolve) => setImmediate(resolve))
 
     expect(onExit).toHaveBeenCalledOnce()
+  })
+})
+
+describe(`createMessageSendBody`, () => {
+  it(`omits legacy from attribution`, () => {
+    expect(createMessageSendBody(`hello`)).toEqual({
+      payload: { text: `hello` },
+    })
+    expect(createMessageSendBody(`hello`)).not.toHaveProperty(`from`)
+  })
+
+  it(`includes a stable client key when provided`, () => {
+    expect(createMessageSendBody(`hello`, { key: `optimistic-1` })).toEqual({
+      key: `optimistic-1`,
+      payload: { text: `hello` },
+    })
+  })
+})
+
+describe(`run item rendering helpers`, () => {
+  it(`ignores transient missing text content`, () => {
+    expect(
+      runItemsToContentItems([
+        {
+          text: {
+            key: `text-1`,
+            run_id: `run-1`,
+            order: `1`,
+            status: `streaming`,
+            content: undefined,
+          },
+          toolCall: null,
+        } as any,
+      ])
+    ).toEqual([])
+  })
+
+  it(`sorts numeric timeline orders numerically`, () => {
+    const items = [
+      {
+        text: {
+          key: `text-10`,
+          run_id: `run-1`,
+          order: 10,
+          status: `completed`,
+          content: `ten`,
+        },
+        toolCall: null,
+      },
+      {
+        text: {
+          key: `text-2`,
+          run_id: `run-1`,
+          order: 2,
+          status: `completed`,
+          content: `two`,
+        },
+        toolCall: null,
+      },
+    ] as any
+
+    expect(
+      [...items].sort(compareRunItems).map((item) => item.text.key)
+    ).toEqual([`text-2`, `text-10`])
   })
 })
 

--- a/packages/electric-ax/test/observe-ui.test.tsx
+++ b/packages/electric-ax/test/observe-ui.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render } from 'ink-testing-library'
 import { createCollection, localOnlyCollectionOptions } from '@tanstack/db'
+import type { Collection, InitialQueryBuilder } from '@tanstack/db'
 import {
   AgentTextView,
   ObserveView,
@@ -14,9 +15,17 @@ import {
   formatTime,
   truncate,
 } from '../src/observe-ui'
+import type { EntityStreamDB } from '../src/entity-stream-db'
+
+type TimelineTestRow = { key: string }
+type EntityStoppedTestRow = {
+  key: string
+  timestamp: string
+  reason?: string
+}
 
 const runtimeMocks = vi.hoisted(() => ({
-  timelineRows: undefined as any,
+  timelineRows: undefined as Collection<TimelineTestRow, string> | undefined,
 }))
 
 vi.mock(`@electric-ax/agents-runtime`, async (importOriginal) => {
@@ -24,8 +33,8 @@ vi.mock(`@electric-ax/agents-runtime`, async (importOriginal) => {
     await importOriginal<typeof import(`@electric-ax/agents-runtime`)>()
   return {
     ...actual,
-    createEntityTimelineQuery: () => (q: any) =>
-      q.from({ row: runtimeMocks.timelineRows }),
+    createEntityTimelineQuery: () => (q: InitialQueryBuilder) =>
+      q.from({ row: runtimeMocks.timelineRows! }),
   }
 })
 
@@ -36,11 +45,11 @@ vi.mock(`@electric-ax/agents-runtime`, async (importOriginal) => {
 function createLocalCollection<TRow extends object>(
   id: string,
   getKey: (row: TRow) => string
-): any {
+): Collection<TRow, string> {
   return createCollection(
     localOnlyCollectionOptions({
       id: `test-${id}-${Math.random().toString(36).slice(2)}`,
-      getKey: getKey as any,
+      getKey,
       initialData: [],
     })
   )
@@ -99,17 +108,17 @@ describe(`ObserveView`, () => {
   it(`rerenders when an entity stopped event arrives without timeline events`, async () => {
     runtimeMocks.timelineRows = createLocalCollection(
       `timeline`,
-      (row: Record<string, unknown>) => String(row.$key ?? row.key ?? ``)
+      (row: TimelineTestRow) => row.key
     )
-    const entityStopped = createLocalCollection(
+    const entityStopped = createLocalCollection<EntityStoppedTestRow>(
       `stopped`,
-      (row: Record<string, unknown>) => String(row.key)
+      (row) => row.key
     )
     const db = {
       collections: {
         entityStopped,
       },
-    } as any
+    } as unknown as EntityStreamDB
     const { lastFrame, unmount } = render(
       <ObserveView
         db={db}

--- a/packages/electric-ax/test/observe-ui.test.tsx
+++ b/packages/electric-ax/test/observe-ui.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'ink-testing-library'
 import { createCollection, localOnlyCollectionOptions } from '@tanstack/db'
 import type { Collection, InitialQueryBuilder } from '@tanstack/db'
+import type * as AgentsRuntime from '@electric-ax/agents-runtime'
 import {
   AgentTextView,
   ObserveView,
@@ -29,8 +30,7 @@ const runtimeMocks = vi.hoisted(() => ({
 }))
 
 vi.mock(`@electric-ax/agents-runtime`, async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import(`@electric-ax/agents-runtime`)>()
+  const actual = await importOriginal<typeof AgentsRuntime>()
   return {
     ...actual,
     createEntityTimelineQuery: () => (q: InitialQueryBuilder) =>

--- a/packages/electric-ax/test/start.test.ts
+++ b/packages/electric-ax/test/start.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import { readFileSync } from 'node:fs'
+import { hostname, userInfo } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import {
   readDotEnvFile,
   resolveAnthropicApiKey,
+  resolveBuiltinServerHeaders,
   resolveComposeProjectName,
   resolveElectricAgentsPort,
   resolvePullWakeOwnerPrincipal,
@@ -116,16 +118,53 @@ describe(`resolvePullWakeOwnerPrincipal`, () => {
   it(`uses the agents identity when present`, () => {
     expect(
       resolvePullWakeOwnerPrincipal(
+        { ELECTRIC_AGENTS_IDENTITY: `a@example.com` },
+        {}
+      )
+    ).toBe(`/principal/user%3Aa%40example.com`)
+  })
+
+  it(`accepts a principal key as the agents identity`, () => {
+    expect(
+      resolvePullWakeOwnerPrincipal(
         { ELECTRIC_AGENTS_IDENTITY: `user:a@example.com` },
         {}
       )
     ).toBe(`/principal/user%3Aa%40example.com`)
   })
 
-  it(`falls back to the local builtin owner`, () => {
+  it(`falls back to the local CLI user owner`, () => {
     expect(resolvePullWakeOwnerPrincipal({}, {})).toBe(
-      `/principal/system%3Abuiltin-agents`
+      `/principal/${encodeURIComponent(`user:${userInfo().username}@${hostname()}`)}`
     )
+  })
+})
+
+describe(`resolveBuiltinServerHeaders`, () => {
+  it(`authenticates as the resolved default runner owner`, () => {
+    expect(
+      resolveBuiltinServerHeaders({}, {}, `/principal/system%3Abuiltin-agents`)
+    ).toEqual({
+      'electric-principal': `/principal/system%3Abuiltin-agents`,
+    })
+  })
+
+  it(`keeps additional headers while forcing the runner owner principal`, () => {
+    expect(
+      resolveBuiltinServerHeaders(
+        {
+          ELECTRIC_AGENTS_SERVER_HEADERS: JSON.stringify({
+            authorization: `Bearer token`,
+            'electric-principal': `user:wrong`,
+          }),
+        },
+        {},
+        `/principal/service%3Asvc-test`
+      )
+    ).toEqual({
+      authorization: `Bearer token`,
+      'electric-principal': `/principal/service%3Asvc-test`,
+    })
   })
 })
 

--- a/packages/electric-ax/tsdown.config.ts
+++ b/packages/electric-ax/tsdown.config.ts
@@ -1,7 +1,10 @@
 import type { Options } from 'tsdown'
 import { readFileSync } from 'node:fs'
 
-const packageVersion = readPackageVersion()
+const packageVersion = readPackageVersion(`./package.json`)
+const agentsServerPackageVersion = readPackageVersion(
+  `../agents-server/package.json`
+)
 type VersionPlugin = {
   name: string
   transform: (code: string, id: string) => string | null
@@ -21,27 +24,35 @@ const config: Options = {
   platform: `node`,
   dts: true,
   clean: true,
-  plugins: [packageVersionPlugin(packageVersion)],
+  plugins: [packageVersionPlugin(packageVersion, agentsServerPackageVersion)],
   external: [/^@durable-streams\//, /^@electric-ax\//, /^omelette$/],
 }
 
 export default config
 
-function readPackageVersion(): string {
-  const raw = readFileSync(new URL(`./package.json`, import.meta.url), `utf8`)
+function readPackageVersion(packagePath: string): string {
+  const raw = readFileSync(new URL(packagePath, import.meta.url), `utf8`)
   const parsed = JSON.parse(raw) as { version?: unknown }
   if (typeof parsed.version !== `string` || !parsed.version.trim()) {
-    throw new Error(`packages/electric-ax/package.json is missing a version`)
+    throw new Error(`${packagePath} is missing a version`)
   }
   return parsed.version.trim()
 }
 
-function packageVersionPlugin(version: string): VersionPlugin {
+function packageVersionPlugin(
+  version: string,
+  agentsServerImageTag: string
+): VersionPlugin {
   return {
     name: `electric-ax-package-version`,
     transform(code: string, id: string) {
       if (!id.endsWith(`/src/version.ts`)) return null
-      return code.replaceAll(`__ELECTRIC_AX_CLI_VERSION__`, version)
+      return code
+        .replaceAll(`__ELECTRIC_AX_CLI_VERSION__`, version)
+        .replaceAll(
+          `__ELECTRIC_AGENTS_SERVER_IMAGE_TAG__`,
+          agentsServerImageTag
+        )
     },
   }
 }

--- a/packages/electric-ax/tsdown.desktop.config.ts
+++ b/packages/electric-ax/tsdown.desktop.config.ts
@@ -1,7 +1,10 @@
 import type { Options } from 'tsdown'
 import { readFileSync } from 'node:fs'
 
-const packageVersion = readPackageVersion()
+const packageVersion = readPackageVersion(`./package.json`)
+const agentsServerPackageVersion = readPackageVersion(
+  `../agents-server/package.json`
+)
 type VersionPlugin = {
   name: string
   transform: (code: string, id: string) => string | null
@@ -21,7 +24,7 @@ const config: Options = {
   dts: false,
   clean: true,
   outDir: `dist-desktop`,
-  plugins: [packageVersionPlugin(packageVersion)],
+  plugins: [packageVersionPlugin(packageVersion, agentsServerPackageVersion)],
   noExternal: [
     /^@durable-streams\//,
     /^@electric-ax\//,
@@ -37,21 +40,29 @@ const config: Options = {
 
 export default config
 
-function readPackageVersion(): string {
-  const raw = readFileSync(new URL(`./package.json`, import.meta.url), `utf8`)
+function readPackageVersion(packagePath: string): string {
+  const raw = readFileSync(new URL(packagePath, import.meta.url), `utf8`)
   const parsed = JSON.parse(raw) as { version?: unknown }
   if (typeof parsed.version !== `string` || !parsed.version.trim()) {
-    throw new Error(`packages/electric-ax/package.json is missing a version`)
+    throw new Error(`${packagePath} is missing a version`)
   }
   return parsed.version.trim()
 }
 
-function packageVersionPlugin(version: string): VersionPlugin {
+function packageVersionPlugin(
+  version: string,
+  agentsServerImageTag: string
+): VersionPlugin {
   return {
     name: `electric-ax-package-version`,
     transform(code: string, id: string) {
       if (!id.endsWith(`/src/version.ts`)) return null
-      return code.replaceAll(`__ELECTRIC_AX_CLI_VERSION__`, version)
+      return code
+        .replaceAll(`__ELECTRIC_AX_CLI_VERSION__`, version)
+        .replaceAll(
+          `__ELECTRIC_AGENTS_SERVER_IMAGE_TAG__`,
+          agentsServerImageTag
+        )
     },
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2161,7 +2161,7 @@ importers:
         version: 0.2.6
       '@durable-streams/state':
         specifier: ^0.3.1
-        version: 0.3.1(@tanstack/db@0.6.7(typescript@5.8.3))
+        version: 0.3.1(@tanstack/db@0.6.7(typescript@5.9.3))
       '@electric-ax/agents':
         specifier: workspace:*
         version: link:../agents
@@ -2172,11 +2172,11 @@ importers:
         specifier: ^1.5.21
         version: link:../typescript-client
       '@tanstack/db':
-        specifier: ^0.6.4
-        version: 0.6.7(typescript@5.8.3)
+        specifier: ^0.6.6
+        version: 0.6.7(typescript@5.9.3)
       '@tanstack/react-db':
         specifier: ^0.1.85
-        version: 0.1.85(react@19.2.0)(typescript@5.8.3)
+        version: 0.1.85(react@19.2.0)(typescript@5.9.3)
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -2207,13 +2207,13 @@ importers:
         version: 4.0.0(@types/react@19.2.14)
       tsdown:
         specifier: ^0.9.0
-        version: 0.9.9(typescript@5.8.3)
+        version: 0.9.9(typescript@5.9.3)
       tsx:
         specifier: ^4.19.2
         version: 4.20.3
       typescript:
-        specifier: ^5.7.2
-        version: 5.8.3
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^4.1.0
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -31334,14 +31334,6 @@ snapshots:
   '@tanstack/react-db@0.1.85(react@19.2.0)(typescript@5.7.2)':
     dependencies:
       '@tanstack/db': 0.6.7(typescript@5.7.2)
-      react: 19.2.0
-      use-sync-external-store: 1.6.0(react@19.2.0)
-    transitivePeerDependencies:
-      - typescript
-
-  '@tanstack/react-db@0.1.85(react@19.2.0)(typescript@5.8.3)':
-    dependencies:
-      '@tanstack/db': 0.6.7(typescript@5.8.3)
       react: 19.2.0
       use-sync-external-store: 1.6.0(react@19.2.0)
     transitivePeerDependencies:


### PR DESCRIPTION
## Executive Summary

Fixes the Electric Agents quickstart path so the printed CLI commands can spawn, route, send to, and observe Horton entities without extra principal or dispatch-policy setup. It also prevents newly-started agent runs from being left in `started` when a wake handler errors before ending them. The user-visible result is that `electric agents quickstart` creates a usable local runner-backed environment, `electric agents observe` uses the same shared timeline live query as the other UIs, interactive terminal sends remain visible while they reconcile with the entity stream, and runtime failures no longer leave the chat UI stuck on "Thinking" for that failure path.

## Root Cause

There were several related quickstart gaps:

- The built-in runner registered with one principal while the CLI used another, so entity type management, runner ownership checks, and default user permissions did not line up.
- Built-in Horton/Worker type registration intentionally omitted a default dispatch policy, so `electric agents spawn /horton/onboarding` could create an entity that no pull-wake runner would claim.
- The CLI-launched built-in runtime installed the optional global Undici fetch cache; in local quickstart this could surface as opaque fetch failures such as `invalid onError method` during type registration.
- `electric agents observe` and the shared UI timeline query were resolving different `@tanstack/db` package instances. TanStack validates live-query sources with package-local `CollectionImpl` identity, so valid StreamDB collections were rejected as non-collections.
- The shared live timeline query concatenated streamed text deltas by row key rather than stream sequence. Once a response reached `msg-0:10`, lexicographic ordering placed that chunk before `msg-0:2`, which only surfaced in consumers reading the live query path.
- Live run item ordering mixed text row creation order with tool-call timeline order. A text row can be created before its first delta arrives, so text could render before an earlier tool call.
- Interactive `observe` sends posted successfully but did not await the returned stream `txid` or send a stable client key, so the optimistic inbox row could disappear before the real stream event reconciled.
- The CLI entity stream helper constructed a bare StreamDB instead of using the agents-runtime `createEntityStreamDB` wrapper used by the web UI. That skipped runtime row-offset materialization (`_timeline_order`), so the shared timeline query fell back to source tie-breakers and grouped inbox rows ahead of run rows.
- Published CLI builds floated `electricax/agents-server:latest`, so a released CLI could start a server image with mismatched runtime contracts.
- A wake handler could create a run row with `status: started` and then throw before the run was ended. The existing handler failure path wrote an error event, but did not terminally update that run, so the UI continued to treat it as the latest streaming response.

## Approach

- Make quickstart resolve one runner owner principal and force that same principal into the built-in runtime's server headers.
- Default the CLI principal to `user:<ELECTRIC_AGENTS_IDENTITY>` so the no-env quickstart commands match the built-in `principal_kind=user` grants.
- Register built-in Horton/Worker types with the local pull-wake runner as their default dispatch target.
- Disable the optional global Durable Streams fetch cache only for the CLI-managed built-in runtime.
- Align `electric-ax` with the same TypeScript/TanStack DB peer set as `agents-runtime`, so both packages resolve the same `@tanstack/db` instance.
- Restore CLI `observe` to `createEntityTimelineQuery(db)` plus `useLiveQuery`, then adapt the shared query rows into the existing Ink terminal sections.
- Order text/reasoning deltas by `_seq` in the shared live query, matching the materialized timeline view.
- Order live run child items in one sequence domain: tool calls by `_seq`, text items by first text-delta `_seq` with text-row `_seq` as fallback.
- Keep interactive observe sends optimistic until the returned `txid` is observed, using a stable client key and pending timeline order so the optimistic row and synced inbox row reconcile.
- Make the CLI entity stream helper delegate to the agents-runtime StreamDB helper, matching the web UI stream setup and preserving `_timeline_order` for shared timeline row ordering.
- Add shared timeline indexes for joined collections so the live query path is warning-free in both CLI and UI consumers.
- Inject the matching `@electric-ax/agents-server` package version into the CLI Docker image tag at build time, and make `ci:publish` rebuild packages after Changesets updates versions.
- Add endpoint/cause context around entity type and runner registration fetch failures.
- Track run status events produced during a wake and, on handler failure, mark the latest new still-started run as failed before writing the error event. The failure path only selects DB-visible runs whose status is still `started`, with a produced-event fallback for runs that were emitted but not yet visible through the local collection.
- Clarify browser-only credentials settings copy so it points at the connected runtime, not editable browser-side provider keys.

## Key Invariants

- The runner registration principal, runner owner, runner claim headers, and CLI default principal must agree for the local quickstart path.
- Built-in agent types must have a runner default dispatch policy when they are registered by a pull-wake built-in runtime.
- `ELECTRIC_AGENTS_PRINCIPAL` remains the explicit override for non-default deployments.
- `electric-ax`, `agents-runtime`, and UI consumers must resolve a single TanStack DB module instance for shared live-query collection identity checks.
- CLI and desktop/web timeline consumers should share `createEntityTimelineQuery(db)`; only the rendering adapter should differ.
- Live streamed deltas must be ordered by stream sequence, not by human-readable event keys.
- Live run child items must be ordered by model event sequence, not by when a text container row was created.
- Terminal optimistic sends must use a stable key and await stream reconciliation before dropping optimistic state.
- CLI and web UI StreamDB setup must share the runtime helper so row offsets and `_timeline_order` are materialized consistently.
- Released `electric-ax` builds should start an agents-server image matching the release version unless explicitly overridden.
- Handler failure cleanup must only fail runs that are still `started`; a completed run must not be regressed to failed if later cleanup throws.

## Non-goals

- This does not make provider keys editable from the browser UI.
- This does not alter runner ownership authorization rules on the server; quickstart now supplies matching principals instead.
- This does not mask model provider failures.
- This does not make the terminal observer render every rich desktop-only timeline row. It maps the shared query output into the existing terminal sections.
- This does not implement abandoned-run recovery for hard process death, laptop sleep, or restart cases where no in-process catch/finally can run. That second layer is tracked in #4633.

## Trade-offs

The CLI observer now shares the same timeline query as the desktop/web UIs, which keeps query semantics in one place and prevents the terminal observer from drifting. The terminal still has a small adapter because its Ink renderer expects simpler records than the desktop timeline component.

The timeline query now creates a few `BasicIndex` indexes before building joins. That is a small setup cost per StreamDB instance, but it avoids repeated TanStack warnings and keeps the shared query suitable for CLI and UI use.

The Docker image pin is injected at build time rather than hard-coded because Changesets owns release version updates. Rebuilding during `ci:publish` ensures the generated artifacts see the bumped package versions.

## Verification

```sh
pnpm --filter @electric-ax/agents-runtime build
pnpm --filter electric-ax build
pnpm --filter @electric-ax/agents-runtime exec vitest run test/entity-timeline.test.ts
pnpm --filter electric-ax test -- entity-stream-db.test.ts observe-ui.test.tsx
pnpm --filter electric-ax test -- observe-ui.test.tsx cli.test.ts start.test.ts
pnpm --filter @electric-ax/agents-server-ui typecheck
pnpm --filter @electric-ax/agents exec vitest run test/builtin-pull-wake-registration.test.ts
pnpm --filter @electric-ax/agents-runtime exec vitest run test/process-wake.test.ts --reporter=dot
```

Manual isolated quickstart verification:

```sh
cd /tmp
ELECTRIC_AGENTS_COMPOSE_PROJECT=electric-agents-verify \
ELECTRIC_AGENTS_PORT=4448 \
node /Users/kylemathews/programs/electric/packages/electric-ax/dist/index.js agents quickstart
```

In a second terminal:

```sh
ELECTRIC_AGENTS_URL=http://localhost:4448 \
node /Users/kylemathews/programs/electric/packages/electric-ax/dist/index.js agents types

ELECTRIC_AGENTS_URL=http://localhost:4448 \
node /Users/kylemathews/programs/electric/packages/electric-ax/dist/index.js agents spawn /horton/onboarding

ELECTRIC_AGENTS_URL=http://localhost:4448 \
node /Users/kylemathews/programs/electric/packages/electric-ax/dist/index.js agents inspect /horton/onboarding

ELECTRIC_AGENTS_URL=http://localhost:4448 \
node /Users/kylemathews/programs/electric/packages/electric-ax/dist/index.js agents send /horton/onboarding "Onboard me to Electric Agents"

ELECTRIC_AGENTS_URL=http://localhost:4448 \
node /Users/kylemathews/programs/electric/packages/electric-ax/dist/index.js agents observe /horton/onboarding
```

Observed results:

- Horton and Worker type registration succeeded.
- Pull-wake runner `builtin-agents` started.
- `agents types` listed built-ins without a manual principal override.
- `agents spawn /horton/onboarding` succeeded.
- `agents inspect /horton/onboarding` showed `dispatch_policy.targets[0].runnerId = builtin-agents`.
- `agents send /horton/onboarding "Onboard me to Electric Agents"` was picked up by the runner.
- `agents observe /horton/onboarding` rendered the timeline through the shared live query instead of throwing `Invalid source for live query`, with no TanStack join-index warning.
- The terminal observer rendered the full streamed Horton response after `_seq` ordering replaced key ordering for live deltas.
- Tool calls now remain before later text when the text row was created before its first delta.

## Files Changed

- `.changeset/quickstart-runner-principal.md`: patch release note for affected packages.
- `.changeset/fail-started-agent-runs.md`: patch release note for the started-run handler failure fix.
- `package.json`: rebuild packages before publish/tag so injected version constants are current after Changesets versioning.
- `packages/agents-runtime/src/create-handler.ts`: include registration endpoint and fetch cause in entity type registration failures.
- `packages/agents-runtime/src/process-wake.ts`, `packages/agents-runtime/test/process-wake.test.ts`: fail newly-started runs when handler errors escape before run completion, without regressing already-completed runs.
- `packages/agents-runtime/src/entity-timeline.ts`: create shared timeline join indexes, keep CLI/UI consumers on the same live query, and order live deltas by stream sequence.
- `packages/agents-runtime/test/create-handler.test.ts`, `packages/agents-runtime/test/entity-timeline.test.ts`: regression coverage for fetch detail, live delta ordering, top-level live timeline row interleaving, and live run child item ordering.
- `packages/agents/src/server.ts`, `packages/agents/test/builtin-pull-wake-registration.test.ts`: default built-in type dispatch to the local runner and cover it.
- `packages/electric-ax/package.json`, `pnpm-lock.yaml`: align `electric-ax` with the same TanStack DB/TypeScript peer instance as `agents-runtime`.
- `packages/electric-ax/src/start.ts`, `packages/electric-ax/src/index.ts`: align quickstart runner owner/server headers and default CLI principal behavior.
- `packages/electric-ax/src/entity-stream-db.ts`, `packages/electric-ax/test/entity-stream-db.test.ts`: delegate CLI stream setup to the agents-runtime helper so timeline ordering matches the web UI.
- `packages/electric-ax/src/observe-ui.tsx`, `packages/electric-ax/test/observe-ui.test.tsx`: render observe from the shared live query, fix terminal wrapping, send interactive messages with stable optimistic keys, and await send txids.
- `packages/electric-ax/src/version.ts`, `packages/electric-ax/tsdown*.config.ts`: inject the matching agents-server Docker image tag into release builds.
- `packages/electric-ax/test/cli.test.ts`, `packages/electric-ax/test/start.test.ts`: coverage for principal/default header behavior.
- `packages/agents-server-ui/src/components/settings/pages/CredentialsPage.tsx`: clarify browser-only provider credentials copy.



