### PR TITLE
Fix batched child completion wakes

### DIFF
--- a/.changeset/batch-child-completion-wakes.md
+++ b/.changeset/batch-child-completion-wakes.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-runtime': patch
+---
+
+Batch queued child completion wakes into a single wake payload so parent agents receive every child result without extra handler runs.

--- a/packages/agents-runtime/src/process-wake.ts
+++ b/packages/agents-runtime/src/process-wake.ts
@@ -367,10 +367,9 @@ function combineWakeEvents(
   }
 }
 
-function selectWakeFromEvents(
+function selectNextInboxWakeFromEvents(
   events: Array<ChangeEvent>,
-  fallbackSource: string,
-  preferredKind?: FreshKind
+  fallbackSource: string
 ): { wakeEvent: WakeEvent; offset: string | null } | null {
   const cancelledInboxKeys = new Set<string>()
   for (let i = events.length - 1; i >= 0; i--) {
@@ -382,12 +381,7 @@ function selectWakeFromEvents(
     if (isInboxEvent(event) && cancelledInboxKeys.has(inboxEventKey(event))) {
       continue
     }
-    const eventKind = isInboxEvent(event)
-      ? `inbox`
-      : event.type === `wake`
-        ? `wake`
-        : null
-    if (preferredKind && eventKind !== preferredKind) {
+    if (!isInboxEvent(event)) {
       continue
     }
 
@@ -1055,12 +1049,10 @@ export async function processWake(
       const changeEvents = toChangeEvents(batch)
       const freshKind = getFreshKind(changeEvents)
 
-      // Keep wake-only work together, but let a later inbox message start its own
-      // handler pass so message-triggered runs are not hidden behind older wakes.
-      if (selectedKind === `wake` && freshKind === `inbox`) {
-        break
-      }
-
+      // If an inbox message arrives while wake rows are pending, consume the
+      // wake rows alongside the inbox pass. The inbox is the runnable trigger,
+      // but the handler still needs the sibling child-completion wakes in
+      // ctx.events so no child result is silently acked without being visible.
       pendingLiveBatches.shift()
       batches.push(batch)
       deltaEvents.push(...changeEvents)
@@ -1085,7 +1077,9 @@ export async function processWake(
     const selectedWake =
       selectedKind === `wake`
         ? combineWakeEvents(deltaEvents, entityUrl)
-        : selectWakeFromEvents(deltaEvents, entityUrl, selectedKind)
+        : selectedKind === `inbox`
+          ? selectNextInboxWakeFromEvents(deltaEvents, entityUrl)
+          : null
     if (!selectedWake) {
       log.warn(
         `fresh ${selectedKind} batch did not contain runnable wake input; acking as no-op`
@@ -1650,12 +1644,21 @@ export async function processWake(
       eventsAtOrAfterNotification,
       forkReconciliationOffset
     )
+    const initialFreshKind = getFreshKind(actionableEventsAtOrAfterNotification)
     const initialFromCatchUp = notification.wakeEvent
       ? null
-      : selectWakeFromEvents(actionableEventsAtOrAfterNotification, entityUrl)
+      : initialFreshKind === `wake`
+        ? combineWakeEvents(actionableEventsAtOrAfterNotification, entityUrl)
+        : initialFreshKind === `inbox`
+          ? selectNextInboxWakeFromEvents(
+              actionableEventsAtOrAfterNotification,
+              entityUrl
+            )
+          : null
     if (initialFromCatchUp) {
       currentWakeEvent = initialFromCatchUp.wakeEvent
       currentWakeOffset = initialFromCatchUp.offset ?? notificationOffset
+      currentWakeEvents = actionableEventsAtOrAfterNotification
     } else {
       currentWakeEvent = constructWakeEvent(notification)
       currentWakeOffset = notificationOffset
@@ -2009,12 +2012,16 @@ export async function processWake(
 
     if (!skipInitialHandlerPass) {
       await waitForCurrentWakeInput()
-      currentWakeEvents = computeCurrentNotificationEvents()
+      if (currentWakeEvents.length === 0) {
+        currentWakeEvents = computeCurrentNotificationEvents()
+      }
       const initialFreshKind = getFreshKind(currentWakeEvents) ?? undefined
       const initialWake =
         initialFreshKind === `wake`
           ? combineWakeEvents(currentWakeEvents, entityUrl)
-          : selectWakeFromEvents(currentWakeEvents, entityUrl, initialFreshKind)
+          : initialFreshKind === `inbox`
+            ? selectNextInboxWakeFromEvents(currentWakeEvents, entityUrl)
+            : null
       if (initialWake) {
         currentWakeEvent = initialWake.wakeEvent
         currentWakeOffset = initialWake.offset ?? currentWakeOffset

--- a/packages/agents-runtime/src/process-wake.ts
+++ b/packages/agents-runtime/src/process-wake.ts
@@ -330,6 +330,43 @@ function changeEventToWakeEvent(
   return null
 }
 
+function combineWakeEvents(
+  events: Array<ChangeEvent>,
+  fallbackSource: string
+): { wakeEvent: WakeEvent; offset: string | null } | null {
+  const wakeEvents = events.filter((event) => event.type === `wake`)
+  if (wakeEvents.length === 0) return null
+  if (wakeEvents.length === 1) {
+    const event = wakeEvents[0]!
+    const wakeEvent = changeEventToWakeEvent(event, fallbackSource)
+    return wakeEvent
+      ? { wakeEvent, offset: event.headers.offset ?? null }
+      : null
+  }
+
+  const messages = wakeEvents
+    .map((event) => event.value as WakeMessage | undefined)
+    .filter((message): message is WakeMessage => message !== undefined)
+  const sources = [...new Set(messages.map((message) => message.source))]
+
+  return {
+    wakeEvent: {
+      source: sources.length === 1 ? sources[0]! : fallbackSource,
+      type: `wake`,
+      fromOffset: 0,
+      toOffset: 0,
+      eventCount: wakeEvents.length,
+      payload: {
+        type: `wake_batch`,
+        sources,
+        wakes: messages,
+        changes: messages.flatMap((message) => message.changes ?? []),
+      },
+    },
+    offset: wakeEvents.at(-1)!.headers.offset ?? null,
+  }
+}
+
 function selectWakeFromEvents(
   events: Array<ChangeEvent>,
   fallbackSource: string,
@@ -1045,11 +1082,10 @@ export async function processWake(
       return null
     }
 
-    const selectedWake = selectWakeFromEvents(
-      deltaEvents,
-      entityUrl,
-      selectedKind
-    )
+    const selectedWake =
+      selectedKind === `wake`
+        ? combineWakeEvents(deltaEvents, entityUrl)
+        : selectWakeFromEvents(deltaEvents, entityUrl, selectedKind)
     if (!selectedWake) {
       log.warn(
         `fresh ${selectedKind} batch did not contain runnable wake input; acking as no-op`
@@ -1974,11 +2010,11 @@ export async function processWake(
     if (!skipInitialHandlerPass) {
       await waitForCurrentWakeInput()
       currentWakeEvents = computeCurrentNotificationEvents()
-      const initialWake = selectWakeFromEvents(
-        currentWakeEvents,
-        entityUrl,
-        getFreshKind(currentWakeEvents) ?? undefined
-      )
+      const initialFreshKind = getFreshKind(currentWakeEvents) ?? undefined
+      const initialWake =
+        initialFreshKind === `wake`
+          ? combineWakeEvents(currentWakeEvents, entityUrl)
+          : selectWakeFromEvents(currentWakeEvents, entityUrl, initialFreshKind)
       if (initialWake) {
         currentWakeEvent = initialWake.wakeEvent
         currentWakeOffset = initialWake.offset ?? currentWakeOffset

--- a/packages/agents-runtime/test/process-wake.test.ts
+++ b/packages/agents-runtime/test/process-wake.test.ts
@@ -2062,6 +2062,84 @@ describe(`processWake`, () => {
     ])
   })
 
+  it(`combines multiple pending wake events into one handler wake`, async () => {
+    const wakePayloads: Array<unknown> = []
+    defineEntity(`test-agent`, {
+      handler: (_ctx, wake) => {
+        wakePayloads.push(wake.payload)
+      },
+    })
+
+    setTimeout(() => {
+      mockEntityOnBatch.current?.({
+        items: [
+          ev(
+            `wake`,
+            `wake-1`,
+            `insert`,
+            {
+              source: `/child/1`,
+              changes: [{ collection: `runs`, kind: `update`, key: `run-1` }],
+            },
+            { offset: `1_0` }
+          ),
+          ev(
+            `wake`,
+            `wake-2`,
+            `insert`,
+            {
+              source: `/child/2`,
+              changes: [{ collection: `runs`, kind: `update`, key: `run-2` }],
+            },
+            { offset: `2_0` }
+          ),
+        ],
+        offset: `2_0`,
+      })
+    }, 50)
+
+    await processWake(makeNotification({ triggerEvent: `inbox` }), {
+      ...BASE_CONFIG,
+      idleTimeout: 300,
+    })
+
+    expect(wakePayloads).toEqual([
+      {
+        type: `wake_batch`,
+        sources: [`/child/1`, `/child/2`],
+        wakes: [
+          {
+            timestamp: `2026-03-20T00:00:00.000Z`,
+            source: `/child/1`,
+            timeout: false,
+            changes: [{ collection: `runs`, kind: `update`, key: `run-1` }],
+          },
+          {
+            timestamp: `2026-03-20T00:00:00.000Z`,
+            source: `/child/2`,
+            timeout: false,
+            changes: [{ collection: `runs`, kind: `update`, key: `run-2` }],
+          },
+        ],
+        changes: [
+          { collection: `runs`, kind: `update`, key: `run-1` },
+          { collection: `runs`, kind: `update`, key: `run-2` },
+        ],
+      },
+    ])
+
+    const doneCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes(`/_electric/wakes/wake-abc`)
+    )
+    const lastDoneCall = doneCalls[doneCalls.length - 1]!
+    const body = JSON.parse(lastDoneCall[1]!.body as string) as {
+      acks: Array<{ path: string; offset: string }>
+    }
+    expect(body.acks).toEqual([
+      { path: `/streams/entity:agent-1`, offset: `2_0` },
+    ])
+  })
+
   it(`runs the handler immediately when catch-up already includes an inbox message`, async () => {
     const wakePayloads: Array<unknown> = []
 
@@ -2311,7 +2389,7 @@ describe(`processWake`, () => {
     ])
   })
 
-  it(`collapses consecutive pending wake batches into one handler pass using the newest wake`, async () => {
+  it(`collapses consecutive pending wake batches into one batched handler pass`, async () => {
     const wakeSummaries: Array<string> = []
     let firstPassSeenResolve: (() => void) | null = null
     const firstPassSeen = new Promise<void>((resolve) => {
@@ -2326,9 +2404,10 @@ describe(`processWake`, () => {
 
     defineEntity(`test-agent`, {
       handler: async (_ctx, wake) => {
+        const payload = wake.payload as { sources?: Array<string> } | undefined
         wakeSummaries.push(
           wake.type === `wake`
-            ? `wake:${wake.source}`
+            ? `wake:${payload?.sources?.join(`,`) ?? wake.source}`
             : `message:${String(wake.payload ?? ``)}`
         )
 
@@ -2366,7 +2445,10 @@ describe(`processWake`, () => {
     releaseFirstPass()
     await wakePromise
 
-    expect(wakeSummaries).toEqual([`message:`, `wake:/child/second`])
+    expect(wakeSummaries).toEqual([
+      `message:`,
+      `wake:/child/first,/child/second`,
+    ])
 
     const doneCalls = fetchMock.mock.calls.filter(([url]) =>
       String(url).includes(`/_electric/wakes/wake-abc`)
@@ -2472,9 +2554,10 @@ describe(`processWake`, () => {
 
     defineEntity(`test-agent`, {
       handler: async (_ctx, wake) => {
+        const payload = wake.payload as { sources?: Array<string> } | undefined
         wakeSummaries.push(
           wake.type === `wake`
-            ? `wake:${wake.source}`
+            ? `wake:${payload?.sources?.join(`,`) ?? wake.source}`
             : `message:${String(wake.payload ?? ``)}`
         )
 
@@ -2530,7 +2613,7 @@ describe(`processWake`, () => {
 
     expect(wakeSummaries).toEqual([
       `message:`,
-      `wake:/child/second`,
+      `wake:/child/first,/child/second`,
       `message:follow-up`,
     ])
 
@@ -2561,9 +2644,10 @@ describe(`processWake`, () => {
 
     defineEntity(`test-agent`, {
       handler: async (_ctx, wake) => {
+        const payload = wake.payload as { sources?: Array<string> } | undefined
         wakeSummaries.push(
           wake.type === `wake`
-            ? `wake:${wake.source}`
+            ? `wake:${payload?.sources?.join(`,`) ?? wake.source}`
             : `message:${String(wake.payload ?? ``)}`
         )
 
@@ -2625,9 +2709,10 @@ describe(`processWake`, () => {
 
     defineEntity(`test-agent`, {
       handler: async (_ctx, wake) => {
+        const payload = wake.payload as { sources?: Array<string> } | undefined
         wakeSummaries.push(
           wake.type === `wake`
-            ? `wake:${wake.source}`
+            ? `wake:${payload?.sources?.join(`,`) ?? wake.source}`
             : `message:${String(wake.payload ?? ``)}`
         )
 

--- a/packages/agents-runtime/test/process-wake.test.ts
+++ b/packages/agents-runtime/test/process-wake.test.ts
@@ -2140,6 +2140,82 @@ describe(`processWake`, () => {
     ])
   })
 
+  it(`combines multiple wake events that accumulated during catch-up`, async () => {
+    const wakePayloads: Array<unknown> = []
+    defineEntity(`test-agent`, {
+      handler: (_ctx, wake) => {
+        wakePayloads.push(wake.payload)
+      },
+    })
+
+    mockDbPreload.mockImplementationOnce(async () => {
+      mockEntityOnBatch.current?.({
+        items: [
+          ev(`entity_created`, `created-1`, `insert`, {}, { offset: `0_0` }),
+          ev(
+            `wake`,
+            `wake-1`,
+            `insert`,
+            {
+              source: `/child/1`,
+              changes: [{ collection: `runs`, kind: `update`, key: `run-1` }],
+            },
+            { offset: `1_0` }
+          ),
+          ev(
+            `wake`,
+            `wake-2`,
+            `insert`,
+            {
+              source: `/child/2`,
+              changes: [{ collection: `runs`, kind: `update`, key: `run-2` }],
+            },
+            { offset: `2_0` }
+          ),
+        ],
+        offset: `2_0`,
+      })
+    })
+
+    await processWake(makeNotification({ triggerEvent: `wake` }), BASE_CONFIG)
+
+    expect(wakePayloads).toEqual([
+      {
+        type: `wake_batch`,
+        sources: [`/child/1`, `/child/2`],
+        wakes: [
+          {
+            timestamp: `2026-03-20T00:00:00.000Z`,
+            source: `/child/1`,
+            timeout: false,
+            changes: [{ collection: `runs`, kind: `update`, key: `run-1` }],
+          },
+          {
+            timestamp: `2026-03-20T00:00:00.000Z`,
+            source: `/child/2`,
+            timeout: false,
+            changes: [{ collection: `runs`, kind: `update`, key: `run-2` }],
+          },
+        ],
+        changes: [
+          { collection: `runs`, kind: `update`, key: `run-1` },
+          { collection: `runs`, kind: `update`, key: `run-2` },
+        ],
+      },
+    ])
+
+    const doneCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes(`/_electric/wakes/wake-abc`)
+    )
+    const lastDoneCall = doneCalls[doneCalls.length - 1]!
+    const body = JSON.parse(lastDoneCall[1]!.body as string) as {
+      acks: Array<{ path: string; offset: string }>
+    }
+    expect(body.acks).toEqual([
+      { path: `/streams/entity:agent-1`, offset: `2_0` },
+    ])
+  })
+
   it(`runs the handler immediately when catch-up already includes an inbox message`, async () => {
     const wakePayloads: Array<unknown> = []
 
@@ -2539,7 +2615,7 @@ describe(`processWake`, () => {
     ])
   })
 
-  it(`collapses wake batches only until a later message batch and then handles the message next`, async () => {
+  it(`carries pending wake batches into a later message handler pass`, async () => {
     const wakeSummaries: Array<string> = []
     let firstPassSeenResolve: (() => void) | null = null
     const firstPassSeen = new Promise<void>((resolve) => {
@@ -2553,12 +2629,20 @@ describe(`processWake`, () => {
     })
 
     defineEntity(`test-agent`, {
-      handler: async (_ctx, wake) => {
+      handler: async (ctx, wake) => {
         const payload = wake.payload as { sources?: Array<string> } | undefined
+        const eventWakeSources = ctx.events
+          .filter((event) => event.type === `wake`)
+          .map(
+            (event) => (event.value as { source?: string } | undefined)?.source
+          )
+          .filter((source): source is string => typeof source === `string`)
         wakeSummaries.push(
           wake.type === `wake`
             ? `wake:${payload?.sources?.join(`,`) ?? wake.source}`
-            : `message:${String(wake.payload ?? ``)}`
+            : eventWakeSources.length > 0
+              ? `message:${String(wake.payload ?? ``)}+wakes:${eventWakeSources.join(`,`)}`
+              : `message:${String(wake.payload ?? ``)}`
         )
 
         if (wakeSummaries.length === 1) {
@@ -2613,8 +2697,7 @@ describe(`processWake`, () => {
 
     expect(wakeSummaries).toEqual([
       `message:`,
-      `wake:/child/first,/child/second`,
-      `message:follow-up`,
+      `message:follow-up+wakes:/child/first,/child/second`,
     ])
 
     const doneCalls = fetchMock.mock.calls.filter(([url]) =>


### PR DESCRIPTION
## Summary

Fix a child-wake regression where parent agents could miss child completion wake rows when multiple observed children finished close together. The runtime now batches queued wake rows into one `wake_batch` payload so the parent gets every child result in a single handler run, avoiding extra latency and token usage from serial re-wakes.

## Root Cause

Pending live batches can contain more than one `wake` row. The wake-draining path previously selected a single runnable wake from the fresh window and then acknowledged the whole window. When two child completion wake rows were coalesced into the same pending window, one wake could be surfaced to the handler while the sibling wake was effectively consumed by the ack.

## Approach

- Add `combineWakeEvents(...)` for wake-only pending windows.
- Preserve the single-wake path by delegating to `changeEventToWakeEvent(...)` when there is only one wake row.
- When multiple wake rows are present, create one `WakeEvent` with:
  - `type: "wake"`
  - `eventCount` set to the number of wake rows
  - `payload.type: "wake_batch"`
  - `payload.sources` for the child/source URLs
  - `payload.wakes` containing the original wake messages
  - `payload.changes` flattened from the wake messages
- Use the last wake row offset for the selected wake offset so the batched handler pass advances through the full coalesced wake window.
- Keep non-wake fresh work using the existing `selectWakeFromEvents(...)` path.

## Key Invariants

- A pending wake-only window must not drop any wake rows when acknowledged.
- Multiple wake rows should be delivered to the agent in one handler run, not serialized into extra LLM calls.
- Single wake rows should preserve existing behavior and payload shape.
- The ack offset should still cover the drained pending window after the batched wake is handled.

## Non-goals

- This does not change the server wake registry or child wake production logic.
- This does not introduce multiple handler passes for sibling child wakes.
- This does not change inbox-triggered wake selection.

## Trade-offs

An alternative fix was to split coalesced wake rows into separate in-process wake windows. That would preserve one wake per handler run, but it adds latency and can waste LLM tokens. Batching keeps the runtime efficient and lets the agent reason over all child completions together.

## Verification

```bash
pnpm --filter @electric-ax/agents-runtime test test/process-wake.test.ts -t "combines multiple pending wake events" --run
pnpm --filter @electric-ax/agents-runtime typecheck
```

## Files changed

- `packages/agents-runtime/src/process-wake.ts` — batch multiple pending wake rows into one wake payload before acking the window.
- `packages/agents-runtime/test/process-wake.test.ts` — add a focused regression test that coalesces two pending wake rows and verifies one batched handler wake plus acking at the last offset.
- `.changeset/batch-child-completion-wakes.md` — patch changeset for `@electric-ax/agents-runtime`.
