### PR TITLE
Add desktop-configurable skill directories

### DIFF
--- a/.changeset/add-desktop-skill-directories.md
+++ b/.changeset/add-desktop-skill-directories.md
@@ -1,0 +1,8 @@
+---
+'@electric-ax/agents-desktop': patch
+'@electric-ax/agents-server-ui': patch
+'@electric-ax/agents-runtime': patch
+'@electric-ax/agents': patch
+---
+
+Add desktop-configurable skill directories and common Claude/Codex skill locations so Markdown command files load recursively as slash-command skills without LLM metadata extraction.

--- a/packages/agents-desktop/src/app/context.ts
+++ b/packages/agents-desktop/src/app/context.ts
@@ -64,6 +64,7 @@ export function createDesktopAppContext(
       runtimeUrl: null,
       activeServer: null,
       workingDirectory: null,
+      skillDirectories: [],
       error: null,
       discoveredServers: [],
       pullWakeRunnerId: null,

--- a/packages/agents-desktop/src/app/controller.ts
+++ b/packages/agents-desktop/src/app/controller.ts
@@ -1,4 +1,5 @@
-import { BrowserWindow } from 'electron'
+import { app, BrowserWindow } from 'electron'
+import fs from 'node:fs'
 import type { DesktopAppContext } from './context'
 import * as AppLifecycle from './lifecycle'
 import * as LoginItems from './login-items'
@@ -10,9 +11,13 @@ import { createLocalDiscoveryLoop } from '../discovery/local-discovery'
 import * as DesktopIpc from '../ipc/register'
 import { ensureRuntimeEntry as ensureRuntimeEntryInStore } from '../runtime/entries'
 import { createRuntimeController } from '../runtime/controller'
+import { desktopSkillDirectories } from '../runtime/lifecycle'
 import * as SettingsBootstrap from '../settings/bootstrap'
 import * as ServerSelection from '../settings/selection'
-import { saveDesktopSettings } from '../settings/store'
+import {
+  normalizeSkillDirectories,
+  saveDesktopSettings,
+} from '../settings/store'
 import { desktopStateForWindow as desktopStateForWindowImpl } from '../state/desktop-state'
 import * as DesktopStateModel from '../state/desktop-state'
 import { injectDevPrincipalHeaders as injectDevPrincipalHeadersForServer } from '../shared/headers'
@@ -63,6 +68,8 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
   const runtimeEntries = ctx.runtimeEntries
   const lastMcpSnapshots = ctx.lastMcpSnapshots
   const explicitDevPrincipal = explicitDevPrincipalFromEnv()
+  let skillDirectoryWatchers: Array<fs.FSWatcher> = []
+  let skillReloadTimer: NodeJS.Timeout | null = null
 
   const saveSettings = async (): Promise<void> => {
     await saveDesktopSettings(settings)
@@ -199,7 +206,12 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
       stopRuntimeEntry,
       restartRuntime,
       refreshDesktopState,
-      quitApp,
+      quitApp: async (): Promise<void> => {
+        for (const watcher of skillDirectoryWatchers) watcher.close()
+        skillDirectoryWatchers = []
+        if (skillReloadTimer) clearTimeout(skillReloadTimer)
+        await quitApp()
+      },
     })
   }
 
@@ -305,7 +317,12 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
   const clearAllLocalDataAndRelaunch = (): Promise<void> =>
     AppLifecycle.clearAllLocalDataAndRelaunch({
       ctx,
-      quitApp,
+      quitApp: async (): Promise<void> => {
+        for (const watcher of skillDirectoryWatchers) watcher.close()
+        skillDirectoryWatchers = []
+        if (skillReloadTimer) clearTimeout(skillReloadTimer)
+        await quitApp()
+      },
     })
 
   const getLaunchAtLoginStatus = () => LoginItems.getLaunchAtLoginStatus()
@@ -317,6 +334,60 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
     settings.launchAtLogin = enabled
     await saveSettings()
     return status
