### PR TITLE
fix(agents): use Anthropic adaptive thinking for Opus 4.6+/4.7 & Sonnet 4.6

### DIFF
--- a/.changeset/anthropic-adaptive-thinking.md
+++ b/.changeset/anthropic-adaptive-thinking.md
@@ -1,0 +1,11 @@
+---
+'@electric-ax/agents': patch
+---
+
+Use Anthropic's adaptive thinking API for models that require it (Opus 4.6/4.7,
+Sonnet 4.6). The builtin model catalog previously injected budget-based
+`thinking: { type: "enabled", budget_tokens }` for every reasoning-capable
+Anthropic model, which Opus 4.7 rejects with a 400 — it needs
+`thinking: { type: "adaptive" }` + `output_config.effort`. Those models now emit
+the adaptive shape (reasoningEffort mapped to the effort level); older models
+keep budget-based thinking.

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -260,6 +260,26 @@ const ANTHROPIC_THINKING_BUDGET_BY_EFFORT: Record<
   high: 24576,
 }
 
+/**
+ * Opus 4.6+/4.7 and Sonnet 4.6 use Anthropic's adaptive thinking API
+ * (`thinking.type: "adaptive"` + `output_config.effort`); the older budget-based
+ * `thinking.type: "enabled"` is rejected on Opus 4.7.
+ */
+function isAdaptiveThinkingModel(modelId: string): boolean {
+  return /(opus-4[-.]6|opus-4[-.]7|sonnet-4[-.]6)/.test(modelId)
+}
+
+/** `reasoningEffort` → Anthropic adaptive `output_config.effort` level. */
+const ANTHROPIC_ADAPTIVE_EFFORT_BY_REASONING: Record<
+  ExplicitReasoningEffort,
+  string
+> = {
+  minimal: `low`,
+  low: `low`,
+  medium: `medium`,
+  high: `high`,
+}
+
 function withProviderPayloadDefaults(
   config: PersistedModelConfig & { getApiKey?: AgentConfig[`getApiKey`] },
   choice: BuiltinModelChoice,
@@ -296,33 +316,52 @@ function withProviderPayloadDefaults(
   }
 
   if (choice.provider === `anthropic`) {
-    // `auto` maps to the minimal budget so extended thinking is always
-    // on for reasoning-capable Anthropic models, matching the OpenAI
-    // branch above (where `auto` falls through to a `minimal` default).
+    // `auto` falls through to a `minimal` default, matching the OpenAI branch.
     const effectiveEffort = reasoningEffort ?? `minimal`
-    const budgetTokens = ANTHROPIC_THINKING_BUDGET_BY_EFFORT[effectiveEffort]
+    // pi-ai writes `thinking: { type: "disabled" }` by default; we merge our
+    // enabled values last so they win.
+    const mergeThinking = (
+      body: Record<string, unknown>,
+      thinking: Record<string, unknown>,
+      extra?: Record<string, unknown>
+    ): Record<string, unknown> => {
+      const existing =
+        typeof body.thinking === `object` && body.thinking !== null
+          ? (body.thinking as Record<string, unknown>)
+          : {}
+      return { ...body, ...extra, thinking: { ...existing, ...thinking } }
+    }
 
+    if (isAdaptiveThinkingModel(String(config.model))) {
+      const effort = ANTHROPIC_ADAPTIVE_EFFORT_BY_REASONING[effectiveEffort]
+      return {
+        ...config,
+        onPayload: (payload) => {
+          if (typeof payload !== `object` || payload === null) return undefined
+          const body = payload as Record<string, unknown>
+          const existingOutputConfig =
+            typeof body.output_config === `object` &&
+            body.output_config !== null
+              ? (body.output_config as Record<string, unknown>)
+              : {}
+          return mergeThinking(
+            body,
+            { type: `adaptive` },
+            { output_config: { ...existingOutputConfig, effort } }
+          )
+        },
+      }
+    }
+
+    const budgetTokens = ANTHROPIC_THINKING_BUDGET_BY_EFFORT[effectiveEffort]
     return {
       ...config,
       onPayload: (payload) => {
         if (typeof payload !== `object` || payload === null) return undefined
-        const body = payload as Record<string, unknown>
-        // pi-ai writes `thinking: { type: "disabled" }` into the payload
-        // by default. Merge our enabled-thinking values last so they win
-        // — otherwise the API rejects `budget_tokens` for a disabled
-        // `thinking` block.
-        const existingThinking =
-          typeof body.thinking === `object` && body.thinking !== null
-            ? (body.thinking as Record<string, unknown>)
-            : {}
-        return {
-          ...body,
-          thinking: {
-            ...existingThinking,
-            type: `enabled`,
-            budget_tokens: budgetTokens,
-          },
-        }
+        return mergeThinking(payload as Record<string, unknown>, {
+          type: `enabled`,
+          budget_tokens: budgetTokens,
+        })
       },
     }
   }

--- a/packages/agents/test/model-catalog.test.ts
+++ b/packages/agents/test/model-catalog.test.ts
@@ -149,7 +149,7 @@ describe(`model catalog`, () => {
     })
   })
 
