### PR TITLE
Delegate built-in reasoning to pi-ai

### DIFF
--- a/.changeset/anthropic-adaptive-thinking.md
+++ b/.changeset/anthropic-adaptive-thinking.md
@@ -1,11 +1,6 @@
 ---
 '@electric-ax/agents': patch
+'@electric-ax/agents-runtime': patch
 ---
 
-Use Anthropic's adaptive thinking API for models that require it (Opus 4.6/4.7,
-Sonnet 4.6). The builtin model catalog previously injected budget-based
-`thinking: { type: "enabled", budget_tokens }` for every reasoning-capable
-Anthropic model, which Opus 4.7 rejects with a 400 — it needs
-`thinking: { type: "adaptive" }` + `output_config.effort`. Those models now emit
-the adaptive shape (reasoningEffort mapped to the effort level); older models
-keep budget-based thinking.
+Delegate built-in reasoning configuration to pi-ai instead of rewriting provider request payloads in the model catalog. Built-in OpenAI, OpenAI Codex, and Anthropic reasoning models now pass `reasoning` through the runtime adapter, preserving the existing `auto` defaults and Anthropic thinking budgets while letting pi-ai own provider-specific payload shapes such as OpenAI reasoning summaries and Anthropic adaptive thinking.

--- a/.changeset/anthropic-adaptive-thinking.md
+++ b/.changeset/anthropic-adaptive-thinking.md
@@ -1,6 +1,11 @@
 ---
 '@electric-ax/agents': patch
-'@electric-ax/agents-runtime': patch
 ---
 
-Delegate built-in reasoning configuration to pi-ai instead of rewriting provider request payloads in the model catalog. Built-in OpenAI, OpenAI Codex, and Anthropic reasoning models now pass `reasoning` through the runtime adapter, preserving the existing `auto` defaults and Anthropic thinking budgets while letting pi-ai own provider-specific payload shapes such as OpenAI reasoning summaries and Anthropic adaptive thinking.
+Use Anthropic's adaptive thinking API for models that require it (Opus 4.6/4.7,
+Sonnet 4.6). The builtin model catalog previously injected budget-based
+`thinking: { type: "enabled", budget_tokens }` for every reasoning-capable
+Anthropic model, which Opus 4.7 rejects with a 400 — it needs
+`thinking: { type: "adaptive" }` + `output_config.effort`. Those models now emit
+the adaptive shape (reasoningEffort mapped to the effort level); older models
+keep budget-based thinking.

--- a/.changeset/delegate-reasoning-pi-ai.md
+++ b/.changeset/delegate-reasoning-pi-ai.md
@@ -1,0 +1,6 @@
+---
+'@electric-ax/agents': patch
+'@electric-ax/agents-runtime': patch
+---
+
+Delegate built-in reasoning configuration to pi-ai instead of rewriting provider request payloads in the model catalog. Built-in OpenAI, OpenAI Codex, and Anthropic reasoning models now pass `reasoning` through the runtime adapter, preserving existing `auto` defaults and Anthropic thinking budgets while letting pi-ai own provider-specific payload shapes.