+  }
+
+  const restartRuntimesForSkillChange = (): void => {
+    if (skillReloadTimer) clearTimeout(skillReloadTimer)
+    skillReloadTimer = setTimeout(() => {
+      skillReloadTimer = null
+      void runtime
+        .restartConnectedRuntimes()
+        .catch((err) =>
+          console.warn(
+            `[agents-desktop] Failed to reload skills after file change:`,
+            err
+          )
+        )
+    }, 300)
+  }
+
+  const refreshSkillDirectoryWatchers = (): void => {
+    for (const watcher of skillDirectoryWatchers) watcher.close()
+    skillDirectoryWatchers = []
+    const dirs = desktopSkillDirectories({
+      workingDirectory: settings.workingDirectory ?? app.getPath(`home`),
+      configured: settings.skillDirectories ?? [],
+    })
+    for (const dir of dirs) {
+      try {
+        if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) continue
+        const watcher = fs.watch(
+          dir,
+          { recursive: true },
+          (_event, filename) => {
+            if (filename && !String(filename).endsWith(`.md`)) return
+            restartRuntimesForSkillChange()
+          }
+        )
+        skillDirectoryWatchers.push(watcher)
+      } catch (err) {
+        console.warn(
+          `[agents-desktop] Could not watch skill directory ${dir}:`,
+          err
+        )
+      }
+    }
+  }
+
+  const getSkillDirectories = (): Array<string> =>
+    settings.skillDirectories ?? []
+
+  const setSkillDirectories = async (dirs: Array<string>): Promise<void> => {
+    settings.skillDirectories = normalizeSkillDirectories(dirs)
+    await saveSettings()
+    refreshDesktopState()
+    refreshSkillDirectoryWatchers()
+    await runtime.restartConnectedRuntimes()
   }
 
   const getPreventAppSuspension = (): boolean =>
@@ -347,7 +418,12 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
     windows,
     createWindow,
     sendCommand,
-    quitApp,
+    quitApp: async (): Promise<void> => {
+      for (const watcher of skillDirectoryWatchers) watcher.close()
+      skillDirectoryWatchers = []
+      if (skillReloadTimer) clearTimeout(skillReloadTimer)
+      await quitApp()
+    },
     showAboutDialog,
     checkForUpdates,
   }
@@ -438,6 +514,8 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
     setLaunchAtLogin,
     getPreventAppSuspension,
     setPreventAppSuspension,
+    getSkillDirectories,
+    setSkillDirectories,
   }
 
   const loadSettings = (): Promise<void> =>
@@ -509,7 +587,10 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
         }
       }
     },
-    loadSettings,
+    loadSettings: async (): Promise<void> => {
+      await loadSettings()
+      refreshSkillDirectoryWatchers()
+    },
     registerIpcHandlers,
     installCloudAuthHeaderInjection,
     createTray,
@@ -520,6 +601,11 @@ export function createDesktopMainController(ctx: DesktopAppContext) {
     connectConfiguredServers,
     startDiscoveryLoop: localDiscovery.startDiscoveryLoop,
     initializeUpdater: updater.initialize,
-    quitApp,
+    quitApp: async (): Promise<void> => {
+      for (const watcher of skillDirectoryWatchers) watcher.close()
+      skillDirectoryWatchers = []
+      if (skillReloadTimer) clearTimeout(skillReloadTimer)
+      await quitApp()
+    },
   }
 }