-  it(`enables Anthropic extended thinking with a minimal budget when reasoningEffort is auto`, async () => {
+  it(`enables Anthropic adaptive thinking at low effort when reasoningEffort is auto`, async () => {
     process.env.ANTHROPIC_API_KEY = `test-anthropic-key`
     vi.stubGlobal(
       `fetch`,
@@ -172,7 +172,8 @@ describe(`model catalog`, () => {
 
     expect(config.onPayload).toBeTypeOf(`function`)
     expect(config.onPayload!({}, {} as any)).toEqual({
-      thinking: { type: `enabled`, budget_tokens: 1024 },
+      thinking: { type: `adaptive` },
+      output_config: { effort: `low` },
     })
   })
 
@@ -200,11 +201,12 @@ describe(`model catalog`, () => {
     expect(
       config.onPayload!({ thinking: { type: `disabled` } }, {} as any)
     ).toEqual({
-      thinking: { type: `enabled`, budget_tokens: 1024 },
+      thinking: { type: `adaptive` },
+      output_config: { effort: `low` },
     })
   })
 
-  it(`scales Anthropic thinking budget with explicit reasoningEffort`, async () => {
+  it(`maps explicit reasoningEffort to the Anthropic adaptive effort level`, async () => {
     process.env.ANTHROPIC_API_KEY = `test-anthropic-key`
     vi.stubGlobal(
       `fetch`,
@@ -227,7 +229,8 @@ describe(`model catalog`, () => {
     })
 
     expect(config.onPayload!({}, {} as any)).toEqual({
-      thinking: { type: `enabled`, budget_tokens: 24576 },
+      thinking: { type: `adaptive` },
+      output_config: { effort: `high` },
     })
   })
 


### PR DESCRIPTION
## Problem

Turns on **`claude-opus-4-7`** crash with:

```
400 invalid_request_error — "thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

The builtin model catalog's Anthropic `onPayload` injects budget-based `thinking: { type: "enabled", budget_tokens }` for **every** reasoning-capable Anthropic model. Opus 4.7 rejects that — it (like Opus 4.6 / Sonnet 4.6) requires Anthropic's **adaptive** thinking API: `thinking: { type: "adaptive" }` + `output_config.effort`.

## Fix

In `model-catalog.ts`, branch the Anthropic thinking injection by model:

- **Adaptive-thinking models** (Opus 4.6/4.7, Sonnet 4.6) → emit `thinking: { type: "adaptive" }` + `output_config: { effort }`, mapping `reasoningEffort` → effort (`minimal`/`low` → `low`, `medium` → `medium`, `high` → `high`). This mirrors pi-ai's own `supportsAdaptiveThinking` gating.
- **Older models** → keep budget-based `thinking: { type: "enabled", budget_tokens }`.

## Testing

- `model-catalog.test.ts` updated (its `claude-sonnet-4-6` model is adaptive) to assert the adaptive payload; all 18 pass.
- `tsc --noEmit` clean for `@electric-ax/agents`.
- Verified live in the desktop app: Opus 4.7 turns now succeed.

Changeset included (`@electric-ax/agents`: patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)