--- a/packages/agents-runtime/src/context-factory.ts
+++ b/packages/agents-runtime/src/context-factory.ts
@@ -785,6 +785,9 @@ export function createHandlerContext<TState extends StateProxy = StateProxy>(
 
           getApiKey: activeAgentConfig.getApiKey,
 
+          reasoning: activeAgentConfig.reasoning,
+          thinkingBudgets: activeAgentConfig.thinkingBudgets,
+
           onPayload: activeAgentConfig.onPayload,
 
           onStepEnd: activeAgentConfig.onStepEnd,

--- a/packages/agents-runtime/src/pi-adapter.ts
+++ b/packages/agents-runtime/src/pi-adapter.ts
@@ -72,6 +72,8 @@ export interface PiAdapterOptions {
   getApiKey?: (
     provider: string
   ) => Promise<string | undefined> | string | undefined
+  reasoning?: SimpleStreamOptions[`reasoning`]
+  thinkingBudgets?: SimpleStreamOptions[`thinkingBudgets`]
   onPayload?: SimpleStreamOptions[`onPayload`]
   // Invoked after each step ends with the token counts reported by the
   // provider. Used by goal-budget enforcement to abort mid-run; see
@@ -281,6 +283,8 @@ export function createPiAgentAdapter(
     const streamFn: StreamFn = (streamModel, context, streamOptions) =>
       baseStreamFn(streamModel, context, {
         ...streamOptions,
+        ...(opts.reasoning && { reasoning: opts.reasoning }),
+        ...(opts.thinkingBudgets && { thinkingBudgets: opts.thinkingBudgets }),
         timeoutMs: modelTimeoutMs,
         maxRetries: modelMaxRetries,
       })

--- a/packages/agents-runtime/src/types.ts
+++ b/packages/agents-runtime/src/types.ts
@@ -959,6 +959,8 @@ export interface AgentConfig {
   getApiKey?: (
     provider: string
   ) => Promise<string | undefined> | string | undefined
+  reasoning?: SimpleStreamOptions[`reasoning`]
+  thinkingBudgets?: SimpleStreamOptions[`thinkingBudgets`]
   onPayload?: SimpleStreamOptions[`onPayload`]
   // Invoked after each step ends with the provider-reported token counts.
   // `input` is the full prompt volume (incl. prompt-cache reads/writes, as

--- a/packages/agents-runtime/test/pi-adapter.test.ts
+++ b/packages/agents-runtime/test/pi-adapter.test.ts
@@ -183,6 +183,71 @@ describe(`createPiAgentAdapter`, () => {
     expect(seenOptions).toEqual([{ timeoutMs: 1234, maxRetries: 2 }])
   })
 
+  it(`passes configured reasoning options to stream calls`, async () => {
+    const seenOptions: Array<{
+      reasoning?: string
+      thinkingBudgets?: unknown
+    }> = []
+    const completedMessage: AssistantMessage = {
+      role: `assistant`,
+      content: [{ type: `text`, text: `ok` }],
+      api: `anthropic-messages`,
+      provider: `anthropic`,
+      model: `claude-sonnet-4-5-20250929`,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason: `stop`,
+      timestamp: Date.now(),
+    }
+
+    const thinkingBudgets = {
+      minimal: 1024,
+      low: 2048,
+      medium: 8192,
+      high: 24576,
+    }
+    const factory = createPiAgentAdapter({
+      systemPrompt: `Test system prompt`,
+      model: `claude-sonnet-4-5-20250929`,
+      tools: [],
+      reasoning: `high`,
+      thinkingBudgets,
+      streamFn: (_model, _context, options) => {
+        seenOptions.push({
+          reasoning: options?.reasoning,
+          thinkingBudgets: options?.thinkingBudgets,
+        })
+        const stream = createAssistantMessageEventStream()
+        queueMicrotask(() => stream.end(completedMessage))
+        return stream
+      },
+    })
+
+    const handle = factory({
+      entityUrl: `test/entity-1`,
+      epoch: 1,
+      messages: [],
+      outboundIdSeed: { run: 0, step: 0, msg: 0, tc: 0, reasoning: 0 },
+      writeEvent: (_event: ChangeEvent) => {},
+    })
+
+    await handle.run(`hello`)
+
+    expect(seenOptions).toEqual([{ reasoning: `high`, thinkingBudgets }])
+  })
+
   it(`preserves existing stream options while injecting timeout and retry options`, async () => {
     let capturedSignal: AbortSignal | undefined
     const completedMessage: AssistantMessage = {

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -50,12 +50,13 @@ type ExplicitReasoningEffort = Exclude<BuiltinReasoningEffort, `auto`>
 
 export type BuiltinAgentModelConfig = Pick<
   AgentConfig,
-  `model` | `provider` | `onPayload` | `getApiKey`
+  | `model`
+  | `provider`
+  | `reasoning`
+  | `thinkingBudgets`
+  | `onPayload`
+  | `getApiKey`
 > & {
-  reasoningEffort?: ExplicitReasoningEffort
-}
-
-type PersistedModelConfig = Pick<AgentConfig, `model` | `provider`> & {
   reasoningEffort?: ExplicitReasoningEffort
 }
 
@@ -239,134 +240,34 @@ function filterChoicesByEnabledModels(
 }
 
 /**
- * Anthropic-specific budget mapping for `reasoningEffort`.
- *
- * Anthropic's `thinking.budget_tokens` is a hard cap on tokens spent
- * inside the thinking block before the model must commit to its
- * answer. Docs require ≥ 1024; we scale from there. Numbers tuned so
- * `medium` is the spot most "show your work" requests land, and
- * `high` covers tougher reasoning without uncapped spend.
- *
- * Keep in sync with provider doc updates — Anthropic has shifted the
- * minimum once already (older models capped lower).
+ * Keep the previous built-in Anthropic token budget tuning while delegating the
+ * provider-specific request shape to pi-ai. pi-ai only uses these budgets for
+ * older budget-based Anthropic thinking models; adaptive-thinking models ignore
+ * them and use the `reasoning` effort level directly.
  */
-const ANTHROPIC_THINKING_BUDGET_BY_EFFORT: Record<
-  ExplicitReasoningEffort,
-  number
-> = {
+const ANTHROPIC_THINKING_BUDGETS = {
   minimal: 1024,
   low: 2048,
   medium: 8192,
   high: 24576,
-}
+} satisfies NonNullable<AgentConfig[`thinkingBudgets`]>
 
-/**
- * Opus 4.6+/4.7 and Sonnet 4.6 use Anthropic's adaptive thinking API
- * (`thinking.type: "adaptive"` + `output_config.effort`); the older budget-based
- * `thinking.type: "enabled"` is rejected on Opus 4.7.
- */
-function isAdaptiveThinkingModel(modelId: string): boolean {
-  return /(opus-4[-.]6|opus-4[-.]7|sonnet-4[-.]6)/.test(modelId)
-}
-
-/** `reasoningEffort` → Anthropic adaptive `output_config.effort` level. */
-const ANTHROPIC_ADAPTIVE_EFFORT_BY_REASONING: Record<
-  ExplicitReasoningEffort,
-  string
-> = {
-  minimal: `low`,
-  low: `low`,
-  medium: `medium`,
-  high: `high`,
-}
-
-function withProviderPayloadDefaults(
-  config: PersistedModelConfig & { getApiKey?: AgentConfig[`getApiKey`] },
+function resolveBuiltinReasoning(
   choice: BuiltinModelChoice,
   reasoningEffort: ExplicitReasoningEffort | null
-): BuiltinAgentModelConfig {
-  if (!choice.reasoning) return config
-
-  if (choice.provider === `openai` || choice.provider === `openai-codex`) {
-    const defaultEffort = choice.provider === `openai-codex` ? `low` : `minimal`
-    const effort =
-      reasoningEffort === `minimal` && choice.provider === `openai-codex`
-        ? `low`
-        : (reasoningEffort ?? defaultEffort)
-
-    return {
-      ...config,
-      onPayload: (payload) => {
-        if (typeof payload !== `object` || payload === null) return undefined
-        const body = payload as Record<string, unknown>
-        const existingReasoning =
-          typeof body.reasoning === `object` && body.reasoning !== null
-            ? (body.reasoning as Record<string, unknown>)
-            : {}
-
-        return {
-          ...body,
-          reasoning: {
-            ...existingReasoning,
-            effort,
-          },
-        }
-      },
-    }
+): AgentConfig[`reasoning`] | undefined {
+  if (!choice.reasoning) return undefined
+  if (
+    choice.provider !== `openai` &&
+    choice.provider !== `openai-codex` &&
+    choice.provider !== `anthropic`
+  ) {
+    return undefined
   }
-
-  if (choice.provider === `anthropic`) {
-    // `auto` falls through to a `minimal` default, matching the OpenAI branch.
-    const effectiveEffort = reasoningEffort ?? `minimal`
-    // pi-ai writes `thinking: { type: "disabled" }` by default; we merge our
-    // enabled values last so they win.
-    const mergeThinking = (
-      body: Record<string, unknown>,
-      thinking: Record<string, unknown>,
-      extra?: Record<string, unknown>
-    ): Record<string, unknown> => {
-      const existing =
-        typeof body.thinking === `object` && body.thinking !== null
-          ? (body.thinking as Record<string, unknown>)
-          : {}
-      return { ...body, ...extra, thinking: { ...existing, ...thinking } }
-    }
-
-    if (isAdaptiveThinkingModel(String(config.model))) {
-      const effort = ANTHROPIC_ADAPTIVE_EFFORT_BY_REASONING[effectiveEffort]
-      return {
-        ...config,
-        onPayload: (payload) => {
-          if (typeof payload !== `object` || payload === null) return undefined
-          const body = payload as Record<string, unknown>
-          const existingOutputConfig =
-            typeof body.output_config === `object` &&
-            body.output_config !== null
-              ? (body.output_config as Record<string, unknown>)
-              : {}
-          return mergeThinking(
-            body,
-            { type: `adaptive` },
-            { output_config: { ...existingOutputConfig, effort } }
-          )
-        },
-      }
-    }
-
-    const budgetTokens = ANTHROPIC_THINKING_BUDGET_BY_EFFORT[effectiveEffort]
-    return {
-      ...config,
-      onPayload: (payload) => {
-        if (typeof payload !== `object` || payload === null) return undefined
-        return mergeThinking(payload as Record<string, unknown>, {
-          type: `enabled`,
-          budget_tokens: budgetTokens,
-        })
-      },
-    }
+  if (choice.provider === `openai-codex`) {
+    return reasoningEffort === `minimal` ? `low` : (reasoningEffort ?? `low`)
   }
-
-  return config
+  return reasoningEffort ?? `minimal`
 }
 
 function parseReasoningEffort(value: unknown): ExplicitReasoningEffort | null {
@@ -443,10 +344,16 @@ export function resolveBuiltinModelConfig(
       : undefined
 
   const choice = selected ?? catalog.defaultChoice
-  const config = {
+  const reasoning = resolveBuiltinReasoning(choice, reasoningEffort)
+  const config: BuiltinAgentModelConfig = {
     provider: choice.provider,
     model: choice.id,
     ...(reasoningEffort && { reasoningEffort }),
+    ...(reasoning && { reasoning }),
+    ...(choice.reasoning &&
+      choice.provider === `anthropic` && {
+        thinkingBudgets: ANTHROPIC_THINKING_BUDGETS,
+      }),
     ...(choice.provider === `openai-codex` && {
       getApiKey: () => readCodexAccessToken(),
     }),
@@ -455,7 +362,7 @@ export function resolveBuiltinModelConfig(
     }),
   }
 
-  return withProviderPayloadDefaults(config, choice, reasoningEffort)
+  return config
 }
 
 export function modelChoiceValues(

--- a/packages/agents/test/model-catalog.test.ts
+++ b/packages/agents/test/model-catalog.test.ts
@@ -117,17 +117,9 @@ describe(`model catalog`, () => {
     expect(config).toMatchObject({
       provider: `openai`,
       model: `gpt-5`,
+      reasoning: `minimal`,
     })
-    expect(config.onPayload).toBeTypeOf(`function`)
-
-    const payload = config.onPayload!(
-      { reasoning: { effort: `none` } },
-      {} as any
-    )
-
-    expect(payload).toEqual({
-      reasoning: { effort: `minimal` },
-    })
+    expect(config.onPayload).toBeUndefined()
   })
 
   it(`uses explicit reasoning effort for OpenAI reasoning models`, async () => {
@@ -138,18 +130,10 @@ describe(`model catalog`, () => {
     })
 
     expect(config.reasoningEffort).toBe(`high`)
-
-    const payload = config.onPayload!(
-      { reasoning: { effort: `none` } },
-      {} as any
-    )
-
-    expect(payload).toEqual({
-      reasoning: { effort: `high` },
-    })
+    expect(config.reasoning).toBe(`high`)
   })
 
-  it(`enables Anthropic adaptive thinking at low effort when reasoningEffort is auto`, async () => {
+  it(`enables Anthropic reasoning through pi-ai when reasoningEffort is auto`, async () => {
     process.env.ANTHROPIC_API_KEY = `test-anthropic-key`
     vi.stubGlobal(
       `fetch`,
@@ -170,43 +154,17 @@ describe(`model catalog`, () => {
       model: `anthropic:claude-sonnet-4-6`,
     })
 
-    expect(config.onPayload).toBeTypeOf(`function`)
-    expect(config.onPayload!({}, {} as any)).toEqual({
-      thinking: { type: `adaptive` },
-      output_config: { effort: `low` },
+    expect(config.onPayload).toBeUndefined()
+    expect(config.reasoning).toBe(`minimal`)
+    expect(config.thinkingBudgets).toEqual({
+      minimal: 1024,
+      low: 2048,
+      medium: 8192,
+      high: 24576,
     })
   })
 
-  it(`overrides a pre-existing thinking.type=disabled in the Anthropic payload`, async () => {
-    process.env.ANTHROPIC_API_KEY = `test-anthropic-key`
-    vi.stubGlobal(
-      `fetch`,
-      vi.fn(async (url: string) => {
-        if (String(url).includes(`api.anthropic.com`)) {
-          return {
-            ok: true,
-            status: 200,
-            json: async () => ({ data: [{ id: `claude-sonnet-4-6` }] }),
-          }
-        }
-        return { ok: false, status: 401, json: async () => ({}) }
-      })
-    )
-
-    const catalog = await createBuiltinModelCatalog()
-    const config = resolveBuiltinModelConfig(catalog!, {
-      model: `anthropic:claude-sonnet-4-6`,
-    })
-
-    expect(
-      config.onPayload!({ thinking: { type: `disabled` } }, {} as any)
-    ).toEqual({
-      thinking: { type: `adaptive` },
-      output_config: { effort: `low` },
-    })
-  })
-
-  it(`maps explicit reasoningEffort to the Anthropic adaptive effort level`, async () => {
+  it(`maps explicit Anthropic reasoningEffort to pi-ai reasoning`, async () => {
     process.env.ANTHROPIC_API_KEY = `test-anthropic-key`
     vi.stubGlobal(
       `fetch`,
@@ -228,10 +186,8 @@ describe(`model catalog`, () => {
       reasoningEffort: `high`,
     })
 
-    expect(config.onPayload!({}, {} as any)).toEqual({
-      thinking: { type: `adaptive` },
-      output_config: { effort: `high` },
-    })
+    expect(config.reasoningEffort).toBe(`high`)
+    expect(config.reasoning).toBe(`high`)
   })
 
   it(`does not expose providers whose keys are rejected`, async () => {


### PR DESCRIPTION
Delegate built-in reasoning configuration to pi-ai instead of rewriting provider request payloads in the model catalog. This preserves existing OpenAI/Codex/Anthropic reasoning defaults while letting pi-ai own provider-specific payload shapes like OpenAI reasoning summaries and Anthropic adaptive thinking.

## Root Cause

The built-in model catalog was using `onPayload` to manually mutate raw provider request bodies for reasoning models. That duplicated provider-specific behavior that pi-ai already implements, and made fixes like Anthropic adaptive thinking and OpenAI reasoning summaries easy to drift or conflict.

## Approach

- Add first-class `reasoning` and `thinkingBudgets` fields to `AgentConfig`.
- Pass those fields through `context-factory` into `createPiAgentAdapter`.
- Forward configured reasoning options into pi-ai stream calls.
- Remove built-in OpenAI/Codex/Anthropic reasoning payload rewriting from `model-catalog.ts`.
- Preserve existing user-facing defaults:
  - OpenAI auto → `minimal`
  - OpenAI Codex auto/minimal → `low`
  - Anthropic auto → `minimal`
  - Anthropic thinking budgets keep the previous tuned values, including `high: 24576`
- Keep `onPayload` available as an advanced escape hatch, but stop using it for built-in reasoning defaults.

## Key Invariants

- Built-in reasoning-capable OpenAI, OpenAI Codex, and Anthropic models still enable reasoning by default.
- DeepSeek/Kimi behavior is unchanged.
- OpenAI Codex still avoids unsupported `minimal` by mapping auto/minimal to `low`.
- Anthropic older budget-based models retain the existing token budget tuning.
- Anthropic adaptive-thinking models are delegated to pi-ai so they receive the correct adaptive payload shape.

## Non-goals

- Does not remove the public/runtime `onPayload` hook.
- Does not change model selection or provider availability detection.
- Does not attempt to add built-in reasoning defaults for every provider marked as reasoning-capable.
- Does not add real-provider integration tests in this PR.

## Trade-offs

The main alternative was to keep expanding catalog-level `onPayload` rewrites for each provider-specific reasoning behavior. Delegating to pi-ai is cleaner because pi-ai already tracks provider API details such as OpenAI reasoning summaries and Anthropic adaptive thinking. The trade-off is that Electric Agents now depends more directly on pi-ai’s `reasoning` option behavior, which is already the abstraction we use for provider streaming.

## Verification

```bash
pnpm --filter @electric-ax/agents-runtime exec vitest run test/pi-adapter.test.ts
pnpm --filter @electric-ax/agents exec vitest run test/model-catalog.test.ts
pnpm --filter @electric-ax/agents-runtime exec tsc --noEmit --pretty false
pnpm --filter @electric-ax/agents exec tsc --noEmit --pretty false
GITHUB_BASE_REF=main node scripts/check-changeset.mjs
```

All passed.

Recommended smoke coverage before merge, if provider credentials are available:

- OpenAI reasoning model, e.g. `gpt-5`
- OpenAI Codex model
- Anthropic older budget-based thinking model
- Anthropic adaptive-thinking model such as `claude-sonnet-4-6` or Opus 4.7

## Files changed

- `.changeset/delegate-reasoning-pi-ai.md`
  - Adds patch changeset coverage for `@electric-ax/agents` and `@electric-ax/agents-runtime`.
- `packages/agents-runtime/src/types.ts`
  - Adds `reasoning` and `thinkingBudgets` to `AgentConfig`.
- `packages/agents-runtime/src/context-factory.ts`
  - Passes configured reasoning options into the pi adapter.
- `packages/agents-runtime/src/pi-adapter.ts`
  - Forwards `reasoning` and `thinkingBudgets` into pi-ai stream calls.
- `packages/agents-runtime/test/pi-adapter.test.ts`
  - Adds coverage that configured reasoning options are passed to stream calls.
- `packages/agents/src/model-catalog.ts`
  - Removes built-in provider payload rewriting via `onPayload`.
  - Resolves built-in reasoning defaults into `AgentConfig.reasoning`.
  - Preserves Anthropic thinking budgets for pi-ai.
- `packages/agents/test/model-catalog.test.ts`
  - Updates expectations from raw payload mutation to delegated reasoning config.