--- a/packages/agents-desktop/src/ipc/preferences.ts
+++ b/packages/agents-desktop/src/ipc/preferences.ts
@@ -9,6 +9,8 @@ export type PreferencesIpcDeps = {
   setLaunchAtLogin: (enabled: boolean) => Promise<LaunchAtLoginStatus>
   getPreventAppSuspension: () => PreventAppSuspensionPreference
   setPreventAppSuspension: (enabled: boolean) => Promise<void>
+  getSkillDirectories: () => Array<string>
+  setSkillDirectories: (dirs: Array<string>) => Promise<void>
 }
 
 export function registerPreferencesIpcHandlers(deps: PreferencesIpcDeps): void {
@@ -24,5 +26,15 @@ export function registerPreferencesIpcHandlers(deps: PreferencesIpcDeps): void {
   ipcMain.handle(
     `desktop:set-prevent-app-suspension`,
     (_event, enabled: boolean) => deps.setPreventAppSuspension(Boolean(enabled))
+  )
+  ipcMain.handle(`desktop:get-skill-directories`, () =>
+    deps.getSkillDirectories()
+  )
+  ipcMain.handle(`desktop:save-skill-directories`, (_event, dirs: unknown) =>
+    deps.setSkillDirectories(
+      Array.isArray(dirs)
+        ? dirs.filter((d): d is string => typeof d === `string`)
+        : []
+    )
   )
 }

--- a/packages/agents-desktop/src/preload.ts
+++ b/packages/agents-desktop/src/preload.ts
@@ -192,6 +192,10 @@ const api = {
     ipcRenderer.invoke(`desktop:set-prevent-app-suspension`, enabled),
   getWorkingDirectory: (): Promise<string | null> =>
     ipcRenderer.invoke(`desktop:get-working-directory`),
+  getSkillDirectories: (): Promise<Array<string>> =>
+    ipcRenderer.invoke(`desktop:get-skill-directories`),
+  saveSkillDirectories: (dirs: Array<string>): Promise<void> =>
+    ipcRenderer.invoke(`desktop:save-skill-directories`, dirs),
   chooseWorkingDirectory: (): Promise<string | null> =>
     ipcRenderer.invoke(`desktop:choose-working-directory`),
   pickDirectory: (options?: { defaultPath?: string }): Promise<string | null> =>

--- a/packages/agents-desktop/src/runtime/lifecycle.ts
+++ b/packages/agents-desktop/src/runtime/lifecycle.ts
@@ -38,6 +38,7 @@ export type RuntimeLifecycleDeps = {
     pullWakeRunnerId?: string | null
     preventAppSuspension?: boolean
     enabledModelValues?: Array<string>
+    skillDirectories?: Array<string>
   }
   runtimeEntries: Map<string, RuntimeEntry>
   windowSelections: Map<number, string | null>
@@ -309,6 +310,10 @@ export async function startRuntime(
     loadProjectMcpConfig: true,
     mcpOAuthRedirectBase: MCP_OAUTH_REDIRECT_BASE,
     baseSkillsDir: AGENT_SKILLS_DIR,
+    appSkillsDirs: desktopSkillDirectories({
+      workingDirectory: deps.settings.workingDirectory ?? app.getPath(`home`),
+      configured: deps.settings.skillDirectories ?? [],
+    }),
     openAuthorizeUrl: (url, server) => {
       void deps.handleAuthorizeUrl(serverId, url, server)
     },
@@ -463,4 +468,38 @@ export async function stopRuntime(
   const id = serverId ?? deps.settings.defaultServerId
   if (!id) return
   await disconnectServer(deps, id)
+}
+
+export function desktopSkillDirectories(opts: {
+  workingDirectory: string
+  configured: ReadonlyArray<string>
+}): Array<string> {
+  const home = app.getPath(`home`)
+  return dedupePaths([
+    path.join(home, `.claude`, `skills`),
+    path.join(home, `.claude`, `commands`),
+    path.join(home, `.codex`, `skills`),
+    path.join(opts.workingDirectory, `.claude`, `skills`),
+    path.join(opts.workingDirectory, `.claude`, `commands`),
+    path.join(opts.workingDirectory, `.codex`, `skills`),
+    ...opts.configured.map((dir) => expandHome(dir, home)),
+  ])
+}
+
+function expandHome(dir: string, home: string): string {
+  if (dir === `~`) return home
+  if (dir.startsWith(`~/`)) return path.join(home, dir.slice(2))
+  return dir
+}
+
+function dedupePaths(paths: ReadonlyArray<string>): Array<string> {
+  const seen = new Set<string>()
+  const result: Array<string> = []
+  for (const entry of paths) {
+    const resolved = path.resolve(entry)
+    if (seen.has(resolved)) continue
+    seen.add(resolved)
+    result.push(resolved)
+  }
+  return result
 }

--- a/packages/agents-desktop/src/settings/store.ts
+++ b/packages/agents-desktop/src/settings/store.ts
@@ -27,10 +27,25 @@ export const DEFAULT_SETTINGS: DesktopSettings = {
   servers: [],
   defaultServerId: null,
   workingDirectory: null,
+  skillDirectories: [],
   apiKeysRef: GLOBAL_API_KEYS_REF,
   launchAtLogin: false,
   preventAppSuspension: true,
   codex: { enabled: false, source: null },
+}
+
+export function normalizeSkillDirectories(value: unknown): Array<string> {
+  if (!Array.isArray(value)) return []
+  const seen = new Set<string>()
+  const dirs: Array<string> = []
+  for (const entry of value) {
+    if (typeof entry !== `string`) continue
+    const dir = entry.trim()
+    if (!dir || seen.has(dir)) continue
+    seen.add(dir)
+    dirs.push(dir)
+  }
+  return dirs
 }
 
 export function normalizeCodexSettings(value: unknown): CodexSettings {
@@ -160,6 +175,9 @@ export async function loadDesktopSettings(
         typeof parsed.workingDirectory === `string`
           ? parsed.workingDirectory
           : null,
+      skillDirectories: normalizeSkillDirectories(
+        (parsed as { skillDirectories?: unknown }).skillDirectories
+      ),
       apiKeysRef,
       launchAtLogin: parsed.launchAtLogin === true,
       preventAppSuspension: parsed.preventAppSuspension !== false,

--- a/packages/agents-desktop/src/shared/types.ts
+++ b/packages/agents-desktop/src/shared/types.ts
@@ -61,6 +61,7 @@ export type DesktopState = {
   runtimeUrl: string | null
   activeServer: ServerConfig | null
   workingDirectory: string | null
+  skillDirectories: Array<string>
   error: string | null
   discoveredServers: Array<DiscoveredServer>
   pullWakeRunnerId: string | null
@@ -126,6 +127,7 @@ export type DesktopSettings = {
   servers: Array<ServerConfig>
   defaultServerId: string | null
   workingDirectory: string | null
+  skillDirectories: Array<string>
   apiKeysRef: string
   launchAtLogin?: boolean
   preventAppSuspension?: boolean

--- a/packages/agents-desktop/src/state/desktop-state.ts
+++ b/packages/agents-desktop/src/state/desktop-state.ts
@@ -10,6 +10,7 @@ export type DesktopStateDeps = {
   settings: {
     servers: Array<ServerConfig>
     workingDirectory?: string | null
+    skillDirectories?: Array<string>
     pullWakeRunnerId?: string | null
   }
   state: DesktopState
@@ -42,6 +43,7 @@ export function desktopStateForWindow(
       ? deps.injectDevPrincipalHeaders(activeServer)
       : null,
     workingDirectory: deps.settings.workingDirectory ?? null,
+    skillDirectories: deps.settings.skillDirectories ?? [],
     error: entry?.lastError ?? null,
     discoveredServers: deps.state.discoveredServers,
     pullWakeRunnerId:

--- a/packages/agents-runtime/src/skills/extract-meta.ts
+++ b/packages/agents-runtime/src/skills/extract-meta.ts
@@ -1,5 +1,3 @@
-import { completeWithLowCostModel } from '../model-runner'
-import { runtimeLog } from '../log'
 import { parsePreamble } from './preamble'
 
 interface ExtractedMeta {
@@ -32,67 +30,12 @@ export async function extractSkillMeta(
     }
   }
 
-  try {
-    return await llmExtract(name, content, preamble)
-  } catch (err) {
-    runtimeLog.warn(
-      `[skills]`,
-      `LLM metadata extraction failed for "${name}":`,
-      err instanceof Error ? err : new Error(String(err))
-    )
-  }
-
   return {
     description: preamble.description ?? humanize(name),
     whenToUse:
       preamble.whenToUse ?? `User asks about ${humanize(name).toLowerCase()}`,
     keywords: preamble.keywords ?? [name],
     max: preamble.max ?? DEFAULT_MAX,
-  }
-}
-
-async function llmExtract(
-  name: string,
-  content: string,
-  partial: {
-    description?: string
-    whenToUse?: string
-    keywords?: Array<string>
-    max?: number
-  }
-): Promise<ExtractedMeta> {
-  const truncated = content.slice(0, 8_000)
-
-  const prompt = `Analyze this skill document and extract metadata. The skill is named "${name}".
-
-<skill>
-${truncated}
-</skill>
-
-Return ONLY a JSON object with these fields:
-- "description": one-line summary of what this skill provides (max 100 chars)
-- "whenToUse": when should an AI agent load this skill (max 200 chars)
-- "keywords": array of 3-8 relevant keywords
-
-Return raw JSON, no markdown fences.`
-
-  const text = await completeWithLowCostModel({
-    purpose: `skill metadata extraction`,
-    systemPrompt: `Extract metadata from skill documents. Return only valid JSON that matches the requested schema.`,
-    prompt,
-    maxTokens: 256,
-    log: (message) => runtimeLog.info(`[skills]`, message),
-    logPrefix: `[skills]`,
-  })
-
-  const parsed = JSON.parse(text)
-
-  return {
-    description: partial.description ?? parsed.description ?? humanize(name),
-    whenToUse:
-      partial.whenToUse ?? parsed.whenToUse ?? `User asks about ${name}`,
-    keywords: partial.keywords ?? parsed.keywords ?? [name],
-    max: partial.max ?? DEFAULT_MAX,
   }
 }
 

--- a/packages/agents-runtime/src/skills/registry.ts
+++ b/packages/agents-runtime/src/skills/registry.ts
@@ -11,27 +11,33 @@ const CACHE_FILENAME = `skills-cache.json`
 interface SkillsRegistryOptions {
   baseSkillsDir: string
   appSkillsDir?: string
+  appSkillsDirs?: ReadonlyArray<string>
   cacheDir: string
 }
 
 type CacheFile = Record<string, SkillMeta>
+type SkillFile = { source: string; userInvocableByDefault: boolean }
 
 export async function createSkillsRegistry(
   opts: SkillsRegistryOptions
 ): Promise<SkillsRegistry> {
-  const { baseSkillsDir, appSkillsDir, cacheDir } = opts
+  const { baseSkillsDir, appSkillsDir, appSkillsDirs, cacheDir } = opts
 
   const cachePath = path.join(cacheDir, CACHE_FILENAME)
   const existingCache = await loadCache(cachePath)
 
-  const files = new Map<string, string>()
-  await scanDir(baseSkillsDir, files)
+  const files = new Map<string, SkillFile>()
+  await scanDir(baseSkillsDir, files, { userInvocableByDefault: false })
   if (appSkillsDir) {
-    await scanDir(appSkillsDir, files)
+    await scanDir(appSkillsDir, files, { userInvocableByDefault: true })
+  }
+  for (const dir of appSkillsDirs ?? []) {
+    await scanDir(dir, files, { userInvocableByDefault: true })
   }
 
   const catalog = new Map<string, SkillMeta>()
-  for (const [name, filePath] of files) {
+  for (const [name, file] of files) {
+    const filePath = file.source
     const content = await fs.readFile(filePath, `utf-8`)
     const hash = sha256(content)
 
@@ -46,6 +52,7 @@ export async function createSkillsRegistry(
     const entry: SkillMeta = {
       name,
       ...meta,
+      userInvocable: meta.userInvocable ?? file.userInvocableByDefault,
       charCount: content.length,
       contentHash: hash,
       source: filePath,
@@ -84,17 +91,36 @@ export async function createSkillsRegistry(
   }
 }
 
-async function scanDir(dir: string, out: Map<string, string>) {
-  let entries: Array<{ name: string; isFile: () => boolean }>
+async function scanDir(
+  dir: string,
+  out: Map<string, SkillFile>,
+  opts: { userInvocableByDefault: boolean }
+) {
+  let entries: Array<{
+    name: string
+    isFile: () => boolean
+    isDirectory: () => boolean
+  }>
   try {
     entries = await fs.readdir(dir, { withFileTypes: true })
   } catch {
     return
   }
   for (const entry of entries) {
+    const entryPath = path.resolve(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === `node_modules` || entry.name === `.git`) continue
+      await scanDir(entryPath, out, opts)
+      continue
+    }
     if (!entry.isFile() || !entry.name.endsWith(`.md`)) continue
-    const name = entry.name.slice(0, -3)
-    out.set(name, path.resolve(dir, entry.name))
+    const parsed = path.parse(entryPath)
+    const name =
+      parsed.name === `SKILL` ? path.basename(parsed.dir) : parsed.name
+    out.set(name, {
+      source: entryPath,
+      userInvocableByDefault: opts.userInvocableByDefault,
+    })
   }
 }
 

--- a/packages/agents-runtime/test/skills/registry.test.ts
+++ b/packages/agents-runtime/test/skills/registry.test.ts
@@ -99,6 +99,42 @@ keywords: [app]
     expect(registry.catalog.has(`deployment`)).toBe(true)
   })
 
+  it(`recursively loads markdown from extra app skill directories`, async () => {
+    const baseDir = path.join(tmpDir, `base-skills`)
+    const extraDir = path.join(tmpDir, `extra-skills`)
+    await fs.mkdir(baseDir, { recursive: true })
+    await writeSkill(path.join(extraDir, `nested`), `gamma`, FULL_PREAMBLE)
+    await fs.mkdir(path.join(extraDir, `delta`), { recursive: true })
+    await fs.writeFile(
+      path.join(extraDir, `delta`, `SKILL.md`),
+      FULL_PREAMBLE,
+      `utf-8`
+    )
+
+    const registry = await createSkillsRegistry({
+      baseSkillsDir: baseDir,
+      appSkillsDirs: [extraDir],
+      cacheDir: path.join(tmpDir, `.electric-agents`),
+    })
+
+    expect(registry.catalog.has(`gamma`)).toBe(true)
+    expect(registry.catalog.get(`gamma`)!.userInvocable).toBe(true)
+    expect(registry.catalog.has(`delta`)).toBe(true)
+    expect(registry.catalog.get(`delta`)!.userInvocable).toBe(true)
+  })
+
+  it(`does not make base skills user invocable by default`, async () => {
+    const baseDir = path.join(tmpDir, `base-skills`)
+    await writeSkill(baseDir, `internal`, FULL_PREAMBLE)
+
+    const registry = await createSkillsRegistry({
+      baseSkillsDir: baseDir,
+      cacheDir: path.join(tmpDir, `.electric-agents`),
+    })
+
+    expect(registry.catalog.get(`internal`)!.userInvocable).toBe(false)
+  })
+
   it(`readContent returns file content`, async () => {
     const skillsDir = path.join(tmpDir, `skills`)
     await writeSkill(skillsDir, `alpha`, FULL_PREAMBLE)

--- a/packages/agents-server-ui/src/components/settings/pages/LocalRuntimePage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/LocalRuntimePage.tsx
@@ -5,6 +5,8 @@ import { appendPathToUrl } from '@electric-ax/agents-runtime/client'
 import { Play, RefreshCw, Square } from 'lucide-react'
 import {
   loadDesktopState,
+  loadSkillDirectories,
+  saveSkillDirectories,
   onDesktopStateChanged,
   type DesktopState,
   type LocalRuntimeStatus,
@@ -153,6 +155,8 @@ export function LocalRuntimePage(): React.ReactElement {
   const [state, setState] = useState<DesktopState | null>(null)
   const [selectedServerId, setSelectedServerId] = useState<string | null>(null)
   const [now, setNow] = useState(() => Date.now())
+  const [skillDirectories, setSkillDirectories] = useState<Array<string>>([])
+  const [skillDirsError, setSkillDirsError] = useState<string | null>(null)
   const { runnersCollection: activeRunnersCollection } = useElectricAgents()
   const runtimeServers = useMemo(
     () =>
@@ -241,7 +245,13 @@ export function LocalRuntimePage(): React.ReactElement {
       if (cancelled) return
       setState(s)
     })
-    const off = onDesktopStateChanged(setState)
+    void loadSkillDirectories().then((dirs) => {
+      if (!cancelled) setSkillDirectories(dirs)
+    })
+    const off = onDesktopStateChanged((s) => {
+      setState(s)
+      setSkillDirectories(s.skillDirectories ?? [])
+    })
     return () => {
       cancelled = true
       off?.()
@@ -268,6 +278,30 @@ export function LocalRuntimePage(): React.ReactElement {
       activeRuntimeServer?.id ?? runtimeServers[0]?.id ?? null
     )
   }, [requestedServerId, runtimeServers, selectedServerId, state])
+
+  const addSkillDirectory = async (): Promise<void> => {
+    setSkillDirsError(null)
+    try {
+      const picked = await window.electronAPI?.pickDirectory?.()
+      if (!picked || skillDirectories.includes(picked)) return
+      const next = [...skillDirectories, picked]
+      setSkillDirectories(next)
+      await saveSkillDirectories(next)
+    } catch (err) {
+      setSkillDirsError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const removeSkillDirectory = async (dir: string): Promise<void> => {
+    setSkillDirsError(null)
+    const next = skillDirectories.filter((entry) => entry !== dir)
+    setSkillDirectories(next)
+    try {
+      await saveSkillDirectories(next)
+    } catch (err) {
+      setSkillDirsError(err instanceof Error ? err.message : String(err))
+    }
+  }
 
   if (!isDesktop) {
     return (
@@ -433,6 +467,55 @@ export function LocalRuntimePage(): React.ReactElement {
               </Text>
             }
           />
+        )}
+      </SettingsSection>
+
+      <SettingsSection
+        title="Skill directories"
+        description="Load Markdown files recursively as skills. Changes are watched and the local runtime restarts to expose updated slash commands."
+        action={
+          <Button
+            variant="soft"
+            tone="neutral"
+            onClick={() => void addSkillDirectory()}
+          >
+            Add directory
+          </Button>
+        }
+      >
+        {skillDirectories.length === 0 ? (
+          <SettingsPanel>
+            <Text size={2} tone="muted">
+              No extra skill directories configured. The built-in skills still
+              load.
+            </Text>
+          </SettingsPanel>
+        ) : (
+          skillDirectories.map((dir) => (
+            <SettingsRow
+              key={dir}
+              label={dir}
+              description="Markdown files in this directory and subdirectories are loaded as skills."
+              wrapControlValue
+              splitLayout
+              control={
+                <Button
+                  variant="soft"
+                  tone="neutral"
+                  onClick={() => void removeSkillDirectory(dir)}
+                >
+                  Remove
+                </Button>
+              }
+            />
+          ))
+        )}
+        {skillDirsError && (
+          <SettingsPanel>
+            <Text size={2} tone="danger">
+              {skillDirsError}
+            </Text>
+          </SettingsPanel>
         )}
       </SettingsSection>
 

--- a/packages/agents-server-ui/src/lib/server-connection.ts
+++ b/packages/agents-server-ui/src/lib/server-connection.ts
@@ -36,6 +36,7 @@ export interface DesktopState {
   runtimeUrl: string | null
   activeServer: ServerConfig | null
   workingDirectory: string | null
+  skillDirectories: Array<string>
   error: string | null
   discoveredServers: Array<DiscoveredServer>
   pullWakeRunnerId: string | null
@@ -377,6 +378,8 @@ declare global {
       getPreventAppSuspension?: () => Promise<PreventAppSuspensionPreference>
       setPreventAppSuspension?: (enabled: boolean) => Promise<void>
       getWorkingDirectory?: () => Promise<string | null>
+      getSkillDirectories?: () => Promise<Array<string>>
+      saveSkillDirectories?: (dirs: Array<string>) => Promise<void>
       chooseWorkingDirectory?: () => Promise<string | null>
       /**
        * One-shot native folder picker. Unlike `chooseWorkingDirectory`,
@@ -653,6 +656,14 @@ export async function savePreventAppSuspensionPreference(
   enabled: boolean
 ): Promise<void> {
   await window.electronAPI?.setPreventAppSuspension?.(enabled)
+}
+
+export async function loadSkillDirectories(): Promise<Array<string>> {
+  return (await window.electronAPI?.getSkillDirectories?.()) ?? []
+}
+
+export async function saveSkillDirectories(dirs: Array<string>): Promise<void> {
+  await window.electronAPI?.saveSkillDirectories?.(dirs)
 }
 
 export async function loadCloudAuthState(): Promise<CloudAuthState | null> {

--- a/packages/agents/src/bootstrap.ts
+++ b/packages/agents/src/bootstrap.ts
@@ -67,6 +67,7 @@ export interface BuiltinAgentHandlerOptions {
   runtimeName?: string
   /** Override for the built-in skills directory; required when embedders bundle this package. */
   baseSkillsDir?: string
+  appSkillsDirs?: ReadonlyArray<string>
   serverHeaders?: HeadersProvider
   defaultDispatchPolicyForType?: (
     typeName: string
@@ -118,6 +119,7 @@ export async function createBuiltinAgentHandler(
     publicUrl,
     runtimeName,
     baseSkillsDir: baseSkillsDirOverride,
+    appSkillsDirs,
     serverHeaders,
     defaultDispatchPolicyForType,
   } = options
@@ -144,6 +146,7 @@ export async function createBuiltinAgentHandler(
     skillsRegistry = await createSkillsRegistry({
       baseSkillsDir,
       appSkillsDir: path.resolve(cwd, `skills`),
+      appSkillsDirs,
       cacheDir: path.resolve(cwd, `.electric-agents`),
     })
     if (skillsRegistry.catalog.size > 0) {

--- a/packages/agents/src/server.ts
+++ b/packages/agents/src/server.ts
@@ -82,6 +82,7 @@ export interface BuiltinAgentsServerOptions {
   loadProjectMcpConfig?: boolean
   /** Override for the built-in skills directory; required when embedders bundle this package. */
   baseSkillsDir?: string
+  appSkillsDirs?: ReadonlyArray<string>
   /** Restrict the model values exposed by built-in agent creation schemas. */
   enabledModelValues?: ReadonlyArray<string> | null
   createElectricTools?: NonNullable<ProcessWakeConfig[`createElectricTools`]>
@@ -307,6 +308,7 @@ export class BuiltinAgentsServer {
         publicUrl,
         runtimeName: `builtin-agents`,
         baseSkillsDir: this.options.baseSkillsDir,
+        appSkillsDirs: this.options.appSkillsDirs,
         enabledModelValues: this.options.enabledModelValues,
         serverHeaders: pullWake.headers,
       })


### PR DESCRIPTION
Adds desktop-configurable skill directories and common default skill locations so Markdown command files can be loaded as Horton skills/slash commands. Users can add directories in Settings → Local Runtime, and changes to those files hot-reload by restarting connected local runtimes.

## Root Cause

Slash command support existed, but the desktop runtime only loaded built-in skills and `<workingDirectory>/skills`. There was no desktop UI for choosing additional skill directories, no persistence/IPC path for those settings, and no watcher to reload skills after command files changed. The existing metadata loader also tried to call an LLM for Markdown files without full Electric skill frontmatter, which becomes noisy, slow, and privacy-unfriendly when scanning user command directories like `~/.claude/commands`.

## Approach

- Extend the skills registry to recursively scan additional app skill directories.
- Treat user/app skill directories as user-invocable by default so Claude/Codex-style command files become slash commands without requiring Electric-specific frontmatter.
- Add desktop settings state, IPC, preload APIs, and Local Runtime settings UI for managing configured skill directories.
- Automatically include common skill/command directories:
  - `~/.claude/skills`
  - `~/.claude/commands`
  - `~/.codex/skills`
  - `<workingDirectory>/.claude/skills`
  - `<workingDirectory>/.claude/commands`
  - `<workingDirectory>/.codex/skills`
- Watch existing configured/default directories recursively and restart connected local runtimes on Markdown changes so skills/slash commands reload.
- Remove LLM metadata extraction fallback. Metadata is now deterministic: use frontmatter when present, otherwise fall back to a humanized name, a generic `whenToUse`, and the skill name as a keyword.

## Key Invariants

- Built-in/base skills are not made user-invocable unless their metadata says so.
- User/app skill directories are user-invocable by default.
- `SKILL.md` is named after its containing directory; other `.md` files are named after their basename.
- Recursive scanning skips `.git` and `node_modules`.
- Missing common/default directories are harmless: they are scanned as empty and are not watched.
- Skill metadata extraction must not make network/model calls at runtime startup.
- Updating skill-directory settings or Markdown files should restart connected local runtimes so entity type registration and slash commands refresh.

## Non-goals

- This does not add an explicit “discovered skills” inspector UI.
- This does not live-patch an already-running runtime’s skills registry in place; it restarts connected local runtimes instead.
- This does not require Claude/Codex command files to adopt Electric-specific frontmatter, though richer frontmatter is still supported.

## Trade-offs

Restarting the local runtime is simpler and keeps registration behavior consistent with startup, at the cost of a brief reconnect. A deeper hot-swap API could avoid restarts but would need to safely refresh the skills registry, Horton slash command registration, and any cached entity-type metadata.

Making user directories slash-command-visible by default matches the intent of selecting command/skill folders, but it means broad directories with many Markdown files can create many commands. The UI still lets users remove configured directories, and common defaults are limited to well-known skill/command locations.

## Verification

```bash
pnpm install
pnpm --filter @electric-ax/agents-mcp build
pnpm --filter @electric-sql/client build
pnpm --filter @electric-ax/agents-runtime typecheck
pnpm --filter @electric-ax/agents-runtime build
pnpm --filter @electric-ax/agents typecheck
pnpm --filter @electric-ax/agents build
pnpm --filter @electric-ax/agents-desktop typecheck
pnpm --filter @electric-ax/agents-server-ui typecheck
pnpm --filter @electric-ax/agents-runtime exec vitest run test/skills/registry.test.ts
```

Manual verification:

1. Start the desktop app from this branch.
2. Confirm common directories like `~/.claude/commands` are picked up after rebuilding/restarting the desktop runtime.
3. Add a directory in Settings → Local Runtime → Skill directories.
4. Confirm Markdown files in that directory appear as slash commands.
5. Edit a Markdown file and confirm the local runtime restarts and reloads skills.

## Files changed

- `packages/agents-runtime/src/skills/registry.ts` — recursively scans skill directories, supports multiple app dirs, maps `SKILL.md` to directory names, and marks app/user dirs user-invocable by default.
- `packages/agents-runtime/src/skills/extract-meta.ts` — removes LLM metadata extraction fallback; uses deterministic frontmatter/name fallbacks only.
- `packages/agents-runtime/test/skills/registry.test.ts` — covers recursive extra directories, `SKILL.md`, and user-invocable defaults.
- `packages/agents/src/bootstrap.ts` / `packages/agents/src/server.ts` — thread `appSkillsDirs` into built-in agent startup.
- `packages/agents-desktop/src/runtime/lifecycle.ts` — passes configured/common skill directories into the runtime and computes default skill locations.
- `packages/agents-desktop/src/app/controller.ts` — watches skill directories, debounces Markdown changes, restarts connected runtimes, and persists skill directory settings.
- `packages/agents-desktop/src/settings/store.ts` / `shared/types.ts` / `state/desktop-state.ts` / `app/context.ts` — add persisted and broadcast desktop skill-directory state.
- `packages/agents-desktop/src/ipc/preferences.ts` / `preload.ts` — expose skill-directory IPC APIs to the renderer.
- `packages/agents-server-ui/src/components/settings/pages/LocalRuntimePage.tsx` — adds the Skill directories settings UI.
- `packages/agents-server-ui/src/lib/server-connection.ts` — adds renderer helpers and typings for skill-directory APIs.
