### PR TITLE
docs: remove stale other_children wake references

### DIFF
--- a/.changeset/remove-stale-other-children-docs.md
+++ b/.changeset/remove-stale-other-children-docs.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents': patch
+---
+
+Remove stale quickstart references to `other_children` wake payloads and describe coordinating child results via durable state and `finished_child` instead.

--- a/packages/agents/skills/quickstart.md
+++ b/packages/agents/skills/quickstart.md
@@ -56,7 +56,7 @@ The handler is **not** a long-running process. It wakes, does its work (usually 
 
 ### Spawning Children
 
-Any entity can spawn child entities. When a child finishes (and the parent registered `wake: { on: "runFinished", includeResponse: true }`), the parent's handler runs again. The wake event includes the child's response and the status of sibling children.
+Any entity can spawn child entities. When a child finishes (and the parent registered `wake: { on: "runFinished", includeResponse: true }`), the parent's handler runs again. The wake event includes the finished child's response. Track child URLs in entity state if you need to coordinate multiple children.
 
 ### The Worker Entity
 
@@ -289,7 +289,7 @@ export function registerPerspectives(registry: EntityRegistry) {
     state: { children: { primaryKey: 'key' } },
     async handler(ctx) {
       ctx.useAgent({
-        systemPrompt: `You are a balanced analyst.\n\n1. Call analyze_question with the question.\n2. Tell the user you are spawning an optimist and a critic to analyze their question and that you will synthesize their perspectives once they finish.\n3. End your turn immediately — say nothing else.\n\nYou will be woken once per worker that finishes. Each wake includes finished_child and other_children (with status "running" or "finished").\n\nCRITICAL: When woken, check other_children. If ANY child still has status "running", you MUST respond with ONLY the exact text "waiting" and nothing else — no commentary, no status updates, no emoji. Just the single word "waiting".\n\nOnly when ALL children show status "finished" should you synthesize a balanced response using both perspectives.`,
+        systemPrompt: `You are a balanced analyst.\n\n1. Call analyze_question with the question.\n2. Tell the user you are spawning an optimist and a critic to analyze their question and that you will synthesize their perspectives once they finish.\n3. End your turn immediately — say nothing else.\n\nYou will be woken once per worker that finishes. Each wake includes finished_child with that worker's result. Use the children state collection to know which workers were spawned and finished_child.url to identify which worker just finished.\n\nCRITICAL: When woken, check the children state collection. If you have not yet received results from every expected child, you MUST respond with ONLY the exact text "waiting" and nothing else — no commentary, no status updates, no emoji. Just the single word "waiting".\n\nOnly when you have results from ALL expected children should you synthesize a balanced response using both perspectives.`,
         model: 'claude-sonnet-4-6',
         tools: [...ctx.electricTools, createAnalyzeTool(ctx)],
       })

--- a/website/docs/agents/reference/built-in-collections.md
+++ b/website/docs/agents/reference/built-in-collections.md
@@ -168,7 +168,6 @@ interface WakeEntry {
   timeout: boolean
   changes: WakeChangeEntry[]
   finished_child?: WakeFinishedChildEntry
-  other_children?: WakeOtherChildEntry[]
 }
 
 interface WakeChangeEntry {
@@ -187,12 +186,6 @@ interface WakeFinishedChildEntry {
   run_status: "completed" | "failed"
   response?: string // concatenated text deltas from the finished run
   error?: string // error message(s) if run_status is "failed"
-}
-
-interface WakeOtherChildEntry {
-  url: string
-  type: string
-  status: "spawning" | "running" | "idle" | "paused" | "stopping" | "stopped" | "killed"
 }
 ```
 

--- a/website/docs/agents/reference/wake-event.md
+++ b/website/docs/agents/reference/wake-event.md
@@ -73,11 +73,6 @@ type WakeMessage = {
     response?: string
     error?: string
   }
-  other_children?: Array<{
-    url: string
-    type: string
-    status: "spawning" | "running" | "idle" | "paused" | "stopping" | "stopped" | "killed"
-  }>
 }
 ```
 

--- a/website/docs/agents/usage/waking-entities.md
+++ b/website/docs/agents/usage/waking-entities.md
@@ -141,7 +141,7 @@ Two wake types reach handlers directly:
 - `"inbox"` — an external message was delivered to this entity's inbox.
 - `"wake"` — a synthesised wake for anything else (child finished, collection change, cron, webhook source, timeout). The specifics are on `wake.payload`. A future-send schedule delivers a message, so it arrives as `"inbox"`.
 
-For the full payload shape (`changes[]`, `finished_child`, `other_children`, `timeout`), see the [wake-type catalog](../reference/wake-event#wake-type-catalog) in the reference.
+For the full payload shape (`changes[]`, `finished_child`, `timeout`), see the [wake-type catalog](../reference/wake-event#wake-type-catalog) in the reference.
 
 ## Coalescing and idempotency
 


### PR DESCRIPTION
## Summary
- remove stale docs that said runFinished wakes include other_children / sibling child statuses
- update the quickstart guidance to coordinate multiple children via state and finished_child
- remove other_children from the public wake payload docs

## Verification
- docs-only change; no automated tests run
- searched agents skills/docs for remaining other_children references