### PR TITLE
Fix agent wake claim token races

### DIFF
--- a/.changeset/fix-agent-wake-claim-token-races.md
+++ b/.changeset/fix-agent-wake-claim-token-races.md
@@ -1,0 +1,6 @@
+---
+'@electric-ax/agents-runtime': patch
+'@electric-ax/agents-server': patch
+---
+
+Fix agent wake handling so concurrent sessions do not invalidate each other's claim write tokens, and retry same-stream wakes after the active wake drains instead of dropping pending work.

--- a/packages/agents-runtime/src/create-handler.ts
+++ b/packages/agents-runtime/src/create-handler.ts
@@ -148,6 +148,9 @@ export interface RuntimeRouter {
     options?: Pick<ProcessWakeConfig, `claimHeaders` | `claimTokenHeader`>
   ) => void
 
+  /** True when a wake for the stream path is already in flight. */
+  isWakeActive: (streamPath: string) => boolean
+
   /** Dispatch an already-parsed webhook wake notification. */
   dispatchWebhookWake: (notification: WebhookNotification) => void
 
@@ -406,7 +409,7 @@ export function createRuntimeRouter(
     notification,
     options
   ): void => {
-    const wakeLabel = notification.entity?.url ?? notification.streamPath
+    const wakeLabel = notification.streamPath
     const controller = new AbortController()
     const wake: Promise<void> = Promise.resolve(
       processWake(notification, {
@@ -437,6 +440,9 @@ export function createRuntimeRouter(
     pendingWakeLabels.set(wake, wakeLabel)
     pendingWakeControllers.set(wake, controller)
   }
+
+  const isWakeActive: RuntimeRouter[`isWakeActive`] = (streamPath) =>
+    [...pendingWakeLabels.values()].includes(streamPath)
 
   const dispatchWebhookWake: RuntimeRouter[`dispatchWebhookWake`] = dispatchWake
 
@@ -623,6 +629,7 @@ export function createRuntimeRouter(
     handleRequest,
     handleWebhookRequest,
     dispatchWake,
+    isWakeActive,
     dispatchWebhookWake,
     drainWakes,
     waitForSettled,
@@ -671,6 +678,7 @@ export function createRuntimeHandler(
     handleRequest: router.handleRequest,
     handleWebhookRequest: router.handleWebhookRequest,
     dispatchWake: router.dispatchWake,
+    isWakeActive: router.isWakeActive,
     dispatchWebhookWake: router.dispatchWebhookWake,
     drainWakes: router.drainWakes,
     waitForSettled: router.waitForSettled,

--- a/packages/agents-runtime/src/process-wake.ts
+++ b/packages/agents-runtime/src/process-wake.ts
@@ -820,6 +820,7 @@ export async function processWake(
         if (runAbortController) {
           log.info(`SIGINT received, aborting active handler invocation`)
           runAbortController.abort()
+          requestShutdown()
         } else if (notification.entity?.status === `running`) {
           // SIGINT may arrive in the small window before the handler invocation
           // controller exists. Only carry it forward for running entities; idle
@@ -828,6 +829,7 @@ export async function processWake(
             `SIGINT received before active run controller, queuing abort`
           )
           pendingRunAbortRequested = true
+          requestShutdown()
         } else {
           log.info(`SIGINT received with no active run, ignoring`)
           markSignalHandled(event, `ignored`, notification.entity?.status)

--- a/packages/agents-runtime/src/process-wake.ts
+++ b/packages/agents-runtime/src/process-wake.ts
@@ -2254,12 +2254,15 @@ export async function processWake(
         )
         if (spawnedChildren.length > 0) {
           log.warn(
-            `handler failed — attempting to close ${spawnedChildren.length} child(ren) spawned before the failure`
+            `handler failed — detaching ${spawnedChildren.length} child wake registration(s) created before the failure`
           )
           const cleanupErrors: Array<Error> = []
           for (const childEntry of spawnedChildren) {
             try {
-              await serverClient.deleteEntity(childEntry.entity_url)
+              await serverClient.unregisterWake({
+                subscriberUrl: entityUrl,
+                sourceUrl: childEntry.entity_url,
+              })
             } catch (err) {
               cleanupErrors.push(toError(err))
             }
@@ -2267,7 +2270,7 @@ export async function processWake(
           if (cleanupErrors.length > 0) {
             throw new AggregateError(
               [toError(setupErr), ...cleanupErrors],
-              `Wake handler failed and child cleanup also failed`
+              `Wake handler failed and child wake cleanup also failed`
             )
           }
         }

--- a/packages/agents-runtime/src/process-wake.ts
+++ b/packages/agents-runtime/src/process-wake.ts
@@ -119,7 +119,11 @@ function inboxEventKey(event: ChangeEvent): string {
 type ServerForkWake = NonNullable<
   Parameters<RuntimeServerClient[`forkEntity`]>[0][`wake`]
 >
-function normalizeForkWake(wake: Wake, subscriberUrl: string): ServerForkWake {
+function normalizeForkWake(
+  wake: Wake,
+  subscriberUrl: string,
+  manifestKey?: string
+): ServerForkWake {
   const isRunFinished =
     wake === `runFinished` ||
     (typeof wake === `object` && wake.on === `runFinished`)
@@ -129,6 +133,9 @@ function normalizeForkWake(wake: Wake, subscriberUrl: string): ServerForkWake {
   const result: ServerForkWake = {
     subscriberUrl,
     condition,
+  }
+  if (manifestKey !== undefined) {
+    result.manifestKey = manifestKey
   }
   if (typeof wake === `object` && wake.on === `runFinished`) {
     if (wake.includeResponse !== undefined) {
@@ -1404,7 +1411,7 @@ export async function processWake(
         // (the only valid target after the route's wake validation).
         const wakeOpt =
           opts?.wake && opts.parent
-            ? normalizeForkWake(opts.wake, opts.parent)
+            ? normalizeForkWake(opts.wake, opts.parent, opts.manifestKey)
             : undefined
         const result = await serverClient.forkEntity({
           sourceEntityUrl,
@@ -2261,7 +2268,7 @@ export async function processWake(
             try {
               await serverClient.unregisterWake({
                 subscriberUrl: entityUrl,
-                sourceUrl: childEntry.entity_url,
+                manifestKey: childEntry.key,
               })
             } catch (err) {
               cleanupErrors.push(toError(err))

--- a/packages/agents-runtime/src/pull-wake-runner.ts
+++ b/packages/agents-runtime/src/pull-wake-runner.ts
@@ -21,7 +21,7 @@ export interface PullWakeEvent {
 export interface PullWakeRunnerConfig {
   baseUrl: string
   runnerId: string
-  runtime: Pick<RuntimeRouter, `dispatchWake` | `drainWakes` | `abortWakes`>
+  runtime: PullWakeRuntime
   offset?: string
   headers?: HeadersProvider
   claimHeaders?: ProcessWakeConfig[`claimHeaders`]
@@ -39,6 +39,13 @@ export interface PullWakeRunnerConfig {
     offset?: string
     signal: AbortSignal
   }) => Promise<PullWakeStreamResponse>
+}
+
+type PullWakeRuntime = Pick<
+  RuntimeRouter,
+  `dispatchWake` | `drainWakes` | `abortWakes`
+> & {
+  isWakeActive?: RuntimeRouter[`isWakeActive`]
 }
 
 export interface PullWakeStreamResponse {
@@ -89,6 +96,7 @@ export interface PullWakeRunnerHealth {
 const CLAIM_ACTOR_STOP_GRACE_MS = 1_000
 const DEFAULT_EVENT_HEARTBEAT_THROTTLE_MS = 2_000
 const HEARTBEAT_FAILURE_STREAM_RESET_THRESHOLD = 2
+const DEFERRED_WAKE_RETRY_MS = 25
 
 export function createPullWakeRunner(
   config: PullWakeRunnerConfig
@@ -119,6 +127,12 @@ export function createPullWakeRunner(
   let consecutiveHeartbeatFailures = 0
   let stopPromise: Promise<void> | null = null
   const claimActors = new Set<Promise<void>>()
+  const claimingStreamPaths = new Set<string>()
+  const deferredWakeEventsByStreamPath = new Map<string, PullWakeEvent>()
+  const deferredWakeTimersByStreamPath = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >()
 
   const wakePath =
     config.wakeStreamPath ??
@@ -329,6 +343,50 @@ export function createPullWakeRunner(
     notifyHeartbeatChange()
   }
 
+  const normalizeStreamPath = (stream: string): string =>
+    stream.startsWith(`/`) ? stream : `/${stream}`
+
+  const hasActiveStreamClaim = (streamPath: string): boolean =>
+    claimingStreamPaths.has(streamPath) ||
+    config.runtime.isWakeActive?.(streamPath) === true
+
+  const clearDeferredWakeRetries = (): void => {
+    for (const timer of deferredWakeTimersByStreamPath.values()) {
+      clearTimeout(timer)
+    }
+    deferredWakeTimersByStreamPath.clear()
+    deferredWakeEventsByStreamPath.clear()
+  }
+
+  const scheduleDeferredWakeClaim = (
+    event: PullWakeEvent,
+    signal: AbortSignal
+  ): void => {
+    const streamPath = normalizeStreamPath(event.stream)
+    deferredWakeEventsByStreamPath.set(streamPath, event)
+    if (deferredWakeTimersByStreamPath.has(streamPath)) return
+
+    const retry = (): void => {
+      deferredWakeTimersByStreamPath.delete(streamPath)
+      const deferredEvent = deferredWakeEventsByStreamPath.get(streamPath)
+      if (!deferredEvent || signal.aborted || !isRunningState()) {
+        deferredWakeEventsByStreamPath.delete(streamPath)
+        return
+      }
+      if (hasActiveStreamClaim(streamPath)) {
+        scheduleDeferredWakeClaim(deferredEvent, signal)
+        return
+      }
+
+      deferredWakeEventsByStreamPath.delete(streamPath)
+      spawnClaimActor(deferredEvent, signal)
+    }
+
+    const timer = setTimeout(retry, DEFERRED_WAKE_RETRY_MS)
+    timer.unref?.()
+    deferredWakeTimersByStreamPath.set(streamPath, timer)
+  }
+
   const claimWake = async (
     event: PullWakeEvent,
     signal: AbortSignal
@@ -384,6 +442,13 @@ export function createPullWakeRunner(
     event: PullWakeEvent,
     signal: AbortSignal
   ): Promise<void> => {
+    const streamPath = normalizeStreamPath(event.stream)
+    if (hasActiveStreamClaim(streamPath)) {
+      recordClaimSkipped()
+      scheduleDeferredWakeClaim(event, signal)
+      return
+    }
+    claimingStreamPaths.add(streamPath)
     try {
       const notification = await claimWake(event, signal)
       if (!notification) return
@@ -406,6 +471,8 @@ export function createPullWakeRunner(
       if (!signal.aborted) {
         reportError(err)
       }
+    } finally {
+      claimingStreamPaths.delete(streamPath)
     }
   }
 
@@ -475,11 +542,15 @@ export function createPullWakeRunner(
     onStopping: () => {
       controller?.abort()
       controller = null
+      claimingStreamPaths.clear()
+      clearDeferredWakeRetries()
       stopHeartbeat()
     },
     shutdown: async () => {
       if (!(await waitForClaimActors())) {
         claimActors.clear()
+        claimingStreamPaths.clear()
+        clearDeferredWakeRetries()
       }
       config.runtime.abortWakes()
       try {
@@ -521,6 +592,8 @@ export function createPullWakeRunner(
       claimsSkipped = 0
       claimsFailed = 0
       consecutiveHeartbeatFailures = 0
+      claimingStreamPaths.clear()
+      clearDeferredWakeRetries()
       startedAt = new Date().toISOString()
       controller = new AbortController()
       startHeartbeat(controller.signal)

--- a/packages/agents-runtime/src/runtime-server-client.ts
+++ b/packages/agents-runtime/src/runtime-server-client.ts
@@ -169,6 +169,11 @@ export interface RuntimeServerClient {
   signalEntity: (options: SignalEntityOptions) => Promise<{ txid: number }>
   ensureStream: (streamPath: string, contentType?: string) => Promise<string>
   deleteEntity: (entityUrl: string) => Promise<void>
+  unregisterWake: (options: {
+    subscriberUrl: string
+    sourceUrl?: string
+    manifestKey?: string
+  }) => Promise<void>
   getSharedStateStreamPath: (sharedStateId: string) => string
   registerWake: (options: RegisterWakeOptions) => Promise<void>
   ensureCronStream: (expression: string, timezone?: string) => Promise<string>
@@ -645,6 +650,23 @@ export function createRuntimeServerClient(
     }
   }
 
+  const unregisterWake = async (options: {
+    subscriberUrl: string
+    sourceUrl?: string
+    manifestKey?: string
+  }): Promise<void> => {
+    const response = await request(`/_electric/wake/unregister`, {
+      method: `POST`,
+      headers: { 'content-type': `application/json` },
+      body: JSON.stringify(options),
+    })
+    if (!response.ok) {
+      throw new Error(
+        `unregisterWake failed (${response.status}): ${await readErrorText(response)}`
+      )
+    }
+  }
+
   const registerWake = async (options: RegisterWakeOptions): Promise<void> => {
     const response = await request(`/_electric/wake`, {
       method: `POST`,
@@ -949,6 +971,7 @@ export function createRuntimeServerClient(
     signalEntity,
     ensureStream,
     deleteEntity,
+    unregisterWake,
     getSharedStateStreamPath,
     registerWake,
     ensureCronStream,

--- a/packages/agents-runtime/src/setup-context.ts
+++ b/packages/agents-runtime/src/setup-context.ts
@@ -100,6 +100,8 @@ export interface WiringConfig {
        * — same translation `createOrGetChild` does for spawn.
        */
       wake?: Wake
+      /** Manifest key that owns this wake registration, when any. */
+      manifestKey?: string
       initialMessage?: unknown
       tags?: Record<string, string>
     }
@@ -1183,6 +1185,7 @@ export function createSetupContext(
               instanceId: id,
               ...(observeChild && { parent: entityUrl }),
               ...(wakeForFork && { wake: wakeForFork }),
+              ...(observeChild && { manifestKey: childKey }),
               ...(opts?.initialMessage !== undefined && {
                 initialMessage: opts.initialMessage,
               }),

--- a/packages/agents-runtime/test/create-handler.test.ts
+++ b/packages/agents-runtime/test/create-handler.test.ts
@@ -228,7 +228,7 @@ describe(`createRuntimeHandler`, () => {
     expect(response.status).toBe(200)
     expect(handler.debugState()).toMatchObject({
       pendingWakeCount: 1,
-      pendingWakeLabels: [`http://localhost:3000/test-agent/test-1`],
+      pendingWakeLabels: [`/streams/entity:test-1`],
       wakeErrorCount: 0,
       typeNames: [`test-agent`],
     })

--- a/packages/agents-runtime/test/process-wake.test.ts
+++ b/packages/agents-runtime/test/process-wake.test.ts
@@ -1667,6 +1667,46 @@ describe(`processWake`, () => {
     )
   })
 
+  it(`detaches newly spawned child wake registrations without killing children when the handler fails`, async () => {
+    defineEntity(`test-agent`, {
+      handler: async (ctx) => {
+        await ctx.spawn(
+          `child-worker`,
+          `worker-1`,
+          {},
+          { wake: { on: `runFinished`, includeResponse: true } }
+        )
+        throw new Error(`parent failed after spawn`)
+      },
+    })
+
+    await expect(processWake(makeNotification(), BASE_CONFIG)).rejects.toThrow(
+      `parent failed after spawn`
+    )
+
+    const unregisterCalls = fetchMock.mock.calls.filter(
+      ([url, opts]) =>
+        String(url).includes(`/_electric/wake/unregister`) &&
+        (opts as RequestInit | undefined)?.method === `POST`
+    )
+    expect(unregisterCalls).toHaveLength(1)
+    expect(JSON.parse(unregisterCalls[0]![1]!.body as string)).toEqual({
+      subscriberUrl: `http://localhost:3000/test-agent/agent-1`,
+      sourceUrl: `/child-worker/spawned-child`,
+    })
+
+    const signalCalls = fetchMock.mock.calls.filter(
+      ([url, opts]) =>
+        String(url).includes(`/signal`) &&
+        (opts as RequestInit | undefined)?.method === `POST`
+    )
+    expect(
+      signalCalls.some(([, opts]) =>
+        String((opts as RequestInit | undefined)?.body).includes(`SIGKILL`)
+      )
+    ).toBe(false)
+  })
+
   it(`does not fail the wake when an unawaited send fails`, async () => {
     defineEntity(`test-agent`, {
       handler: (ctx) => {

--- a/packages/agents-runtime/test/process-wake.test.ts
+++ b/packages/agents-runtime/test/process-wake.test.ts
@@ -985,6 +985,85 @@ describe(`processWake`, () => {
     )
   })
 
+  it(`does not continue fresh inbox work after SIGINT aborts an active run`, async () => {
+    const wakePayloads: Array<unknown> = []
+    let handlerStartedResolve: (() => void) | null = null
+    const handlerStarted = new Promise<void>((resolve) => {
+      handlerStartedResolve = resolve
+    })
+    let signalAbortedResolve: (() => void) | null = null
+    const signalAborted = new Promise<void>((resolve) => {
+      signalAbortedResolve = resolve
+    })
+
+    defineEntity(`test-agent`, {
+      handler: async (ctx, wake) => {
+        wakePayloads.push(wake.payload)
+        handlerStartedResolve?.()
+        if (ctx.signal.aborted) {
+          signalAbortedResolve?.()
+          return
+        }
+        await new Promise<void>((resolve) => {
+          ctx.signal.addEventListener(
+            `abort`,
+            () => {
+              signalAbortedResolve?.()
+              resolve()
+            },
+            { once: true }
+          )
+        })
+      },
+    })
+
+    const notification = makeNotification({ triggerEvent: `inbox` })
+    notification.entity!.status = `running`
+    const wakePromise = processWake(notification, BASE_CONFIG)
+    await handlerStarted
+
+    mockEntityOnBatch.current?.({
+      items: [
+        ev(
+          `signal`,
+          `sigint-handler`,
+          `insert`,
+          { signal: `SIGINT`, status: `unhandled` },
+          { offset: `10_500` }
+        ),
+      ],
+      offset: `10_500`,
+    })
+    mockEntityOnBatch.current?.({
+      items: [
+        ev(
+          `inbox`,
+          `m-after-sigint`,
+          `insert`,
+          { payload: `should run in a later wake` },
+          { offset: `10_600` }
+        ),
+      ],
+      offset: `10_600`,
+    })
+
+    await signalAborted
+    await wakePromise
+
+    expect(wakePayloads).toEqual([undefined])
+    const doneCalls = fetchMock.mock.calls.filter(
+      ([url, opts]) =>
+        String(url).includes(`/_electric/wakes/wake-abc`) &&
+        (opts?.body as string | undefined)?.includes(`"done":true`)
+    )
+    const body = JSON.parse(doneCalls.at(-1)![1]!.body as string) as {
+      acks: Array<{ path: string; offset: string }>
+    }
+    expect(body.acks).toEqual([
+      { path: `/streams/entity:agent-1`, offset: `10_500` },
+    ])
+  })
+
   it(`waits for async signal handlers even when the main handler fails`, async () => {
     let handlerStartedResolve: (() => void) | null = null
     const handlerStarted = new Promise<void>((resolve) => {

--- a/packages/agents-runtime/test/process-wake.test.ts
+++ b/packages/agents-runtime/test/process-wake.test.ts
@@ -7,7 +7,7 @@ import {
   resolveWebhookSourceSubscription,
   type WebhookSourceContract,
 } from '../src/webhook-sources'
-import { manifestSourceKey } from '../src/manifest-helpers'
+import { manifestChildKey, manifestSourceKey } from '../src/manifest-helpers'
 import { db, pgSync } from '../src/observation-sources'
 import { processWake } from '../src/process-wake'
 import { clearRegistry, defineEntity } from '../src/define-entity'
@@ -1692,7 +1692,7 @@ describe(`processWake`, () => {
     expect(unregisterCalls).toHaveLength(1)
     expect(JSON.parse(unregisterCalls[0]![1]!.body as string)).toEqual({
       subscriberUrl: `http://localhost:3000/test-agent/agent-1`,
-      sourceUrl: `/child-worker/spawned-child`,
+      manifestKey: manifestChildKey(`child-worker`, `worker-1`),
     })
 
     const signalCalls = fetchMock.mock.calls.filter(

--- a/packages/agents-runtime/test/pull-wake-runner.test.ts
+++ b/packages/agents-runtime/test/pull-wake-runner.test.ts
@@ -84,6 +84,7 @@ async function waitFor(
 function runtime() {
   return {
     dispatchWake: vi.fn(),
+    isWakeActive: vi.fn(() => false),
     drainWakes: vi.fn(async () => undefined),
     abortWakes: vi.fn(),
   }
@@ -175,6 +176,106 @@ describe(`createPullWakeRunner`, () => {
 
     await runner.stop()
     expect(testRuntime.drainWakes).toHaveBeenCalledTimes(1)
+  })
+
+  it(`defers duplicate wake events while a stream is already being claimed`, async () => {
+    const event = wakeEvent(`one`)
+    const claimed = notification(`one`)
+    const claimResponse = deferred<Response>()
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        (_input: RequestInfo | URL) => claimResponse.promise
+      )
+      .mockImplementationOnce(async (_input: RequestInfo | URL) =>
+        Response.json(
+          {
+            error: {
+              code: `NO_PENDING_WORK`,
+              message: `Subscription has no pending work`,
+            },
+          },
+          { status: 409 }
+        )
+      )
+    vi.stubGlobal(`fetch`, fetchMock)
+    const testRuntime = runtime()
+    const streamFactory = vi.fn(async () => ({
+      offset: `42`,
+      async *jsonStream() {
+        yield event
+        yield event
+      },
+      closed: Promise.resolve(),
+    }))
+
+    const runner = createPullWakeRunner({
+      baseUrl: `http://server`,
+      runnerId: `runner-1`,
+      runtime: testRuntime,
+      heartbeatIntervalMs: 0,
+      streamFactory,
+    })
+
+    runner.start()
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    claimResponse.resolve(Response.json(claimed))
+    await waitFor(() => {
+      expect(testRuntime.dispatchWake).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+    expect(runner.getHealth().claims_skipped).toBe(2)
+
+    await runner.stop()
+  })
+
+  it(`retries a locally skipped wake after the active stream wake drains`, async () => {
+    const event = wakeEvent(`one`)
+    const claimed = notification(`one`)
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>
+      Response.json(claimed)
+    )
+    vi.stubGlobal(`fetch`, fetchMock)
+    let streamActive = true
+    const testRuntime = {
+      ...runtime(),
+      isWakeActive: vi.fn(() => streamActive),
+    }
+    const streamFactory = vi.fn(async () => ({
+      offset: `42`,
+      async *jsonStream() {
+        yield event
+      },
+      closed: Promise.resolve(),
+    }))
+
+    const runner = createPullWakeRunner({
+      baseUrl: `http://server`,
+      runnerId: `runner-1`,
+      runtime: testRuntime,
+      heartbeatIntervalMs: 0,
+      streamFactory,
+    })
+
+    runner.start()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    streamActive = false
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(testRuntime.dispatchWake).toHaveBeenCalledTimes(1)
+    })
+    expect(runner.getHealth().claims_skipped).toBe(1)
+
+    await runner.stop()
   })
 
   it(`skips stale wake events when claim returns no pending work`, async () => {

--- a/packages/agents-server/src/claim-write-token-store.ts
+++ b/packages/agents-server/src/claim-write-token-store.ts
@@ -7,26 +7,22 @@ interface ActiveClaimWriteToken {
 
 export class ClaimWriteTokenStore {
   private readonly claimsByStream = new Map<string, ActiveClaimWriteToken>()
-  private readonly streamByConsumer = new Map<string, string>()
+  private readonly streamKeysByConsumer = new Map<string, Set<string>>()
 
   mint(service: string, streamPath: string, consumerId: string): string {
     const streamKey = this.streamKey(service, streamPath)
     const consumerKey = this.consumerKey(service, consumerId)
     const previousClaimForStream = this.claimsByStream.get(streamKey)
     if (previousClaimForStream) {
-      this.streamByConsumer.delete(
-        this.consumerKey(service, previousClaimForStream.consumerId)
+      this.removeConsumerStream(
+        this.consumerKey(service, previousClaimForStream.consumerId),
+        streamKey
       )
-    }
-
-    const previousStreamForConsumer = this.streamByConsumer.get(consumerKey)
-    if (previousStreamForConsumer) {
-      this.claimsByStream.delete(previousStreamForConsumer)
     }
 
     const token = randomUUID()
     this.claimsByStream.set(streamKey, { token, consumerId })
-    this.streamByConsumer.set(consumerKey, streamKey)
+    this.addConsumerStream(consumerKey, streamKey)
     return token
   }
 
@@ -50,18 +46,40 @@ export class ClaimWriteTokenStore {
     if (!activeClaim) return
 
     this.claimsByStream.delete(streamKey)
-    this.streamByConsumer.delete(
-      this.consumerKey(service, activeClaim.consumerId)
+    this.removeConsumerStream(
+      this.consumerKey(service, activeClaim.consumerId),
+      streamKey
     )
   }
 
   clearConsumer(service: string, consumerId: string): void {
     const consumerKey = this.consumerKey(service, consumerId)
-    const streamKey = this.streamByConsumer.get(consumerKey)
-    if (!streamKey) return
+    const streamKeys = this.streamKeysByConsumer.get(consumerKey)
+    if (!streamKeys) return
 
-    this.streamByConsumer.delete(consumerKey)
-    this.claimsByStream.delete(streamKey)
+    this.streamKeysByConsumer.delete(consumerKey)
+    for (const streamKey of streamKeys) {
+      this.claimsByStream.delete(streamKey)
+    }
+  }
+
+  private addConsumerStream(consumerKey: string, streamKey: string): void {
+    let streamKeys = this.streamKeysByConsumer.get(consumerKey)
+    if (!streamKeys) {
+      streamKeys = new Set()
+      this.streamKeysByConsumer.set(consumerKey, streamKeys)
+    }
+    streamKeys.add(streamKey)
+  }
+
+  private removeConsumerStream(consumerKey: string, streamKey: string): void {
+    const streamKeys = this.streamKeysByConsumer.get(consumerKey)
+    if (!streamKeys) return
+
+    streamKeys.delete(streamKey)
+    if (streamKeys.size === 0) {
+      this.streamKeysByConsumer.delete(consumerKey)
+    }
   }
 
   private streamKey(service: string, streamPath: string): string {

--- a/packages/agents-server/src/routing/internal-router.ts
+++ b/packages/agents-server/src/routing/internal-router.ts
@@ -70,6 +70,12 @@ const wakeRegistrationBodySchema = Type.Object({
   manifestKey: Type.Optional(Type.String()),
 })
 
+const wakeUnregisterBodySchema = Type.Object({
+  subscriberUrl: Type.String(),
+  sourceUrl: Type.Optional(Type.String()),
+  manifestKey: Type.Optional(Type.String()),
+})
+
 const subscriptionWebhookBodySchema = Type.Object(
   {
     subscription_id: Type.Optional(Type.String()),
@@ -101,6 +107,7 @@ const wakeCallbackBodySchema = Type.Object(
 )
 
 type WakeRegistrationBody = Static<typeof wakeRegistrationBodySchema>
+type WakeUnregisterBody = Static<typeof wakeUnregisterBodySchema>
 type SubscriptionWebhookBody = Static<typeof subscriptionWebhookBodySchema>
 type WakeCallbackBody = Static<typeof wakeCallbackBodySchema>
 
@@ -126,6 +133,11 @@ internalRouter.post(
   `/wake`,
   withSchema(wakeRegistrationBodySchema),
   registerWake
+)
+internalRouter.post(
+  `/wake/unregister`,
+  withSchema(wakeUnregisterBodySchema),
+  unregisterWake
 )
 internalRouter.post(
   `/subscription-webhooks/:subscriptionId`,
@@ -364,6 +376,36 @@ async function registerWake(
   const opts = routeBody<WakeRegistrationBody>(request)
   await ctx.entityManager.registerWake(opts)
   return status(204)
+}
+
+async function unregisterWake(
+  request: IRequest,
+  ctx: TenantContext
+): Promise<Response> {
+  const opts = routeBody<WakeUnregisterBody>(request)
+  if (opts.sourceUrl !== undefined) {
+    await ctx.entityManager.wakeRegistry.unregisterBySubscriberAndSource(
+      opts.subscriberUrl,
+      opts.sourceUrl,
+      ctx.service
+    )
+    return status(204)
+  }
+
+  if (opts.manifestKey !== undefined) {
+    await ctx.entityManager.wakeRegistry.unregisterByManifestKey(
+      opts.subscriberUrl,
+      opts.manifestKey,
+      ctx.service
+    )
+    return status(204)
+  }
+
+  return apiError(
+    400,
+    `INVALID_WAKE_UNREGISTER`,
+    `sourceUrl or manifestKey is required`
+  )
 }
 
 async function listWebhookSources(

--- a/packages/agents-server/src/routing/internal-router.ts
+++ b/packages/agents-server/src/routing/internal-router.ts
@@ -808,21 +808,13 @@ async function wakeCallback(
       serverLog.info(
         `[wake-callback] done received for stream=${target.primaryStream} consumer=${consumerId}`
       )
-      const stillOwnsClaim = ctx.runtime.claimWriteTokens.owns(
-        ctx.service,
-        target.primaryStream,
-        consumerId
-      )
-      const entity = await ctx.entityManager.registry.getEntityByStream(
-        target.primaryStream
-      )
-
       // Release the consumer_claims row by its DB identity (consumerId,
       // epoch). The in-memory write token is a separate concern (write
       // authorization during the run); release of the durable row must
       // succeed even if the token was lost (server restart) or evicted
       // (a later wake re-minted for the same stream).
       let entityCleared = false
+      let releasedClaimStream = target.primaryStream
       if (epoch !== undefined) {
         const result =
           await ctx.entityManager.registry.materializeReleasedClaim?.({
@@ -843,7 +835,16 @@ async function wakeCallback(
               : undefined,
           })
         entityCleared = result?.entityCleared ?? false
+        releasedClaimStream = result?.claim?.stream_path ?? releasedClaimStream
       }
+
+      const stillOwnsClaim = ctx.runtime.claimWriteTokens.owns(
+        ctx.service,
+        releasedClaimStream,
+        consumerId
+      )
+      const entity =
+        await ctx.entityManager.registry.getEntityByStream(releasedClaimStream)
 
       // Transition entity back to idle when either signal says it's safe:
       // - entityCleared: our release just cleared the entity's active
@@ -865,7 +866,7 @@ async function wakeCallback(
         )
       } else if (!entity) {
         serverLog.warn(
-          `[wake-callback] done received but no entity found for stream=${target.primaryStream}`
+          `[wake-callback] done received but no entity found for stream=${releasedClaimStream}`
         )
       }
 
@@ -875,11 +876,11 @@ async function wakeCallback(
       if (stillOwnsClaim) {
         ctx.runtime.claimWriteTokens.clearStream(
           ctx.service,
-          target.primaryStream
+          releasedClaimStream
         )
       } else if (entity) {
         serverLog.info(
-          `[wake-callback] done arrived after in-memory token evicted (stream=${target.primaryStream} consumer=${consumerId})`
+          `[wake-callback] done arrived after in-memory token evicted (stream=${releasedClaimStream} consumer=${consumerId})`
         )
       }
     } else if (requestBody?.done === true) {

--- a/packages/agents-server/test/claim-write-token-store.test.ts
+++ b/packages/agents-server/test/claim-write-token-store.test.ts
@@ -15,16 +15,40 @@ describe(`ClaimWriteTokenStore`, () => {
     expect(store.isValid(`tenant-b`, streamPath, tenantBToken)).toBe(true)
   })
 
-  it(`replaces stale claims for the same stream or consumer`, () => {
+  it(`replaces stale claims for the same stream`, () => {
     const store = new ClaimWriteTokenStore()
 
     const firstToken = store.mint(`tenant-a`, `/one/main`, `wake-1`)
     const secondToken = store.mint(`tenant-a`, `/one/main`, `wake-2`)
-    const thirdToken = store.mint(`tenant-a`, `/two/main`, `wake-2`)
 
     expect(store.isValid(`tenant-a`, `/one/main`, firstToken)).toBe(false)
-    expect(store.isValid(`tenant-a`, `/one/main`, secondToken)).toBe(false)
-    expect(store.isValid(`tenant-a`, `/two/main`, thirdToken)).toBe(true)
-    expect(store.owns(`tenant-a`, `/two/main`, `wake-2`)).toBe(true)
+    expect(store.isValid(`tenant-a`, `/one/main`, secondToken)).toBe(true)
+    expect(store.owns(`tenant-a`, `/one/main`, `wake-2`)).toBe(true)
+  })
+
+  it(`allows one consumer to hold claims for multiple streams`, () => {
+    const store = new ClaimWriteTokenStore()
+
+    const firstToken = store.mint(`tenant-a`, `/one/main`, `runner-1`)
+    const secondToken = store.mint(`tenant-a`, `/two/main`, `runner-1`)
+
+    expect(store.isValid(`tenant-a`, `/one/main`, firstToken)).toBe(true)
+    expect(store.isValid(`tenant-a`, `/two/main`, secondToken)).toBe(true)
+    expect(store.owns(`tenant-a`, `/one/main`, `runner-1`)).toBe(true)
+    expect(store.owns(`tenant-a`, `/two/main`, `runner-1`)).toBe(true)
+  })
+
+  it(`clears all claims for a consumer`, () => {
+    const store = new ClaimWriteTokenStore()
+
+    const firstToken = store.mint(`tenant-a`, `/one/main`, `runner-1`)
+    const secondToken = store.mint(`tenant-a`, `/two/main`, `runner-1`)
+    const otherToken = store.mint(`tenant-a`, `/three/main`, `runner-2`)
+
+    store.clearConsumer(`tenant-a`, `runner-1`)
+
+    expect(store.isValid(`tenant-a`, `/one/main`, firstToken)).toBe(false)
+    expect(store.isValid(`tenant-a`, `/two/main`, secondToken)).toBe(false)
+    expect(store.isValid(`tenant-a`, `/three/main`, otherToken)).toBe(true)
   })
 })

--- a/packages/agents-server/test/subscription-webhooks-routing.test.ts
+++ b/packages/agents-server/test/subscription-webhooks-routing.test.ts
@@ -915,6 +915,100 @@ describe(`subscription webhooks for Durable Streams subscriptions`, () => {
       }
     })
 
+    it(`uses the released claim stream, not the mutable callback primaryStream, when one consumer owns multiple streams`, async () => {
+      const select = selectDb([
+        {
+          callbackUrl: `http://durable.local/v1/stream-meta/subscriptions/horton-handler/callback?opaque=tenant-a`,
+          // Simulate consumer_callbacks being updated by a later claim for stream B
+          // before the earlier stream A done callback is processed.
+          primaryStream: `/horton/demo-b/main`,
+        },
+      ])
+      upstreamOk()
+      const ctx = buildContext({
+        pgDb: { select: select.select } as any,
+      })
+      ;(ctx.entityManager.registry.getEntityByStream as any).mockImplementation(
+        async (stream: string) => ({
+          url:
+            stream === `/horton/demo-a/main`
+              ? `/horton/demo-a`
+              : `/horton/demo-b`,
+          type: `horton`,
+          status: `idle`,
+          streams: { main: stream },
+          tags: {},
+          spawn_args: {},
+          write_token: `write-token`,
+        })
+      )
+      ;(
+        ctx.entityManager.registry.materializeReleasedClaim as any
+      ).mockResolvedValue({
+        claim: {
+          consumer_id: `wake-1`,
+          epoch: 7,
+          entity_url: `/horton/demo-a`,
+          stream_path: `/horton/demo-a/main`,
+        },
+        entityCleared: true,
+      })
+
+      ctx.runtime.claimWriteTokens.mint(
+        `tenant-a`,
+        `/horton/demo-a/main`,
+        `wake-1`
+      )
+      ctx.runtime.claimWriteTokens.mint(
+        `tenant-a`,
+        `/horton/demo-b/main`,
+        `wake-1`
+      )
+
+      try {
+        const response = await globalRouter.fetch(
+          new Request(`http://agents.local/_electric/wake-callbacks/wake-1`, {
+            method: `POST`,
+            headers: {
+              'content-type': `application/json`,
+              authorization: `Bearer callback-token`,
+            },
+            body: JSON.stringify({
+              epoch: 7,
+              acks: [{ path: `/horton/demo-a/main`, offset: `1` }],
+              done: true,
+            }),
+          }),
+          ctx
+        )
+
+        expect(response.status).toBe(200)
+        expect(
+          ctx.entityManager.registry.getEntityByStream
+        ).toHaveBeenCalledWith(`/horton/demo-a/main`)
+        expect(ctx.entityManager.registry.updateStatus).toHaveBeenCalledWith(
+          `/horton/demo-a`,
+          `idle`
+        )
+        expect(
+          ctx.runtime.claimWriteTokens.owns(
+            `tenant-a`,
+            `/horton/demo-a/main`,
+            `wake-1`
+          )
+        ).toBe(false)
+        expect(
+          ctx.runtime.claimWriteTokens.owns(
+            `tenant-a`,
+            `/horton/demo-b/main`,
+            `wake-1`
+          )
+        ).toBe(true)
+      } finally {
+        vi.mocked(globalThis.fetch).mockRestore()
+      }
+    })
+
     it(`releases the consumer_claims row for the old consumer when a newer consumer has taken over the in-memory token, without disturbing the newer consumer's token or the entity status`, async () => {
       const select = selectDb([
         {

--- a/packages/agents-server/test/subscription-webhooks-routing.test.ts
+++ b/packages/agents-server/test/subscription-webhooks-routing.test.ts
@@ -162,10 +162,12 @@ function buildContext(overrides: Partial<TenantContext> = {}): TenantContext {
 describe(`subscription webhooks for Durable Streams subscriptions`, () => {
   it(`unregisters a parent wake registration without signaling the source entity`, async () => {
     const unregisterBySubscriberAndSource = vi.fn().mockResolvedValue(undefined)
+    const unregisterByManifestKey = vi.fn().mockResolvedValue(undefined)
     const ctx = buildContext({
       entityManager: {
         wakeRegistry: {
           unregisterBySubscriberAndSource,
+          unregisterByManifestKey,
         },
       } as any,
     })
@@ -184,6 +186,36 @@ describe(`subscription webhooks for Durable Streams subscriptions`, () => {
       `/worker/child`,
       `tenant-a`
     )
+    expect(unregisterByManifestKey).not.toHaveBeenCalled()
+  })
+
+  it(`unregisters a parent wake registration by manifest key`, async () => {
+    const unregisterBySubscriberAndSource = vi.fn().mockResolvedValue(undefined)
+    const unregisterByManifestKey = vi.fn().mockResolvedValue(undefined)
+    const ctx = buildContext({
+      entityManager: {
+        wakeRegistry: {
+          unregisterBySubscriberAndSource,
+          unregisterByManifestKey,
+        },
+      } as any,
+    })
+
+    const response = await globalRouter.fetch(
+      request(`POST`, `/_electric/wake/unregister`, {
+        subscriberUrl: `/horton/parent`,
+        manifestKey: `child:worker:child-1`,
+      }),
+      ctx
+    )
+
+    expect(response.status).toBe(204)
+    expect(unregisterByManifestKey).toHaveBeenCalledWith(
+      `/horton/parent`,
+      `child:worker:child-1`,
+      `tenant-a`
+    )
+    expect(unregisterBySubscriberAndSource).not.toHaveBeenCalled()
   })
 
   it(`validates upstream Durable Streams webhook signatures before dispatching`, async () => {

--- a/packages/agents-server/test/subscription-webhooks-routing.test.ts
+++ b/packages/agents-server/test/subscription-webhooks-routing.test.ts
@@ -160,6 +160,32 @@ function buildContext(overrides: Partial<TenantContext> = {}): TenantContext {
 }
 
 describe(`subscription webhooks for Durable Streams subscriptions`, () => {
+  it(`unregisters a parent wake registration without signaling the source entity`, async () => {
+    const unregisterBySubscriberAndSource = vi.fn().mockResolvedValue(undefined)
+    const ctx = buildContext({
+      entityManager: {
+        wakeRegistry: {
+          unregisterBySubscriberAndSource,
+        },
+      } as any,
+    })
+
+    const response = await globalRouter.fetch(
+      request(`POST`, `/_electric/wake/unregister`, {
+        subscriberUrl: `/horton/parent`,
+        sourceUrl: `/worker/child`,
+      }),
+      ctx
+    )
+
+    expect(response.status).toBe(204)
+    expect(unregisterBySubscriberAndSource).toHaveBeenCalledWith(
+      `/horton/parent`,
+      `/worker/child`,
+      `tenant-a`
+    )
+  })
+
   it(`validates upstream Durable Streams webhook signatures before dispatching`, async () => {
     const select = selectDb([
       { webhookUrl: `http://runtime.local/_electric/builtin-agent-handler` },


### PR DESCRIPTION
Fixes agent wake handling so concurrent desktop sessions no longer invalidate each other's claim write tokens, and same-stream duplicate wakes are retried after the active wake drains instead of being dropped.

This should stop the recent local desktop stall pattern where an unrelated wake or SIGINT caused another active session to start receiving `Invalid write token` 401s. It also narrows failed-parent child cleanup so a parent handler failure detaches the parent wake registration instead of sending `SIGKILL` to a child that may already be running.

## Root Cause

The claim write token store treated a consumer as owning at most one stream. When the same desktop runner/consumer claimed a wake for a second agent stream, it deleted the first stream's token, so the still-active wake failed later writes with `UNAUTHORIZED: Invalid write token`.

A second race existed for duplicate same-stream wake events. The runner could claim another wake for a stream while the previous wake was still active, minting a replacement token for that same stream. The first fix avoided concurrent same-stream claims, but review caught that a simple local skip could strand pending work if the skipped event was the only retry signal.

Separately, parent handler failure cleanup used `deleteEntity()` for children spawned before the failure. That client method actually sends semantic `SIGKILL`, which is too broad for rolling back a failed parent manifest entry.

## Approach

- Scope claim write tokens by stream, while keeping a reverse index so `clearConsumer()` still clears all streams owned by that consumer.
- Track active wake stream paths in the runtime router, and let the pull wake runner ask whether a stream is already in flight.
- Prevent concurrent claims for the same stream while a claim or wake is active.
- Defer locally skipped same-stream wake events and retry them after the active stream wake drains.
- Treat `SIGINT` of an active or just-starting run as a shutdown request, so the wake closes instead of returning to idle and immediately processing fresh input in the aborted invocation.
- Add a narrow internal wake unregister endpoint and use it to detach failed-parent child wake registrations without signaling the child entity.

## Key Invariants

- A consumer may hold claim write tokens for multiple streams at the same time.
- A stream has at most one active claim token at a time.
- A duplicate wake-stream event must not mint a replacement token while that stream is active.
- A locally skipped wake must be retried after the active wake drains so pending work is not stranded.
- `SIGINT` aborts the current handler and closes that wake; later work runs in a later wake.
- Failed parent cleanup may detach wake registrations created by that failed run, but must not terminate the child entity.

## Non-goals

- This does not change Durable Streams lease/heartbeat semantics.
- This does not rewrite the runtime as per-agent XState actors; it adds guardrails to the existing promise-based wake dispatch model.
- This does not remove the explicit public/legacy `SIGKILL` APIs; it stops using them for failed-parent child cleanup.

## Verification

```bash
pnpm --filter @electric-ax/agents-runtime exec vitest run test/pull-wake-runner.test.ts test/process-wake.test.ts --pool-options.threads.maxThreads=2
pnpm --filter @electric-ax/agents-server exec vitest run test/claim-write-token-store.test.ts test/subscription-webhooks-routing.test.ts --maxWorkers=2
pnpm --filter @electric-ax/agents-runtime typecheck
pnpm --filter @electric-ax/agents-server typecheck
GITHUB_BASE_REF=main node scripts/check-changeset.mjs
```

## Files Changed

- `packages/agents-server/src/claim-write-token-store.ts`: allow one consumer to hold multiple stream-scoped claim tokens.
- `packages/agents-runtime/src/create-handler.ts`: expose stream-path active wake tracking to the pull runner.
- `packages/agents-runtime/src/pull-wake-runner.ts`: prevent concurrent same-stream claims and defer/retry skipped active-stream wake events.
- `packages/agents-runtime/src/process-wake.ts`: close the wake after active-run `SIGINT` aborts, and detach child wake registrations on parent handler failure without killing children.
- `packages/agents-runtime/src/runtime-server-client.ts` and `packages/agents-server/src/routing/internal-router.ts`: add a narrow internal wake unregister call.
- Runtime and server tests: cover multi-stream consumers, same-stream duplicate deferral, retry after active wake drains, SIGINT wake closure, and failed-parent child wake detach.
- `.changeset/fix-agent-wake-claim-token-races.md`: patch changeset for the affected agents packages.