### PR TITLE
Refactor wake registry sync and fix child wake delivery

### DIFF
--- a/.changeset/fix-deferred-pull-wakes.md
+++ b/.changeset/fix-deferred-pull-wakes.md
@@ -3,6 +3,6 @@
 '@electric-ax/agents-server': patch
 ---
 
-Fix child wake delivery so multiple deferred wakes for the same entity stream are preserved.
+Fix child wake delivery so same-stream wake trigger notifications are queued while an active claim is already running, ensuring the runner checks for all pending wake rows again after the active work drains.
 
 Refactor the server wake registry to use TanStack DB collections and optimistic actions over `wake_registrations`, removing the manual ShapeStream-backed registration cache and stale-cache reload fallback.

--- a/.changeset/fix-deferred-pull-wakes.md
+++ b/.changeset/fix-deferred-pull-wakes.md
@@ -1,5 +1,6 @@
 ---
 '@electric-ax/agents-runtime': patch
+'@electric-ax/agents-server': patch
 ---
 
-Fix pull-wake delivery so multiple deferred wakes for the same entity stream are preserved and delivered instead of being overwritten while an earlier wake is still active.
+Fix child wake delivery so multiple deferred wakes for the same entity stream are preserved and runFinished wake evaluation recovers from a stale server-side registration cache.

--- a/.changeset/fix-deferred-pull-wakes.md
+++ b/.changeset/fix-deferred-pull-wakes.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-runtime': patch
+---
+
+Fix pull-wake delivery so multiple deferred wakes for the same entity stream are preserved and delivered instead of being overwritten while an earlier wake is still active.

--- a/.changeset/fix-deferred-pull-wakes.md
+++ b/.changeset/fix-deferred-pull-wakes.md
@@ -3,4 +3,6 @@
 '@electric-ax/agents-server': patch
 ---
 
-Fix child wake delivery so multiple deferred wakes for the same entity stream are preserved and runFinished wake evaluation recovers from a stale server-side registration cache.
+Fix child wake delivery so multiple deferred wakes for the same entity stream are preserved.
+
+Refactor the server wake registry to use TanStack DB collections and optimistic actions over `wake_registrations`, removing the manual ShapeStream-backed registration cache and stale-cache reload fallback.

--- a/docs/superpowers/plans/2026-06-19-wake-registry-tanstack-db.md
+++ b/docs/superpowers/plans/2026-06-19-wake-registry-tanstack-db.md
@@ -1,0 +1,1525 @@
+# Wake Registry TanStack DB Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `WakeRegistry`'s manual Postgres row cache and ShapeStream sync with TanStack DB collections, optimistic actions, `queryOnce`, and collection effects.
+
+**Architecture:** `WakeRegistry` will own one TanStack DB collection of `wake_registrations` rows. Runtime uses `electricCollectionOptions` over the Postgres table; unit tests use a local-only collection. All mutations go through `createOptimisticAction`; each action persists to Postgres in its `mutationFn`, then awaits the Electric collection txid. Evaluation reads with `queryOnce`, and timeout wake timers are driven by `createEffect` over collection rows.
+
+**Tech Stack:** TypeScript, Vitest, Drizzle ORM, Postgres, Electric `@electric-sql/client`, TanStack DB `@tanstack/db`, TanStack Electric collection `@tanstack/electric-db-collection`.
+
+## Global Constraints
+
+- Runtime requires Electric; there is no no-Electric Postgres fallback.
+- No `wake_registrations` schema migration.
+- No custom TanStack DB adapter.
+- No pull-wake runner changes.
+- No changes to persisted wake row payloads.
+- All public `WakeRegistry` mutations invoke optimistic actions.
+- Bulk unregister operations are one action per domain intent.
+- Wake evaluation uses `queryOnce` over the collection.
+- Timeout wake timers are driven by `createEffect` over collection rows.
+- `WakeRegistry` must not instantiate `Shape` or `ShapeStream` directly.
+- Before running package typecheck/tests in this worktree, run `pnpm install` from the repository root if workspace links are missing.
+
+---
+
+## File Structure
+
+- `packages/agents-server/package.json`
+  - Add runtime dependencies: `@tanstack/db` and `@tanstack/electric-db-collection`.
+- `packages/agents-server/src/wake-registry.ts`
+  - Main refactor. Owns TanStack DB collection, actions, query-based evaluation, and timeout effects.
+- `packages/agents-server/src/entity-manager.ts`
+  - Await async `wakeRegistry.evaluate(...)`, remove reload-on-miss fallback, and require `startSync(...)` for runtime startup.
+- `packages/agents-server/src/host.ts`
+  - Require `electricUrl` for host startup; remove `loadRegistrations()` fallback.
+- `packages/agents-server/src/standalone-runtime.ts`
+  - Keep passing Electric URL into `rebuildWakeRegistry(...)`; missing Electric URL should fail through `EntityManager.rebuildWakeRegistry(...)`.
+- `packages/agents-server/test/wake-registry.test.ts`
+  - Convert unit tests to local-only collection startup and async evaluation.
+- `packages/agents-server/test/wake-registry-sync.test.ts`
+  - Replace manual ShapeStream mock tests with Postgres + Electric collection integration tests or remove if covered elsewhere.
+- `packages/agents-server/test/server-start.test.ts`
+  - Update mocked `WakeRegistry` API and assert missing Electric URL fails when applicable.
+- `.changeset/fix-deferred-pull-wakes.md`
+  - Update if package dependencies/behavior summary changes.
+
+---
+
+### Task 1: Add TanStack DB Dependencies and Local Collection Foundation
+
+**Files:**
+
+- Modify: `packages/agents-server/package.json:46-67`
+- Modify: `packages/agents-server/src/wake-registry.ts:1-180`
+- Test: `packages/agents-server/test/wake-registry.test.ts:32-61`
+
+**Interfaces:**
+
+- Consumes: existing `WakeRegistration`, `WakeEvalResult`, `DrizzleDB`, `DEFAULT_TENANT_ID`.
+- Produces:
+  - `interface WakeRegistrationCollectionRow`
+  - `WakeRegistry.startLocalForTests(): Promise<void>`
+  - `WakeRegistry.evaluate(...): Promise<Array<WakeEvalResult>>`
+  - `WakeRegistry.requireCollection(): Collection<WakeRegistrationCollectionRow, number>`
+
+- [ ] **Step 1: Add dependencies**
+
+Add these dependencies to `packages/agents-server/package.json` under `dependencies`:
+
+```json
+"@tanstack/db": "^0.6.7",
+"@tanstack/electric-db-collection": "^0.3.5"
+```
+
+Run from repo root:
+
+```bash
+pnpm install
+```
+
+Expected: lockfile updates cleanly and package workspace links are materialized.
+
+- [ ] **Step 2: Write failing local-collection evaluation test**
+
+In `packages/agents-server/test/wake-registry.test.ts`, add this test near the first simple `Wake Registry` tests. This test intentionally uses a local collection helper that does not exist yet:
+
+```ts
+it(`evaluates registrations from local TanStack DB collection`, async () => {
+  const registry = new WakeRegistry(createMockDb())
+  await registry.startLocalForTests()
+
+  await registry.register({
+    subscriberUrl: `/parent/p1`,
+    sourceUrl: `/child/c1`,
+    condition: `runFinished`,
+    oneShot: false,
+  })
+
+  const results = await registry.evaluate(`/child/c1`, {
+    type: `run`,
+    key: `run-1`,
+    value: { status: `completed` },
+    headers: { operation: `update` },
+  })
+
+  expect(results).toHaveLength(1)
+  expect(results[0]!.subscriberUrl).toBe(`/parent/p1`)
+  expect(results[0]!.registrationDbId).toBe(1)
+  expect(results[0]!.sourceEventKey).toBe(`update:run-1`)
+})
+```
+
+- [ ] **Step 3: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @electric-ax/agents-server test test/wake-registry.test.ts -t "evaluates registrations from local TanStack DB collection" --run
+```
+
+Expected: FAIL with TypeScript/runtime error that `startLocalForTests` does not exist or `evaluate` is not awaitable yet.
+
+- [ ] **Step 4: Add collection foundation alongside the legacy runtime cache**
+
+Task 1 is an incremental local-only foundation. Keep the existing `registrationCache`, `ShapeStream`, `startSync(...)`, and runtime cache code in place until Task 4 removes them. In `packages/agents-server/src/wake-registry.ts`, add TanStack DB imports at the top while keeping imports that are still needed by the legacy runtime path:
+
+```ts
+import {
+  and as dbAnd,
+  createCollection,
+  createOptimisticAction,
+  eq as dbEq,
+  localOnlyCollectionOptions,
+  queryOnce,
+} from '@tanstack/db'
+import { and, eq } from 'drizzle-orm'
+import { wakeRegistrations } from './db/schema.js'
+import { DEFAULT_TENANT_ID } from './tenant.js'
+import type { Collection } from '@tanstack/db'
+import type { DrizzleDB } from './db/index.js'
+```
+
+Do not remove the existing `ShapeStream`, `serverLog`, `electricUrlWithPath`, `Row`, or `Value` imports in Task 1 if they are still used by the legacy runtime path. Task 4 removes manual ShapeStream runtime sync.
+
+Add this row type and local test state after `WakeDebounceCallback`:
+
+```ts
+interface WakeRegistrationCollectionRow {
+  id: number
+  tenantId: string
+  subscriberUrl: string
+  sourceUrl: string
+  condition: WakeRegistration[`condition`]
+  debounceMs: number
+  timeoutMs: number
+  oneShot: boolean
+  timeoutConsumed: boolean
+  includeResponse: boolean
+  manifestKey: string | null
+  createdAt: Date
+}
+
+type WakeRegistryMode = `unstarted` | `local-test` | `electric`
+```
+
+In `WakeRegistry`, add these fields next to the existing legacy cache/sync fields. Do not remove the old cache fields in Task 1 because the existing runtime `startSync(...)` path still uses them until Task 4.
+
+```ts
+private registrationsCollection: Collection<WakeRegistrationCollectionRow, number> | null = null
+private mode: WakeRegistryMode = `unstarted`
+private nextLocalId = 1
+```
+
+Add these helpers inside `WakeRegistry`:
+
+```ts
+private requireCollection(): Collection<WakeRegistrationCollectionRow, number> {
+  if (!this.registrationsCollection) {
+    throw new Error(`WakeRegistry has not been started`)
+  }
+  return this.registrationsCollection
+}
+
+async startLocalForTests(): Promise<void> {
+  if (this.registrationsCollection) return
+  this.mode = `local-test`
+  this.registrationsCollection = createCollection(
+    localOnlyCollectionOptions<WakeRegistrationCollectionRow>({
+      id: `wake-registrations-local:${this.tenantId ?? `all`}`,
+      getKey: (row) => row.id,
+      initialData: [],
+    })
+  )
+  await this.registrationsCollection.preload()
+}
+
+private allocateLocalId(): number {
+  return this.nextLocalId++
+}
+
+private normalizeRegistration(
+  reg: WakeRegistration,
+  tenantId: string,
+  id: number
+): WakeRegistrationCollectionRow {
+  return {
+    id,
+    tenantId,
+    subscriberUrl: reg.subscriberUrl,
+    sourceUrl: reg.sourceUrl,
+    condition: reg.condition,
+    debounceMs: reg.debounceMs ?? 0,
+    timeoutMs: reg.timeoutMs ?? 0,
+    oneShot: reg.oneShot,
+    timeoutConsumed: false,
+    includeResponse: reg.includeResponse !== false,
+    manifestKey: reg.manifestKey ?? null,
+    createdAt: new Date(),
+  }
+}
+```
+
+- [ ] **Step 5: Implement local register action and async queryOnce evaluation**
+
+Add this action field and initializer inside `WakeRegistry`. The local action is enough for this task; runtime persistence is added later.
+
+```ts
+private registerAction = createOptimisticAction<WakeRegistrationCollectionRow>({
+  onMutate: (row) => {
+    this.requireCollection().insert(row)
+  },
+  mutationFn: async () => {
+    if (this.mode === `local-test`) return
+    throw new Error(`WakeRegistry registerAction runtime persistence is not initialized`)
+  },
+})
+```
+
+Replace `register(reg: WakeRegistration): Promise<void>` with this minimal local implementation:
+
+```ts
+async register(reg: WakeRegistration): Promise<void> {
+  const tenantId = this.resolveTenantId(reg.tenantId)
+  const id = this.mode === `local-test` ? this.allocateLocalId() : this.allocateLocalId()
+  const tx = this.registerAction(this.normalizeRegistration(reg, tenantId, id))
+  await tx.isPersisted.promise
+}
+```
+
+Replace the start of `evaluate(...)` with an async collection query. Keep the existing matching/debounce/result code, but iterate over `regs` from `queryOnce` instead of the old `registrationCache` array:
+
+```ts
+async evaluate(
+  sourceUrl: string,
+  event: Record<string, unknown>,
+  tenantId?: string
+): Promise<Array<WakeEvalResult>> {
+  const resolvedTenantId = this.resolveTenantId(tenantId)
+  const regs = await queryOnce((q) =>
+    q
+      .from({ reg: this.requireCollection() })
+      .where(({ reg }) =>
+        dbAnd(dbEq(reg.tenantId, resolvedTenantId), dbEq(reg.sourceUrl, sourceUrl))
+      )
+  )
+  if (regs.length === 0) return []
+
+  const results: Array<WakeEvalResult> = []
+  const oneShotRows: Array<WakeRegistrationCollectionRow> = []
+
+  for (const reg of regs) {
+    const match = this.matchCondition(reg, event)
+    if (!match) continue
+
+    const timerKey = this.registrationKey(reg)
+    const timeoutTimer = this.timeoutTimers.get(timerKey)
+    if (timeoutTimer) {
+      clearTimeout(timeoutTimer)
+      this.timeoutTimers.delete(timerKey)
+      void this.markTimeoutConsumed(reg.id, reg.tenantId)
+    }
+
+    if (reg.debounceMs > 0) {
+      const buffer = this.debounceBuffers.get(timerKey) ?? []
+      buffer.push(match.change)
+      this.debounceBuffers.set(timerKey, buffer)
+      if (match.runFinishedStatus) {
+        this.debounceRunStatus.set(timerKey, match.runFinishedStatus)
+      }
+      const existing = this.debounceTimers.get(timerKey)
+      if (existing) clearTimeout(existing)
+      const timer = setTimeout(() => {
+        this.debounceTimers.delete(timerKey)
+        const flushed = this.debounceBuffers.get(timerKey)
+        if (flushed && flushed.length > 0) {
+          this.debounceBuffers.delete(timerKey)
+          const runStatus = this.debounceRunStatus.get(timerKey)
+          this.debounceRunStatus.delete(timerKey)
+          this.deliverDebounce({
+            tenantId: reg.tenantId,
+            subscriberUrl: reg.subscriberUrl,
+            registrationDbId: reg.id,
+            sourceEventKey: flushed[flushed.length - 1]!.key,
+            wakeMessage: {
+              source: sourceUrl,
+              timeout: false,
+              changes: flushed,
+            },
+            runFinishedStatus: runStatus,
+            includeResponse: reg.includeResponse,
+          })
+        }
+      }, reg.debounceMs)
+      this.debounceTimers.set(timerKey, timer)
+    } else {
+      results.push({
+        tenantId: reg.tenantId,
+        subscriberUrl: reg.subscriberUrl,
+        registrationDbId: reg.id,
+        sourceEventKey: wakeSourceEventId(event),
+        wakeMessage: {
+          source: sourceUrl,
+          timeout: false,
+          changes: [match.change],
+        },
+        runFinishedStatus: match.runFinishedStatus,
+        includeResponse: reg.includeResponse,
+      })
+    }
+
+    if (reg.oneShot) oneShotRows.push(reg)
+  }
+
+  for (const reg of oneShotRows) {
+    this.clearRegistrationState(reg)
+    this.timeoutDelivered.delete(reg.id)
+    this.requireCollection().delete(reg.id)
+  }
+
+  return results
+}
+```
+
+Update `registrationKey`, `clearRegistrationState`, `matchCondition`, and timeout helper parameter types from `CachedWakeRegistration` to `WakeRegistrationCollectionRow` where needed:
+
+```ts
+private registrationKey(reg: WakeRegistrationCollectionRow): string
+private clearRegistrationState(reg: WakeRegistrationCollectionRow): void
+private matchCondition(reg: WakeRegistrationCollectionRow, event: Record<string, unknown>): ...
+```
+
+- [ ] **Step 6: Run the focused test to verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @electric-ax/agents-server test test/wake-registry.test.ts -t "evaluates registrations from local TanStack DB collection" --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/agents-server/package.json pnpm-lock.yaml packages/agents-server/src/wake-registry.ts packages/agents-server/test/wake-registry.test.ts
+git commit -m "Introduce TanStack DB wake registry collection"
+```
+
+---
+
+### Task 2: Convert All Unit-Test Registry Mutations to Optimistic Actions
+
+**Files:**
+
+- Modify: `packages/agents-server/src/wake-registry.ts:298-530, 730-910`
+- Modify: `packages/agents-server/test/wake-registry.test.ts`
+
+**Interfaces:**
+
+- Consumes: `WakeRegistrationCollectionRow`, `WakeRegistry.requireCollection()`, async `WakeRegistry.evaluate(...)`.
+- Produces:
+  - `unregisterByManifestKeyAction`
+  - `unregisterBySubscriberAction`
+  - `unregisterBySourceAction`
+  - `unregisterBySubscriberAndSourceAction`
+  - `markTimeoutConsumedAction`
+  - `consumeMatchedRegistrationsAction`
+
+- [ ] **Step 1: Write failing tests for bulk unregister actions**
+
+Add these tests to `packages/agents-server/test/wake-registry.test.ts` near existing unregister tests:
+
+```ts
+it(`unregisterBySource removes all matching local collection rows`, async () => {
+  const registry = new WakeRegistry(createMockDb())
+  await registry.startLocalForTests()
+
+  await registry.register({
+    subscriberUrl: `/parent/a`,
+    sourceUrl: `/source/1`,
+    condition: { on: `change` },
+    oneShot: false,
+  })
+  await registry.register({
+    subscriberUrl: `/parent/b`,
+    sourceUrl: `/source/1`,
+    condition: { on: `change` },
+    oneShot: false,
+  })
+  await registry.register({
+    subscriberUrl: `/parent/c`,
+    sourceUrl: `/source/2`,
+    condition: { on: `change` },
+    oneShot: false,
+  })
+
+  await registry.unregisterBySource(`/source/1`)
+
+  expect(
+    await registry.evaluate(`/source/1`, {
+      type: `texts`,
+      key: `t1`,
+      value: {},
+      headers: { operation: `insert` },
+    })
+  ).toHaveLength(0)
+  expect(
+    await registry.evaluate(`/source/2`, {
+      type: `texts`,
+      key: `t2`,
+      value: {},
+      headers: { operation: `insert` },
+    })
+  ).toHaveLength(1)
+})
+
+it(`oneShot match removes row before a second immediate evaluation`, async () => {
+  const registry = new WakeRegistry(createMockDb())
+  await registry.startLocalForTests()
+
+  await registry.register({
+    subscriberUrl: `/parent/p1`,
+    sourceUrl: `/child/c1`,
+    condition: `runFinished`,
+    oneShot: true,
+  })
+
+  const event = {
+    type: `run`,
+    key: `run-1`,
+    value: { status: `completed` },
+    headers: { operation: `update` },
+  }
+
+  expect(await registry.evaluate(`/child/c1`, event)).toHaveLength(1)
+  expect(await registry.evaluate(`/child/c1`, event)).toHaveLength(0)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @electric-ax/agents-server test test/wake-registry.test.ts -t "unregisterBySource removes|oneShot match removes" --run
+```
+
+Expected: FAIL if unregisters or one-shot cleanup still use old cache/DB paths.
+
+- [ ] **Step 3: Add query helpers for matching rows**
+
+Add these helpers to `WakeRegistry`:
+
+```ts
+private async rowsByPredicate(
+  predicate: (row: WakeRegistrationCollectionRow) => boolean
+): Promise<Array<WakeRegistrationCollectionRow>> {
+  const rows = await queryOnce((q) => q.from({ reg: this.requireCollection() }))
+  return rows.filter(predicate)
+}
+
+private async rowsForSource(
+  tenantId: string,
+  sourceUrl: string
+): Promise<Array<WakeRegistrationCollectionRow>> {
+  return await queryOnce((q) =>
+    q
+      .from({ reg: this.requireCollection() })
+      .where(({ reg }) =>
+        dbAnd(dbEq(reg.tenantId, tenantId), dbEq(reg.sourceUrl, sourceUrl))
+      )
+  )
+}
+```
+
+This task may use `rowsByPredicate` for local actions because action `onMutate` must be synchronous. Capture the rows before invoking the action and pass their ids into the action input.
+
+- [ ] **Step 4: Implement unregister optimistic actions**
+
+Add action input types near `WakeRegistryMode`:
+
+```ts
+type DeleteRowsInput = {
+  rows: Array<WakeRegistrationCollectionRow>
+  persist:
+    | {
+        kind: `manifestKey`
+        tenantId: string
+        subscriberUrl: string
+        manifestKey: string
+      }
+    | {
+        kind: `subscriber`
+        tenantId: string
+        subscriberUrl: string
+      }
+    | {
+        kind: `source`
+        tenantId: string
+        sourceUrl: string
+      }
+    | {
+        kind: `subscriberAndSource`
+        tenantId: string
+        subscriberUrl: string
+        sourceUrl: string
+      }
+    | {
+        kind: `oneShot`
+      }
+}
+```
+
+Add one shared delete action:
+
+```ts
+private deleteRowsAction = createOptimisticAction<DeleteRowsInput>({
+  onMutate: ({ rows }) => {
+    const collection = this.requireCollection()
+    for (const row of rows) {
+      this.clearRegistrationState(row)
+      this.timeoutDelivered.delete(row.id)
+      collection.delete(row.id)
+    }
+  },
+  mutationFn: async ({ persist }) => {
+    if (this.mode === `local-test` || persist.kind === `oneShot`) return
+    throw new Error(`WakeRegistry deleteRowsAction runtime persistence is not initialized`)
+  },
+})
+```
+
+Replace unregister methods with wrappers that query rows, invoke the action, and await persistence:
+
+```ts
+async unregisterBySource(sourceUrl: string, tenantId?: string): Promise<void> {
+  const resolvedTenantId = this.resolveTenantId(tenantId)
+  const rows = await this.rowsForSource(resolvedTenantId, sourceUrl)
+  const tx = this.deleteRowsAction({
+    rows,
+    persist: { kind: `source`, tenantId: resolvedTenantId, sourceUrl },
+  })
+  await tx.isPersisted.promise
+}
+```
+
+Implement the other three unregister methods with the same pattern:
+
+```ts
+async unregisterBySubscriber(subscriberUrl: string, tenantId?: string): Promise<void> {
+  const resolvedTenantId = this.resolveTenantId(tenantId)
+  const rows = await this.rowsByPredicate(
+    (row) => row.tenantId === resolvedTenantId && row.subscriberUrl === subscriberUrl
+  )
+  const tx = this.deleteRowsAction({
+    rows,
+    persist: { kind: `subscriber`, tenantId: resolvedTenantId, subscriberUrl },
+  })
+  await tx.isPersisted.promise
+}
+
+async unregisterByManifestKey(
+  subscriberUrl: string,
+  manifestKey: string,
+  tenantId?: string
+): Promise<void> {
+  const resolvedTenantId = this.resolveTenantId(tenantId)
+  const rows = await this.rowsByPredicate(
+    (row) =>
+      row.tenantId === resolvedTenantId &&
+      row.subscriberUrl === subscriberUrl &&
+      row.manifestKey === manifestKey
+  )
+  const tx = this.deleteRowsAction({
+    rows,
+    persist: { kind: `manifestKey`, tenantId: resolvedTenantId, subscriberUrl, manifestKey },
+  })
+  await tx.isPersisted.promise
+}
+
+async unregisterBySubscriberAndSource(
+  subscriberUrl: string,
+  sourceUrl: string,
+  tenantId?: string
+): Promise<void> {
+  const resolvedTenantId = this.resolveTenantId(tenantId)
+  const rows = await this.rowsByPredicate(
+    (row) =>
+      row.tenantId === resolvedTenantId &&
+      row.subscriberUrl === subscriberUrl &&
+      row.sourceUrl === sourceUrl
+  )
+  const tx = this.deleteRowsAction({
+    rows,
+    persist: { kind: `subscriberAndSource`, tenantId: resolvedTenantId, subscriberUrl, sourceUrl },
+  })
+  await tx.isPersisted.promise
+}
+```
+
+- [ ] **Step 5: Implement mark-timeout-consumed action**
+
+Add this action:
+
+```ts
+private markTimeoutConsumedAction = createOptimisticAction<{
+  row: WakeRegistrationCollectionRow
+}>({
+  onMutate: ({ row }) => {
+    this.requireCollection().update(row.id, (draft) => {
+      draft.timeoutConsumed = true
+    })
+  },
+  mutationFn: async () => {
+    if (this.mode === `local-test`) return
+    throw new Error(`WakeRegistry markTimeoutConsumedAction runtime persistence is not initialized`)
+  },
+})
+```
+
+Replace `markTimeoutConsumed(dbId, tenantId)` with:
+
+```ts
+private async markTimeoutConsumed(dbId: number, tenantId: string): Promise<void> {
+  const row = await queryOnce((q) =>
+    q
+      .from({ reg: this.requireCollection() })
+      .where(({ reg }) => dbAnd(dbEq(reg.tenantId, tenantId), dbEq(reg.id, dbId)))
+      .findOne()
+  )
+  if (!row) return
+  const tx = this.markTimeoutConsumedAction({ row })
+  await tx.isPersisted.promise
+}
+```
+
+- [ ] **Step 6: Route one-shot cleanup through the shared action**
+
+In `evaluate(...)`, replace direct `collection.delete(...)` one-shot cleanup with:
+
+```ts
+if (oneShotRows.length > 0) {
+  const tx = this.deleteRowsAction({
+    rows: oneShotRows,
+    persist: { kind: `oneShot` },
+  })
+  void tx.isPersisted.promise.catch((error) => {
+    console.warn(`[wake-registry] failed to persist one-shot cleanup:`, error)
+  })
+}
+```
+
+- [ ] **Step 7: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @electric-ax/agents-server test test/wake-registry.test.ts -t "unregisterBySource removes|oneShot match removes|evaluates registrations from local" --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/agents-server/src/wake-registry.ts packages/agents-server/test/wake-registry.test.ts
+git commit -m "Move wake registry mutations to optimistic actions"
+```
+
+---
+
+### Task 3: Drive Timeout Wakes with TanStack DB Effects
+
+**Files:**
+
+- Modify: `packages/agents-server/src/wake-registry.ts:104-177, 562-728`
+- Modify: `packages/agents-server/test/wake-registry.test.ts`
+
+**Interfaces:**
+
+- Consumes: `WakeRegistrationCollectionRow`, local collection startup, optimistic timeout action.
+- Produces:
+  - `private registrationsEffect: { dispose(): Promise<void> } | null`
+  - `private startRegistrationEffect(): void`
+  - timeout timers synchronized from collection rows via `createEffect`
+
+- [ ] **Step 1: Write failing timeout effect tests**
+
+Add this test near existing timeout tests:
+
+```ts
+it(`timeout effect delivers timeout wake once and marks row consumed`, async () => {
+  const registry = new WakeRegistry(createMockDb())
+  await registry.startLocalForTests()
+  const delivered: Array<WakeEvalResult> = []
+  registry.setTimeoutCallback((result) => delivered.push(result))
+
+  await registry.register({
+    subscriberUrl: `/parent/p1`,
+    sourceUrl: `/child/c1`,
+    condition: `runFinished`,
+    oneShot: false,
+    timeoutMs: 25,
+  })
+
+  await new Promise((resolve) => setTimeout(resolve, 80))
+
+  expect(delivered).toHaveLength(1)
+  expect(delivered[0]!.wakeMessage.timeout).toBe(true)
+
+  await new Promise((resolve) => setTimeout(resolve, 80))
+  expect(delivered).toHaveLength(1)
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @electric-ax/agents-server test test/wake-registry.test.ts -t "timeout effect delivers" --run
+```
+
+Expected: FAIL until the collection effect starts timers from row enter/update events.
+
+- [ ] **Step 3: Import `createEffect` and add effect field**
+
+Update imports from `@tanstack/db`:
+
+```ts
+import {
+  and as dbAnd,
+  createCollection,
+  createEffect,
+  createOptimisticAction,
+  eq as dbEq,
+  localOnlyCollectionOptions,
+  queryOnce,
+} from '@tanstack/db'
+```
+
+Add field:
+
+```ts
+private registrationsEffect: { dispose(): Promise<void> } | null = null
+```
+
+- [ ] **Step 4: Start the effect after collection preload**
+
+Add this method:
+
+```ts
+private startRegistrationEffect(): void {
+  if (this.registrationsEffect) return
+  const collection = this.requireCollection()
+  this.registrationsEffect = createEffect({
+    query: (q) => q.from({ reg: collection }),
+    skipInitial: false,
+    onEnter: ({ value }) => {
+      this.syncTimeoutTimer(value)
+    },
+    onUpdate: ({ value }) => {
+      this.syncTimeoutTimer(value)
+    },
+    onExit: ({ value }) => {
+      this.clearRegistrationState(value)
+      this.timeoutDelivered.delete(value.id)
+    },
+  })
+}
+```
+
+Call it at the end of `startLocalForTests()` after `await this.registrationsCollection.preload()`:
+
+```ts
+this.startRegistrationEffect()
+```
+
+- [ ] **Step 5: Update timeout helpers to collection row type**
+
+Replace old timeout helper signatures with:
+
+```ts
+private startTimeoutTimer(reg: WakeRegistrationCollectionRow): void
+private startTimeoutTimerWithDuration(reg: WakeRegistrationCollectionRow, durationMs: number): void
+private syncTimeoutTimer(reg: WakeRegistrationCollectionRow): void
+private deliverTimeoutForRegistration(reg: WakeRegistrationCollectionRow): void
+private timeoutWakeResult(reg: WakeRegistrationCollectionRow): WakeEvalResult
+```
+
+Use `reg.id` instead of `dbId` inside these helpers. The key bodies should be:
+
+```ts
+private startTimeoutTimer(reg: WakeRegistrationCollectionRow): void {
+  if (reg.timeoutMs <= 0) return
+  this.startTimeoutTimerWithDuration(reg, reg.timeoutMs)
+}
+
+private startTimeoutTimerWithDuration(
+  reg: WakeRegistrationCollectionRow,
+  durationMs: number
+): void {
+  const timerKey = this.registrationKey(reg)
+  const timer = setTimeout(() => {
+    this.timeoutTimers.delete(timerKey)
+    this.deliverTimeoutForRegistration(reg)
+  }, durationMs)
+  this.timeoutTimers.set(timerKey, timer)
+}
+
+private syncTimeoutTimer(reg: WakeRegistrationCollectionRow): void {
+  const timerKey = this.registrationKey(reg)
+
+  if (reg.timeoutConsumed || reg.timeoutMs <= 0) {
+    this.clearTimeoutState(timerKey)
+    return
+  }
+
+  if (this.timeoutTimers.has(timerKey)) return
+
+  const remaining = reg.createdAt.getTime() + reg.timeoutMs - Date.now()
+  if (remaining > 0) {
+    this.startTimeoutTimerWithDuration(reg, remaining)
+    return
+  }
+
+  if (this.timeoutDelivered.has(reg.id)) return
+  this.deliverTimeoutForRegistration(reg)
+}
+
+private deliverTimeoutForRegistration(reg: WakeRegistrationCollectionRow): void {
+  if (this.deliverTimeout(this.timeoutWakeResult(reg))) {
+    this.timeoutDelivered.add(reg.id)
+    void this.markTimeoutConsumed(reg.id, reg.tenantId).catch((error) => {
+      console.warn(`[wake-registry] failed to mark timeout consumed:`, error)
+    })
+  }
+}
+
+private timeoutWakeResult(reg: WakeRegistrationCollectionRow): WakeEvalResult {
+  return {
+    tenantId: reg.tenantId,
+    subscriberUrl: reg.subscriberUrl,
+    registrationDbId: reg.id,
+    sourceEventKey: `timeout`,
+    wakeMessage: {
+      source: reg.sourceUrl,
+      timeout: true,
+      changes: [],
+    },
+  }
+}
+```
+
+- [ ] **Step 6: Stop effect and clear timers on shutdown**
+
+Replace `stopSync()` with a general cleanup that still keeps the public method name for current call sites:
+
+```ts
+async stopSync(): Promise<void> {
+  await this.registrationsEffect?.dispose()
+  this.registrationsEffect = null
+  this.registrationsCollection = null
+  this.mode = `unstarted`
+  this.resetRuntimeState()
+}
+
+private resetRuntimeState(): void {
+  for (const timer of this.debounceTimers.values()) clearTimeout(timer)
+  this.debounceTimers.clear()
+  this.debounceBuffers.clear()
+  this.debounceRunStatus.clear()
+  for (const timer of this.timeoutTimers.values()) clearTimeout(timer)
+  this.timeoutTimers.clear()
+  this.timeoutDelivered.clear()
+}
+```
+
+- [ ] **Step 7: Run timeout tests**
+
+Run:
+
+```bash
+pnpm --filter @electric-ax/agents-server test test/wake-registry.test.ts -t "timeout" --run
+```
+
+Expected: timeout tests PASS or fail only where assertions still assume old synchronous cache behavior.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/agents-server/src/wake-registry.ts packages/agents-server/test/wake-registry.test.ts
+git commit -m "Drive wake timeouts from registry collection effects"
+```
+
+---
+
+### Task 4: Implement Runtime Electric Collection and Postgres Txid Mutation Handlers
+
+**Files:**
+
+- Modify: `packages/agents-server/src/wake-registry.ts:1-360`
+- Test: `packages/agents-server/test/wake-registry-sync.test.ts`
+
+**Interfaces:**
+
+- Consumes: local collection/action architecture from Tasks 1-3.
+- Produces:
+  - Runtime `WakeRegistry.startSync(electricUrl, electricSecret?)`
+  - Electric collection with `snakeCamelMapper()`
+  - runtime `registerAction`, `deleteRowsAction`, `markTimeoutConsumedAction` persistence
+  - no direct `Shape` or `ShapeStream` usage in `WakeRegistry`
+
+- [ ] **Step 1: Write failing integration test for Electric-backed registry sync**
+
+Replace `packages/agents-server/test/wake-registry-sync.test.ts` with this integration test skeleton. It uses the existing managed test backend.
+
+```ts
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { createDb } from '../src/db'
+import { wakeRegistrations } from '../src/db/schema'
+import { WakeRegistry } from '../src/wake-registry'
+import {
+  TEST_ELECTRIC_URL,
+  TEST_POSTGRES_URL,
+  resetElectricAgentsTestBackend,
+} from './test-backend'
+
+const db = createDb(TEST_POSTGRES_URL)
+
+describe(`WakeRegistry Electric collection sync`, () => {
+  beforeAll(async () => {
+    await resetElectricAgentsTestBackend()
+  })
+
+  afterAll(async () => {
+    await db.end?.()
+  })
+
+  it(`syncs a registered wake through Postgres and Electric`, async () => {
+    const registry = new WakeRegistry(db as any)
+    await registry.startSync(TEST_ELECTRIC_URL)
+
+    await registry.register({
+      subscriberUrl: `/parent/p1`,
+      sourceUrl: `/child/c1`,
+      condition: `runFinished`,
+      oneShot: false,
+    })
+
+    const rows = await db
+      .select()
+      .from(wakeRegistrations)
+      .where(eq(wakeRegistrations.sourceUrl, `/child/c1`))
+
+    expect(rows).toHaveLength(1)
+
+    const results = await registry.evaluate(`/child/c1`, {
+      type: `run`,
+      key: `run-1`,
+      value: { status: `completed` },
+      headers: { operation: `update` },
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0]!.registrationDbId).toBe(rows[0]!.id)
+
+    await registry.stopSync()
+  })
+})
+```
+
+If `createDb(TEST_POSTGRES_URL)` does not expose `end`, remove the `afterAll` block and follow the existing DB helper pattern in nearby integration tests.
+
+- [ ] **Step 2: Run integration test to verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @electric-ax/agents-server test test/wake-registry-sync.test.ts --run
+```
+
+Expected: FAIL because `startSync` still uses manual ShapeStream or runtime actions do not persist and await Electric txids yet.
+
+- [ ] **Step 3: Import Electric collection and column mapper**
+
+Update imports in `wake-registry.ts`:
+
+```ts
+import { snakeCamelMapper } from '@electric-sql/client'
+import { electricCollectionOptions } from '@tanstack/electric-db-collection'
+import { sql } from 'drizzle-orm'
+import { electricUrlWithPath } from './utils/electric-url.js'
+import { serverLog } from './utils/log.js'
+```
+
+Keep Drizzle `and`/`eq` imports for mutation predicates:
+
+```ts
+import { and, eq, sql } from 'drizzle-orm'
+```
+
+- [ ] **Step 4: Implement sequence id allocation and txid helper**
+
+Add these helpers to `WakeRegistry`:
+
+```ts
+private async allocateRuntimeId(): Promise<number> {
+  const rows = await this.db.execute(sql<{ id: string }>`select nextval('wake_registrations_id_seq')::text as id`)
+  const value = Array.isArray(rows) ? rows[0]?.id : (rows as any)[0]?.id
+  const id = Number(value)
+  if (!Number.isInteger(id)) {
+    throw new Error(`Failed to allocate wake registration id`)
+  }
+  return id
+}
+
+private async currentTxid(): Promise<number> {
+  const rows = await this.db.execute(sql<{ txid: string }>`select pg_current_xact_id()::xid::text as txid`)
+  const value = Array.isArray(rows) ? rows[0]?.txid : (rows as any)[0]?.txid
+  const txid = Number(value)
+  if (!Number.isInteger(txid)) {
+    throw new Error(`Failed to read Postgres transaction id`)
+  }
+  return txid
+}
+```
+
+If `DrizzleDB.execute(...)` returns `{ rows }` rather than an array in this codebase, adapt the extraction to:
+
+```ts
+const result = await this.db.execute(...)
+const value = result.rows[0]?.txid
+```
+
+Use the actual shape observed by TypeScript/tests; keep the method returning `number`.
+
+- [ ] **Step 5: Implement Electric `startSync`**
+
+Replace old `startSync(...)` with an Electric collection that syncs rows but does not persist writes itself. Persistence belongs to the optimistic action `mutationFn` methods in later steps.
+
+```ts
+async startSync(electricUrl: string, electricSecret?: string): Promise<void> {
+  if (this.registrationsCollection) {
+    await this.registrationsCollection.preload()
+    return
+  }
+
+  this.mode = `electric`
+  this.registrationsCollection = createCollection(
+    electricCollectionOptions<WakeRegistrationCollectionRow>({
+      id: `wake-registrations:${this.tenantId ?? `all`}`,
+      getKey: (row) => row.id,
+      shapeOptions: {
+        url: electricUrlWithPath(electricUrl, `/v1/shape`).toString(),
+        params: {
+          table: `wake_registrations`,
+          ...(this.tenantId
+            ? { where: `tenant_id = ${sqlStringLiteral(this.tenantId)}` }
+            : {}),
+          ...(electricSecret ? { secret: electricSecret } : {}),
+          columns: [
+            `id`,
+            `tenant_id`,
+            `subscriber_url`,
+            `source_url`,
+            `condition`,
+            `debounce_ms`,
+            `timeout_ms`,
+            `one_shot`,
+            `timeout_consumed`,
+            `include_response`,
+            `manifest_key`,
+            `created_at`,
+          ],
+          replica: `full`,
+        },
+        parser: {
+          timestamptz: (value: string) => new Date(value),
+        },
+        columnMapper: snakeCamelMapper(),
+      },
+    })
+  )
+
+  await this.registrationsCollection.preload()
+  this.startRegistrationEffect()
+}
+```
+
+- [ ] **Step 6: Implement runtime persistence helpers**
+
+Add these helpers:
+
+```ts
+private async persistInsert(row: WakeRegistrationCollectionRow): Promise<number> {
+  const result = await this.db.transaction(async (tx) => {
+    await tx
+      .insert(wakeRegistrations)
+      .values({
+        id: row.id,
+        tenantId: row.tenantId,
+        subscriberUrl: row.subscriberUrl,
+        sourceUrl: row.sourceUrl,
+        condition: row.condition,
+        debounceMs: row.debounceMs,
+        timeoutMs: row.timeoutMs,
+        oneShot: row.oneShot,
+        timeoutConsumed: row.timeoutConsumed,
+        includeResponse: row.includeResponse,
+        manifestKey: row.manifestKey,
+        createdAt: row.createdAt,
+      })
+      .onConflictDoNothing()
+    const rows = await tx.execute(sql<{ txid: string }>`select pg_current_xact_id()::xid::text as txid`)
+    return Number(Array.isArray(rows) ? rows[0]!.txid : (rows as any)[0]!.txid)
+  })
+  return result
+}
+
+private async persistTimeoutConsumed(row: WakeRegistrationCollectionRow): Promise<number> {
+  return await this.db.transaction(async (tx) => {
+    await tx
+      .update(wakeRegistrations)
+      .set({ timeoutConsumed: row.timeoutConsumed })
+      .where(and(eq(wakeRegistrations.tenantId, row.tenantId), eq(wakeRegistrations.id, row.id)))
+    const rows = await tx.execute(sql<{ txid: string }>`select pg_current_xact_id()::xid::text as txid`)
+    return Number(Array.isArray(rows) ? rows[0]!.txid : (rows as any)[0]!.txid)
+  })
+}
+
+private async persistDeleteRows(rows: Array<WakeRegistrationCollectionRow>): Promise<number> {
+  return await this.db.transaction(async (tx) => {
+    for (const row of rows) {
+      await tx
+        .delete(wakeRegistrations)
+        .where(and(eq(wakeRegistrations.tenantId, row.tenantId), eq(wakeRegistrations.id, row.id)))
+    }
+    const txRows = await tx.execute(sql<{ txid: string }>`select pg_current_xact_id()::xid::text as txid`)
+    return Number(Array.isArray(txRows) ? txRows[0]!.txid : (txRows as any)[0]!.txid)
+  })
+}
+```
+
+If Drizzle's transaction type does not accept `.execute` in this form, follow the pattern already used in `packages/agents-server/src/entity-registry.ts` for `pg_current_xact_id()::xid::text`.
+
+- [ ] **Step 7: Wire runtime actions to persistence**
+
+Update `register(...)` to allocate runtime ids from Postgres:
+
+```ts
+async register(reg: WakeRegistration): Promise<void> {
+  const tenantId = this.resolveTenantId(reg.tenantId)
+  const id = this.mode === `electric` ? await this.allocateRuntimeId() : this.allocateLocalId()
+  const tx = this.registerAction(this.normalizeRegistration(reg, tenantId, id))
+  await tx.isPersisted.promise
+}
+```
+
+Update `registerAction.mutationFn` so the action persists once, then waits for Electric to sync that txid into the collection:
+
+```ts
+mutationFn: async (row) => {
+  if (this.mode === `local-test`) return
+  if (this.mode === `electric`) {
+    const txid = await this.persistInsert(row)
+    await this.requireCollection().utils.awaitTxId(txid, 10_000)
+    return { txid }
+  }
+  throw new Error(`WakeRegistry registerAction called before startup`)
+}
+```
+
+Update `deleteRowsAction.mutationFn`:
+
+```ts
+mutationFn: async ({ rows }) => {
+  if (this.mode === `local-test`) return
+  if (this.mode === `electric`) {
+    const txid = await this.persistDeleteRows(rows)
+    await this.requireCollection().utils.awaitTxId(txid, 10_000)
+    return { txid }
+  }
+  throw new Error(`WakeRegistry deleteRowsAction called before startup`)
+}
+```
+
+Update `markTimeoutConsumedAction.mutationFn`:
+
+```ts
+mutationFn: async ({ row }) => {
+  if (this.mode === `local-test`) return
+  if (this.mode === `electric`) {
+    const txid = await this.persistTimeoutConsumed({
+      ...row,
+      timeoutConsumed: true,
+    })
+    await this.requireCollection().utils.awaitTxId(txid, 10_000)
+    return { txid }
+  }
+  throw new Error(
+    `WakeRegistry markTimeoutConsumedAction called before startup`
+  )
+}
+```
+
+- [ ] **Step 8: Remove manual Shape code**
+
+Delete these obsolete items from `wake-registry.ts`:
+
+```ts
+interface WakeRegistrationShapeRow ...
+normalizeShapeRow(...)
+shapeRowMatchesRegistration(...)
+waitForRegistrationInShape(...)
+recoverSync(...)
+loadRegistrations(...)
+replaceCachedRegistrations(...)
+upsertCachedRegistration(...)
+removeCachedRegistrationByDbId(...)
+findCachedRegistration(...)
+resetCachedRegistrations(...)
+```
+
+Also remove all direct imports/usages of `Shape`, `ShapeStream`, `Row`, and `Value`.
+
+- [ ] **Step 9: Run sync integration test**
+
+Run:
+
+```bash
+pnpm --filter @electric-ax/agents-server test test/wake-registry-sync.test.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/agents-server/src/wake-registry.ts packages/agents-server/test/wake-registry-sync.test.ts
+git commit -m "Use Electric collection for wake registrations"
+```
+
+---
+
+### Task 5: Update EntityManager, Host Startup, and Async Evaluation Call Sites
+
+**Files:**
+
+- Modify: `packages/agents-server/src/entity-manager.ts:430-440, 3291-3310`
+- Modify: `packages/agents-server/src/host.ts:111-120`
+- Modify: `packages/agents-server/src/standalone-runtime.ts:151-157`
+- Modify: `packages/agents-server/test/server-start.test.ts`
+- Modify: `packages/agents-server/test/wake-registry.test.ts`
+
+**Interfaces:**
+
+- Consumes: async `WakeRegistry.evaluate(...)`, `WakeRegistry.startSync(...)`, removed `loadRegistrations()`.
+- Produces: runtime startup fails without Electric URL, no reload-on-miss fallback, all tests await evaluation.
+
+- [ ] **Step 1: Write failing startup test for missing Electric URL**
+
+In `packages/agents-server/test/server-start.test.ts`, update or add a test with this assertion:
+
+```ts
+it(`fails host startup without Electric URL for wake registry sync`, async () => {
+  const host = createTestHost({ electricUrl: undefined })
+
+  await expect(host.start()).rejects.toThrow(
+    `WakeRegistry runtime requires an Electric URL`
+  )
+})
+```
+
+If `createTestHost` does not exist, follow the existing host construction helper in this file and assert the same error around `host.start()`.
+
+- [ ] **Step 2: Run startup test to verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @electric-ax/agents-server test test/server-start.test.ts -t "fails host startup without Electric URL" --run
+```
+
+Expected: FAIL because host still calls `loadRegistrations()` or the test helper needs updating.
+
+- [ ] **Step 3: Update `EntityManager.rebuildWakeRegistry`**
+
+Replace `rebuildWakeRegistry(...)` in `packages/agents-server/src/entity-manager.ts` with:
+
+```ts
+async rebuildWakeRegistry(
+  electricUrl?: string,
+  electricSecret?: string
+): Promise<void> {
+  if (!electricUrl) {
+    throw new Error(`WakeRegistry runtime requires an Electric URL`)
+  }
+  await this.wakeRegistry.startSync(electricUrl, electricSecret)
+}
+```
+
+- [ ] **Step 4: Await async registry evaluation and remove reload-on-miss workaround**
+
+In `evaluateWakes(...)`, replace:
+
+```ts
+const results = this.wakeRegistry.evaluate(sourceUrl, event, this.tenantId)
+```
+
+with:
+
+```ts
+const results = await this.wakeRegistry.evaluate(
+  sourceUrl,
+  event,
+  this.tenantId
+)
+```
+
+Ensure no code remains that calls `wakeRegistry.loadRegistrations()` or retries `evaluate(...)` after a miss.
+
+- [ ] **Step 5: Update `AgentsHost.start`**
+
+Replace the wake registry startup block in `packages/agents-server/src/host.ts` with:
+
+```ts
+if (!this.electricUrl) {
+  throw new Error(`WakeRegistry runtime requires an Electric URL`)
+}
+await this.wakeRegistry.startSync(this.electricUrl, this.electricSecret)
+```
+
+- [ ] **Step 6: Update test mocks**
+
+In `packages/agents-server/test/server-start.test.ts`, remove mocked `loadRegistrations()` from `MockWakeRegistry`. Keep:
+
+```ts
+startSync(): Promise<void> {
+  return Promise.resolve()
+}
+```
+
+If tests need a local-only registry, use `startLocalForTests()` directly in wake registry unit tests, not host startup tests.
+
+- [ ] **Step 7: Convert direct unit-test evaluations to await**
+
+In `packages/agents-server/test/wake-registry.test.ts`, replace patterns like:
+
+```ts
+const results = registry.evaluate(`/child/c1`, event)
+```
+
+with:
+
+```ts
+const results = await registry.evaluate(`/child/c1`, event)
+```
+
+For inline assertions, replace:
+
+```ts
+expect(registry.evaluate(`/child/c1`, event)).toHaveLength(1)
+```
+
+with:
+
+```ts
+await expect(registry.evaluate(`/child/c1`, event)).resolves.toHaveLength(1)
+```
+
+- [ ] **Step 8: Run affected tests**
+
+Run:
+
+```bash
+pnpm --filter @electric-ax/agents-server test test/server-start.test.ts test/wake-registry.test.ts --run
+```
+
+Expected: PASS or only failures from tests still asserting deleted manual Shape/cache behavior.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/agents-server/src/entity-manager.ts packages/agents-server/src/host.ts packages/agents-server/src/standalone-runtime.ts packages/agents-server/test/server-start.test.ts packages/agents-server/test/wake-registry.test.ts
+git commit -m "Require Electric for wake registry runtime"
+```
+
+---
+
+### Task 6: Remove Obsolete Manual Cache Tests and Verify Full Wake Registry Behavior
+
+**Files:**
+
+- Modify: `packages/agents-server/test/wake-registry.test.ts`
+- Modify: `packages/agents-server/test/wake-registry-sync.test.ts`
+- Modify: `.changeset/fix-deferred-pull-wakes.md`
+
+**Interfaces:**
+
+- Consumes: completed TanStack DB-backed registry and async call sites.
+- Produces: passing targeted test suite and updated changeset summary.
+
+- [ ] **Step 1: Delete obsolete manual Shape/cache tests**
+
+Remove tests whose only subject is deleted internals:
+
+```ts
+it(`removes cached registrations from shape delete old_value ids`, ...)
+it(`ignores malformed shape messages without headers while waiting for up-to-date`, ...)
+it(`hydrates and updates the cache from shape changes`, ...)
+it(`reloads wake registrations ... cache miss`, ...)
+```
+
+Do not delete behavior tests for tenant scoping, wake matching, debounce, timeout, one-shot, unregister, or end-to-end wake delivery.
+
+- [ ] **Step 2: Ensure every unit test starts local registry explicitly**
+
+For every unit test that creates `new WakeRegistry(createMockDb())`, add:
+
+```ts
+await registry.startLocalForTests()
+```
+
+before `register(...)` or `evaluate(...)`.
+
+Do not add `startLocalForTests()` to integration tests that use `ElectricAgentsServer`, `EntityManager`, or real `TEST_ELECTRIC_URL`; those should exercise runtime `startSync(...)`.
+
+- [ ] **Step 3: Run all wake registry tests**
+
+Run:
+
+```bash
+pnpm --filter @electric-ax/agents-server test test/wake-registry.test.ts test/wake-registry-sync.test.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run broader affected agent-server tests**
+
+Run:
+
+```bash
+pnpm --filter @electric-ax/agents-server test test/server-start.test.ts test/horton-pull-wake-e2e.test.ts test/pg-sync-wake-delivery.test.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+Run:
+
+```bash
+pnpm --filter @electric-ax/agents-server typecheck
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 6: Update changeset**
+
+Edit `.changeset/fix-deferred-pull-wakes.md` so the `@electric-ax/agents-server` entry mentions the TanStack DB registry refactor. Keep the existing runtime changeset text for `@electric-ax/agents-runtime` intact.
+
+Use wording like:
+
+```md
+Refactor the server wake registry to use TanStack DB collections and optimistic actions over `wake_registrations`, removing the manual ShapeStream-backed registration cache and stale-cache reload fallback.
+```
+
+- [ ] **Step 7: Validate changeset coverage**
+
+Run:
+
+```bash
+GITHUB_BASE_REF=main node scripts/check-changeset.mjs
+```
+
+Expected: success message that changesets cover affected packages.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/agents-server/test/wake-registry.test.ts packages/agents-server/test/wake-registry-sync.test.ts .changeset/fix-deferred-pull-wakes.md
+git commit -m "Verify TanStack DB wake registry behavior"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Collection as only in-memory state: Tasks 1, 4, 6 remove `registrationCache`, `Shape`, and Shape tests.
+- Runtime Electric collection: Task 4.
+- Unit-test local-only collection: Tasks 1, 2, 6.
+- Optimistic actions for all mutations: Task 2 and runtime persistence in Task 4.
+- `queryOnce` evaluation: Task 1, call sites in Task 5.
+- `createEffect` timeout side effects: Task 3.
+- Remove reload-on-miss and `loadRegistrations()`: Tasks 4 and 5.
+- Tests and verification: Tasks 1-6 include red/green commands and final typecheck.
+
+**Placeholder scan:** No `TBD`, `TODO`, `implement later`, or `similar to Task N` placeholders remain. The one conditional instruction about Drizzle execute shape gives exact fallback code paths and a required return type.
+
+**Type consistency:** The plan consistently uses `WakeRegistrationCollectionRow.id: number` as the TanStack DB key, `WakeRegistry.startLocalForTests()`, async `WakeRegistry.evaluate(...)`, and shared optimistic actions. Later tasks consume names introduced in earlier tasks.

--- a/docs/superpowers/specs/2026-03-23-wake-registry-tanstack-db-design.md
+++ b/docs/superpowers/specs/2026-03-23-wake-registry-tanstack-db-design.md
@@ -1,0 +1,370 @@
+# Wake Registry TanStack DB Design
+
+## Context
+
+The current child wake delivery fix compensates for stale or incomplete wake registry state by reloading `wake_registrations` from Postgres when `runFinished` evaluation misses the in-memory cache. That fixes one symptom, but the underlying architecture still has two flawed state paths:
+
+1. Tests imperatively manage an in-memory cache.
+2. Runtime manually syncs a Postgres table into that cache with `Shape` / `ShapeStream`.
+
+The desired replacement is to use TanStack DB as the wake registry state engine.
+
+## Goals
+
+- Make TanStack DB collection state the only in-memory source of wake registration rows.
+- Use an Electric-backed collection in runtime so Postgres changes sync through Electric.
+- Use a local-only collection only in unit tests.
+- Use optimistic actions for every wake registry mutation.
+- Use `queryOnce` for one-shot evaluation reads.
+- Use `createEffect` for wake timeout timer side effects.
+- Remove manual Shape subscription/cache code and the reload-on-miss workaround.
+
+## Non-goals
+
+- No `wake_registrations` schema migration.
+- No custom TanStack DB adapter.
+- No pull-wake runner changes.
+- No changes to persisted wake row payloads.
+- No broad `EntityManager` refactor beyond async wake evaluation call sites.
+
+## Architecture
+
+`WakeRegistry` owns one TanStack DB collection and one effect handle:
+
+```ts
+private registrationsCollection: Collection<WakeRegistrationCollectionRow> | null
+private registrationsEffect: { dispose(): Promise<void> } | null
+```
+
+It no longer owns an authoritative `registrationCache`, `Shape`, `ShapeStream`, shape unsubscribe callback, or shape recovery promise.
+
+The existing runtime delivery state remains in `WakeRegistry` because it is not registration row state:
+
+- debounce timers
+- debounce buffers
+- latest debounced run status
+- timeout timers
+- timeout-delivered tracking
+- timeout/debounce callbacks
+
+### Collection row shape
+
+Use camelCase fields internally:
+
+```ts
+type WakeRegistrationCollectionRow = {
+  id: number
+  tenantId: string
+  subscriberUrl: string
+  sourceUrl: string
+  condition: WakeRegistration['condition']
+  debounceMs: number
+  timeoutMs: number
+  oneShot: boolean
+  timeoutConsumed: boolean
+  includeResponse: boolean
+  manifestKey: string | null
+  createdAt: Date
+}
+```
+
+`id` is both the TanStack DB collection key and the Postgres `wake_registrations.id`. Persisted rows already have a unique serial id, so the collection should use it directly rather than inventing a separate deterministic key.
+
+For newly registered rows, the action input must include an id before `onMutate` runs, because optimistic actions apply collection changes synchronously. Runtime can preallocate the id from the Postgres sequence and then insert with that explicit id in the action `mutationFn`. Local-only tests can allocate ids from an in-memory counter.
+
+## Runtime collection
+
+`startSync(electricUrl, electricSecret)` creates an Electric collection over `wake_registrations`:
+
+```ts
+createCollection(
+  electricCollectionOptions({
+    id: `wake-registrations:${tenantId ?? 'all'}`,
+    getKey: (row) => row.id,
+    schema,
+    shapeOptions: {
+      url: electricUrlWithPath(electricUrl, '/v1/shape').toString(),
+      params: {
+        table: 'wake_registrations',
+        ...(tenantId
+          ? { where: `tenant_id = ${sqlStringLiteral(tenantId)}` }
+          : {}),
+        columns: [
+          'id',
+          'tenant_id',
+          'subscriber_url',
+          'source_url',
+          'condition',
+          'debounce_ms',
+          'timeout_ms',
+          'one_shot',
+          'timeout_consumed',
+          'include_response',
+          'manifest_key',
+          'created_at',
+        ],
+        replica: 'full',
+        ...(electricSecret ? { secret: electricSecret } : {}),
+      },
+      parser: {
+        timestamptz: (value: string) => new Date(value),
+      },
+      columnMapper: snakeCamelMapper(),
+    },
+    onInsert,
+    onUpdate,
+    onDelete,
+  })
+)
+```
+
+Use Electric's built-in `snakeCamelMapper()` in `shapeOptions.columnMapper` to map snake_case Postgres columns to camelCase collection fields. `created_at` must still parse to `Date` on the sync path via the `timestamptz` parser.
+
+Startup fails if the collection cannot preload. Running with an empty registry after failed sync would silently drop terminal wake events.
+
+## Local-only collection
+
+Runtime requires Electric. There is no no-Electric Postgres fallback and no replacement for the old `loadRegistrations()` rebuild path.
+
+For unit tests only, create or replace a local-only collection:
+
+```ts
+createCollection(
+  localOnlyCollectionOptions({
+    id: `wake-registrations-local:${tenantId ?? 'all'}`,
+    getKey: (row) => row.id,
+    initialData: [],
+  })
+)
+```
+
+Unit tests should not need Postgres or Electric just to exercise registry logic. They can start with an empty local-only collection and create rows through the same optimistic actions used by runtime.
+
+Integration tests that need real persistence or cross-process sync should use Postgres + Electric and `startSync(...)`, not a local collection seeded from Postgres. Server startup without an Electric URL should fail rather than silently rebuilding local state from Postgres.
+
+## Mutation model
+
+All `WakeRegistry` mutations use `createOptimisticAction`. Public registry methods do not call `collection.insert`, `collection.update`, or `collection.delete` directly.
+
+Actions:
+
+- `registerAction`
+- `unregisterByManifestKeyAction`
+- `unregisterBySubscriberAction`
+- `unregisterBySourceAction`
+- `unregisterBySubscriberAndSourceAction`
+- `markTimeoutConsumedAction`
+- `consumeMatchedRegistrationsAction` or equivalent one-shot cleanup action
+
+Each action has two responsibilities:
+
+1. `onMutate`: synchronously apply optimistic changes to the collection.
+2. `mutationFn`: persist the intent to Postgres in runtime mode and return/await a txid. In local-only mode, this is a no-op or minimal test hook.
+
+### Register
+
+`register(reg)` resolves the tenant, normalizes defaults, invokes `registerAction`, and awaits `tx.isPersisted.promise`.
+
+`registerAction.onMutate` inserts or upserts the normalized row into the collection.
+
+`registerAction.mutationFn` performs the existing insert:
+
+- insert into `wake_registrations`
+- `ON CONFLICT DO NOTHING`
+- insert with the preallocated id
+- if conflicted, fetch the existing row and transaction id
+
+The transaction id comes from the same Postgres transaction:
+
+```sql
+SELECT pg_current_xact_id()::xid::text AS txid
+```
+
+The Electric collection should hold optimistic state until that txid syncs back. Because the action preallocates the numeric id, `WakeEvalResult.registrationDbId` can use the collection key directly.
+
+### Bulk unregister actions
+
+Bulk unregister methods are domain intents, not repeated ad-hoc row deletes. Each uses one optimistic action:
+
+- `unregisterByManifestKey(subscriberUrl, manifestKey, tenantId?)`
+- `unregisterBySubscriber(subscriberUrl, tenantId?)`
+- `unregisterBySource(sourceUrl, tenantId?)`
+- `unregisterBySubscriberAndSource(subscriberUrl, sourceUrl, tenantId?)`
+
+Each action’s `onMutate` deletes all currently matching collection rows synchronously.
+
+Each action’s `mutationFn` runs one SQL/Drizzle delete statement for the same predicate and returns/awaits the resulting txid.
+
+Public methods await `tx.isPersisted.promise` because callers expect unregister completion.
+
+### Timeout consumed
+
+When a wake timeout is delivered or a matching event clears a timeout, `markTimeoutConsumedAction` updates the row:
+
+```ts
+draft.timeoutConsumed = true
+```
+
+Its runtime `mutationFn` persists `timeout_consumed = true` and returns/awaits a txid.
+
+Current fire-and-forget semantics can stay fire-and-forget, but failures must be logged with tenant id, registration id, source url, and subscriber url.
+
+### One-shot cleanup
+
+When `evaluate()` matches one-shot registrations, it invokes a cleanup action that deletes the matched rows optimistically before `evaluate()` returns. This prevents immediate repeated evaluation from double-delivering.
+
+Persistence can remain fire-and-forget if the current path is fire-and-forget, with logged failures.
+
+## Evaluation reads
+
+`evaluate()` becomes async:
+
+```ts
+async evaluate(
+  sourceUrl: string,
+  event: Record<string, unknown>,
+  tenantId?: string
+): Promise<Array<WakeEvalResult>>
+```
+
+It reads current registrations with `queryOnce`:
+
+```ts
+const regs = await queryOnce((q) =>
+  q
+    .from({ reg: this.requireRegistrationsCollection() })
+    .where(({ reg }) =>
+      and(eq(reg.tenantId, resolvedTenantId), eq(reg.sourceUrl, sourceUrl))
+    )
+)
+```
+
+`queryOnce` is async because a source collection may need preload. In the registry’s normal runtime path the collection is already loaded, so this should usually be a cheap microtick async boundary.
+
+The existing condition matching and wake result construction can remain mostly unchanged:
+
+- `runFinished` matches terminal run updates
+- collection-change conditions match collection names and ops
+- immediate matches return `WakeEvalResult[]`
+- debounced matches append to debounce buffers
+- timeout timers are cleared when the expected event arrives first
+
+No code path should reload all registrations from Postgres on an evaluation miss.
+
+## Timeout wake side effects
+
+Wake registration `timeoutMs` measures how long a registration has been waiting for its matching source event. If that event does not arrive before `createdAt + timeoutMs`, the subscriber receives a timeout wake:
+
+```ts
+wakeMessage: {
+  source: reg.sourceUrl,
+  timeout: true,
+  changes: [],
+}
+```
+
+Use `createEffect` over the registration collection to manage these Node timers:
+
+```ts
+createEffect({
+  query: (q) => q.from({ reg: registrationsCollection }),
+  skipInitial: false,
+  onEnter: ({ value }) => syncTimeoutTimer(value),
+  onUpdate: ({ value }) => syncTimeoutTimer(value),
+  onExit: ({ value }) => clearRegistrationState(value),
+})
+```
+
+Timer behavior:
+
+- On enter/update, if `timeoutMs <= 0` or `timeoutConsumed`, ensure no timer is active.
+- If `createdAt + timeoutMs` is in the future, schedule one Node timer.
+- If the deadline has already passed and the timeout has not been delivered, deliver the timeout wake once if a tenant callback is registered.
+- On exit, clear timeout/debounce state and remove the row from `timeoutDelivered`.
+
+When a timeout fires, it delivers the existing timeout wake result and invokes `markTimeoutConsumedAction`.
+
+## Error handling
+
+- Startup fails if the Electric collection preload fails.
+- Local-only unit-test initialization should not perform DB I/O.
+- Runtime startup without an Electric URL fails clearly; there is no Postgres-seeded fallback.
+- Awaited public mutation methods reject if persistence fails; TanStack DB rolls back optimistic state.
+- Fire-and-forget action failures are logged with enough context to diagnose the row and intent.
+- Electric collection owns Shape lifecycle and retry behavior. `WakeRegistry` should not reimplement Shape recovery.
+- Evaluation misses are not retried by reloading all rows from Postgres.
+
+## Call-site changes
+
+- Update every `wakeRegistry.evaluate(...)` call to `await wakeRegistry.evaluate(...)`.
+- Remove `EntityManager.evaluateWakes()` retry/reload-on-cache-miss logic.
+- Remove `loadRegistrations()` and update startup paths to require `startSync(...)` for runtime.
+- Keep `flushDebounce(...)` synchronous unless it starts reading registration rows. It currently only drains debounce buffers.
+
+## Test plan
+
+Update existing wake registry unit tests:
+
+- Convert direct `registry.evaluate(...)` assertions to `await registry.evaluate(...)`.
+- Preserve coverage for:
+  - tenant scoping
+  - `runFinished` matching
+  - collection-change matching
+  - debounce coalescing
+  - timeout delivery
+  - timeout not consumed before callback registration
+  - one-shot cleanup
+  - unregister variants
+  - `includeResponse`
+  - concurrent child `runFinished` delivery
+
+Remove or replace tests that only cover manual Shape cache machinery:
+
+- direct `applyShapeMessage` tests
+- malformed Shape message handling
+- custom Shape recovery behavior
+
+Add TanStack DB-specific tests:
+
+- `registerAction` preallocates an id, inserts into the local collection, and `evaluate()` sees it through `queryOnce`.
+- Each bulk unregister action removes all matching rows optimistically.
+- One-shot cleanup removes matched rows before a second immediate evaluation.
+- `markTimeoutConsumedAction` prevents repeat timeout delivery.
+- Local-only unit tests require no Postgres, Electric, or Electric mock.
+
+Add or keep an integration-style Electric test if practical:
+
+- registry A registers a wake through Postgres/Electric collection
+- registry B observes the row through Electric collection
+- a terminal child run event evaluated by registry B produces the parent wake without any reload-on-miss fallback
+
+## Files likely touched
+
+- `packages/agents-server/package.json`
+  - add `@tanstack/db`
+  - add `@tanstack/electric-db-collection`
+- `packages/agents-server/src/wake-registry.ts`
+  - main refactor
+- `packages/agents-server/src/entity-manager.ts`
+  - await async evaluation and remove reload-on-miss fallback
+- `packages/agents-server/test/wake-registry.test.ts`
+  - update async assertions and action expectations
+- `packages/agents-server/test/wake-registry-sync.test.ts`
+  - remove/replace manual Shape tests with Postgres + Electric integration coverage where needed
+- `.changeset/*`
+  - update package changeset if implementation changes dependencies or behavior
+
+## Acceptance criteria
+
+- `WakeRegistry` has no authoritative `Map<string, CachedWakeRegistration[]>` cache.
+- `WakeRegistry` does not instantiate `Shape` or `ShapeStream` directly.
+- Runtime registration state comes from an Electric TanStack DB collection.
+- Unit-test registration state comes from a local-only TanStack DB collection.
+- Runtime startup without Electric fails instead of calling `loadRegistrations()`.
+- All public registry mutations invoke optimistic actions.
+- Bulk unregister operations are one action per domain intent.
+- Runtime mutation handlers return/await real Postgres txids.
+- Wake evaluation uses `queryOnce` over the collection.
+- Timeout wake timers are driven by `createEffect` over collection rows.
+- `EntityManager` no longer reloads registrations on terminal evaluation miss.
+- Existing wake registry behavior tests pass after async/action updates.

--- a/packages/agents-runtime/src/create-handler.ts
+++ b/packages/agents-runtime/src/create-handler.ts
@@ -145,7 +145,10 @@ export interface RuntimeRouter {
    */
   dispatchWake: (
     notification: WakeNotification,
-    options?: Pick<ProcessWakeConfig, `claimHeaders` | `claimTokenHeader`>
+    options?: Pick<
+      ProcessWakeConfig,
+      `claimHeaders` | `claimTokenHeader` | `onDoneNextWake`
+    >
   ) => void
 
   /** True when a wake for the stream path is already in flight. */

--- a/packages/agents-runtime/src/process-wake.ts
+++ b/packages/agents-runtime/src/process-wake.ts
@@ -634,7 +634,47 @@ export async function processWake(
     return left < right ? -1 : 1
   }
 
+  const firstPendingRunnableFreshOffset = (): string | null => {
+    for (const batch of pendingLiveBatches) {
+      const events = toChangeEvents(batch)
+      const cancelledInboxKeys = new Set(
+        events.filter(isInboxCancellationEvent).map(inboxEventKey)
+      )
+      for (const event of events) {
+        if (event.type === `wake`) {
+          return event.headers.offset ?? batch.offset
+        }
+        if (isInboxEvent(event)) {
+          if (cancelledInboxKeys.has(inboxEventKey(event))) continue
+          const value = event.value as
+            | {
+                payload?: unknown
+                mode?: `immediate` | `queued` | `paused` | `steer`
+                status?: `pending` | `processed` | `cancelled`
+              }
+            | undefined
+          if (
+            value?.status !== `cancelled` &&
+            (value?.payload !== undefined ||
+              value?.mode === `queued` ||
+              value?.mode === `steer`)
+          ) {
+            return event.headers.offset ?? batch.offset
+          }
+        }
+      }
+    }
+    return null
+  }
+
   const setSafeAckOffset = (offset: string): void => {
+    const pendingFreshOffset = firstPendingRunnableFreshOffset()
+    if (
+      pendingFreshOffset !== null &&
+      compareOffsets(offset, pendingFreshOffset) >= 0
+    ) {
+      return
+    }
     if (compareOffsets(offset, safeAckOffset) > 0) {
       safeAckOffset = offset
     }

--- a/packages/agents-runtime/src/process-wake.ts
+++ b/packages/agents-runtime/src/process-wake.ts
@@ -75,6 +75,7 @@ interface ClaimCallbackResponse {
   claimToken?: string
   token?: string
   writeToken?: string
+  next_wake?: boolean
   error?: { code?: string; message?: string }
 }
 
@@ -2489,7 +2490,7 @@ export async function processWake(
         log.info(`shutdown requested, sending done callback at checkpoint`)
       }
       try {
-        await sendDone(
+        const doneResponse = await sendDone(
           callback,
           activeClaimToken,
           claimHeaderConfig,
@@ -2497,6 +2498,9 @@ export async function processWake(
           streamPath,
           doneOffset === `-1` ? null : doneOffset
         )
+        if (doneResponse.next_wake) {
+          config.onDoneNextWake?.(streamPath)
+        }
       } catch (err) {
         cleanupErrors.push(toError(err))
       }
@@ -2538,7 +2542,7 @@ async function sendDone(
   epoch: number,
   streamPath: string,
   offset: string | null
-): Promise<void> {
+): Promise<ClaimCallbackResponse> {
   const response = await fetch(callback, {
     method: `POST`,
     headers: await createClaimCallbackHeaders(claimHeaderConfig, token),
@@ -2549,15 +2553,16 @@ async function sendDone(
     }),
   })
 
+  const body = await response.text().catch(() => `<body unreadable>`)
   if (!response.ok) {
-    let body = ``
-    try {
-      body = await response.text()
-    } catch {
-      body = `<body unreadable>`
-    }
     throw new Error(
       `Done callback failed (${response.status}): ${body || response.statusText}`
     )
+  }
+
+  const raw = parseClaimCallbackResponseBody(body)
+  return {
+    ...raw,
+    ok: raw.ok === undefined ? response.ok && raw.error === undefined : raw.ok,
   }
 }

--- a/packages/agents-runtime/src/pull-wake-runner.ts
+++ b/packages/agents-runtime/src/pull-wake-runner.ts
@@ -108,6 +108,7 @@ export function createPullWakeRunner(
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null
   let eventHeartbeatTimer: ReturnType<typeof setTimeout> | null = null
   let heartbeatInFlight: Promise<void> | null = null
+  let heartbeatInFlightSignal: AbortSignal | null = null
   let heartbeatPending = false
   let currentOffset = config.offset ?? `-1`
   let startedAt: string | null = null
@@ -128,7 +129,7 @@ export function createPullWakeRunner(
   let stopPromise: Promise<void> | null = null
   const claimActors = new Set<Promise<void>>()
   const claimingStreamPaths = new Set<string>()
-  const deferredWakeEventsByStreamPath = new Map<string, PullWakeEvent>()
+  const deferredWakeEventsByStreamPath = new Map<string, Array<PullWakeEvent>>()
   const deferredWakeTimersByStreamPath = new Map<
     string,
     ReturnType<typeof setTimeout>
@@ -235,10 +236,15 @@ export function createPullWakeRunner(
   const requestHeartbeat = (signal: AbortSignal): void => {
     if (signal.aborted) return
     heartbeatPending = true
-    if (heartbeatInFlight) return
-    heartbeatInFlight = flushHeartbeats(signal).finally(() => {
-      heartbeatInFlight = null
+    if (heartbeatInFlight && heartbeatInFlightSignal === signal) return
+    const inFlight = flushHeartbeats(signal).finally(() => {
+      if (heartbeatInFlight === inFlight) {
+        heartbeatInFlight = null
+        heartbeatInFlightSignal = null
+      }
     })
+    heartbeatInFlight = inFlight
+    heartbeatInFlightSignal = signal
   }
 
   const flushHeartbeats = async (signal: AbortSignal): Promise<void> => {
@@ -358,33 +364,48 @@ export function createPullWakeRunner(
     deferredWakeEventsByStreamPath.clear()
   }
 
-  const scheduleDeferredWakeClaim = (
-    event: PullWakeEvent,
+  const scheduleDeferredWakeRetry = (
+    streamPath: string,
     signal: AbortSignal
   ): void => {
-    const streamPath = normalizeStreamPath(event.stream)
-    deferredWakeEventsByStreamPath.set(streamPath, event)
     if (deferredWakeTimersByStreamPath.has(streamPath)) return
 
     const retry = (): void => {
       deferredWakeTimersByStreamPath.delete(streamPath)
-      const deferredEvent = deferredWakeEventsByStreamPath.get(streamPath)
-      if (!deferredEvent || signal.aborted || !isRunningState()) {
+      const deferredEvents = deferredWakeEventsByStreamPath.get(streamPath)
+      if (!deferredEvents?.length || signal.aborted || !isRunningState()) {
         deferredWakeEventsByStreamPath.delete(streamPath)
         return
       }
       if (hasActiveStreamClaim(streamPath)) {
-        scheduleDeferredWakeClaim(deferredEvent, signal)
+        scheduleDeferredWakeRetry(streamPath, signal)
         return
       }
 
-      deferredWakeEventsByStreamPath.delete(streamPath)
+      const deferredEvent = deferredEvents.shift()!
+      if (deferredEvents.length === 0) {
+        deferredWakeEventsByStreamPath.delete(streamPath)
+      }
       spawnClaimActor(deferredEvent, signal)
+      if (deferredEvents.length > 0) {
+        scheduleDeferredWakeRetry(streamPath, signal)
+      }
     }
 
     const timer = setTimeout(retry, DEFERRED_WAKE_RETRY_MS)
     timer.unref?.()
     deferredWakeTimersByStreamPath.set(streamPath, timer)
+  }
+
+  const scheduleDeferredWakeClaim = (
+    event: PullWakeEvent,
+    signal: AbortSignal
+  ): void => {
+    const streamPath = normalizeStreamPath(event.stream)
+    const deferredEvents = deferredWakeEventsByStreamPath.get(streamPath) ?? []
+    deferredEvents.push(event)
+    deferredWakeEventsByStreamPath.set(streamPath, deferredEvents)
+    scheduleDeferredWakeRetry(streamPath, signal)
   }
 
   const claimWake = async (

--- a/packages/agents-runtime/src/pull-wake-runner.ts
+++ b/packages/agents-runtime/src/pull-wake-runner.ts
@@ -382,14 +382,9 @@ export function createPullWakeRunner(
         return
       }
 
-      const deferredEvent = deferredEvents.shift()!
-      if (deferredEvents.length === 0) {
-        deferredWakeEventsByStreamPath.delete(streamPath)
-      }
+      const deferredEvent = deferredEvents[0]!
+      deferredWakeEventsByStreamPath.delete(streamPath)
       spawnClaimActor(deferredEvent, signal)
-      if (deferredEvents.length > 0) {
-        scheduleDeferredWakeRetry(streamPath, signal)
-      }
     }
 
     const timer = setTimeout(retry, DEFERRED_WAKE_RETRY_MS)

--- a/packages/agents-runtime/src/pull-wake-runner.ts
+++ b/packages/agents-runtime/src/pull-wake-runner.ts
@@ -364,30 +364,41 @@ export function createPullWakeRunner(
     deferredWakeEventsByStreamPath.clear()
   }
 
+  const drainQueuedWakeClaims = (
+    streamPath: string,
+    signal: AbortSignal
+  ): void => {
+    const timer = deferredWakeTimersByStreamPath.get(streamPath)
+    if (timer) {
+      clearTimeout(timer)
+      deferredWakeTimersByStreamPath.delete(streamPath)
+    }
+
+    const deferredEvents = deferredWakeEventsByStreamPath.get(streamPath)
+    if (!deferredEvents?.length || signal.aborted || !isRunningState()) {
+      deferredWakeEventsByStreamPath.delete(streamPath)
+      return
+    }
+    if (hasActiveStreamClaim(streamPath)) {
+      scheduleDeferredWakeRetry(streamPath, signal)
+      return
+    }
+
+    const deferredEvent = deferredEvents[0]!
+    deferredWakeEventsByStreamPath.delete(streamPath)
+    spawnClaimActor(deferredEvent, signal)
+  }
+
   const scheduleDeferredWakeRetry = (
     streamPath: string,
     signal: AbortSignal
   ): void => {
     if (deferredWakeTimersByStreamPath.has(streamPath)) return
 
-    const retry = (): void => {
-      deferredWakeTimersByStreamPath.delete(streamPath)
-      const deferredEvents = deferredWakeEventsByStreamPath.get(streamPath)
-      if (!deferredEvents?.length || signal.aborted || !isRunningState()) {
-        deferredWakeEventsByStreamPath.delete(streamPath)
-        return
-      }
-      if (hasActiveStreamClaim(streamPath)) {
-        scheduleDeferredWakeRetry(streamPath, signal)
-        return
-      }
-
-      const deferredEvent = deferredEvents[0]!
-      deferredWakeEventsByStreamPath.delete(streamPath)
-      spawnClaimActor(deferredEvent, signal)
-    }
-
-    const timer = setTimeout(retry, DEFERRED_WAKE_RETRY_MS)
+    const timer = setTimeout(
+      () => drainQueuedWakeClaims(streamPath, signal),
+      DEFERRED_WAKE_RETRY_MS
+    )
     timer.unref?.()
     deferredWakeTimersByStreamPath.set(streamPath, timer)
   }
@@ -400,7 +411,12 @@ export function createPullWakeRunner(
     const deferredEvents = deferredWakeEventsByStreamPath.get(streamPath) ?? []
     deferredEvents.push(event)
     deferredWakeEventsByStreamPath.set(streamPath, deferredEvents)
-    scheduleDeferredWakeRetry(streamPath, signal)
+    if (hasActiveStreamClaim(streamPath)) {
+      recordClaimSkipped()
+      scheduleDeferredWakeRetry(streamPath, signal)
+      return
+    }
+    drainQueuedWakeClaims(streamPath, signal)
   }
 
   const claimWake = async (
@@ -539,7 +555,7 @@ export function createPullWakeRunner(
       eventsReceived++
       notifyHeartbeatChange()
       const signal = controller?.signal
-      if (signal && !signal.aborted) spawnClaimActor(event, signal)
+      if (signal && !signal.aborted) scheduleDeferredWakeClaim(event, signal)
     },
     onOffset: (offset) => {
       if (offset !== currentOffset) {

--- a/packages/agents-runtime/src/pull-wake-runner.ts
+++ b/packages/agents-runtime/src/pull-wake-runner.ts
@@ -129,7 +129,7 @@ export function createPullWakeRunner(
   let stopPromise: Promise<void> | null = null
   const claimActors = new Set<Promise<void>>()
   const claimingStreamPaths = new Set<string>()
-  const deferredWakeEventsByStreamPath = new Map<string, Array<PullWakeEvent>>()
+  const deferredWakeEventsByStreamPath = new Map<string, PullWakeEvent>()
   const deferredWakeTimersByStreamPath = new Map<
     string,
     ReturnType<typeof setTimeout>
@@ -374,8 +374,8 @@ export function createPullWakeRunner(
       deferredWakeTimersByStreamPath.delete(streamPath)
     }
 
-    const deferredEvents = deferredWakeEventsByStreamPath.get(streamPath)
-    if (!deferredEvents?.length || signal.aborted || !isRunningState()) {
+    const deferredEvent = deferredWakeEventsByStreamPath.get(streamPath)
+    if (!deferredEvent || signal.aborted || !isRunningState()) {
       deferredWakeEventsByStreamPath.delete(streamPath)
       return
     }
@@ -384,7 +384,6 @@ export function createPullWakeRunner(
       return
     }
 
-    const deferredEvent = deferredEvents[0]!
     deferredWakeEventsByStreamPath.delete(streamPath)
     spawnClaimActor(deferredEvent, signal)
   }
@@ -408,9 +407,9 @@ export function createPullWakeRunner(
     signal: AbortSignal
   ): void => {
     const streamPath = normalizeStreamPath(event.stream)
-    const deferredEvents = deferredWakeEventsByStreamPath.get(streamPath) ?? []
-    deferredEvents.push(event)
-    deferredWakeEventsByStreamPath.set(streamPath, deferredEvents)
+    if (!deferredWakeEventsByStreamPath.has(streamPath)) {
+      deferredWakeEventsByStreamPath.set(streamPath, event)
+    }
     if (hasActiveStreamClaim(streamPath)) {
       recordClaimSkipped()
       scheduleDeferredWakeRetry(streamPath, signal)

--- a/packages/agents-runtime/src/pull-wake-runner.ts
+++ b/packages/agents-runtime/src/pull-wake-runner.ts
@@ -490,6 +490,12 @@ export function createPullWakeRunner(
         config.runtime.dispatchWake(notification, {
           claimHeaders: resolveClaimHeaders,
           claimTokenHeader: config.claimTokenHeader,
+          onDoneNextWake: (nextStreamPath) => {
+            scheduleDeferredWakeClaim(
+              { ...event, stream: nextStreamPath },
+              signal
+            )
+          },
         })
       } catch (err) {
         reportError(err)

--- a/packages/agents-runtime/src/types.ts
+++ b/packages/agents-runtime/src/types.ts
@@ -788,6 +788,11 @@ export interface ProcessWakeConfig {
   }) => Array<AgentTool> | Promise<Array<AgentTool>>
   /** Optional shutdown signal to end idle waits during host teardown. */
   shutdownSignal?: AbortSignal
+  /**
+   * Called when the Durable Streams done callback reports that releasing this
+   * claim left pending work for the same subscription.
+   */
+  onDoneNextWake?: (streamPath: string) => void
   /** Idle timeout in ms before closing the wake (default: 20_000) */
   idleTimeout?: number
   /** Heartbeat interval in ms (default: 10_000) */

--- a/packages/agents-runtime/test/process-wake.test.ts
+++ b/packages/agents-runtime/test/process-wake.test.ts
@@ -560,6 +560,34 @@ describe(`processWake`, () => {
     expect(body.epoch).toBe(1)
   })
 
+  it(`notifies the runner when done leaves another wake pending`, async () => {
+    defineEntity(`test-agent`, {
+      handler: () => {},
+    })
+    const onDoneNextWake = vi.fn()
+    fetchMock.mockImplementation((url, opts) => {
+      const body = opts?.body ? JSON.parse(String(opts.body)) : {}
+      if (String(url).includes(`/_electric/wakes/wake-abc`) && body.done) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ ok: true, next_wake: true }), {
+            status: 200,
+            headers: { 'content-type': `application/json` },
+          })
+        )
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'content-type': `application/json` },
+        })
+      )
+    })
+
+    await processWake(makeNotification(), { ...BASE_CONFIG, onDoneNextWake })
+
+    expect(onDoneNextWake).toHaveBeenCalledWith(`/streams/entity:agent-1`)
+  })
+
   it(`acks the local consumed offset on done even when the stream tail is ahead`, async () => {
     defineEntity(`test-agent`, {
       handler: () => {},
@@ -983,6 +1011,80 @@ describe(`processWake`, () => {
     expect(mockProducerAppend).toHaveBeenCalledWith(
       expect.stringContaining(`"outcome":"aborted"`)
     )
+  })
+
+  it(`does not ack queued inbox that arrived before SIGINT aborts an active run`, async () => {
+    const wakePayloads: Array<unknown> = []
+    let handlerStartedResolve: (() => void) | null = null
+    const handlerStarted = new Promise<void>((resolve) => {
+      handlerStartedResolve = resolve
+    })
+    let signalAbortedResolve: (() => void) | null = null
+    const signalAborted = new Promise<void>((resolve) => {
+      signalAbortedResolve = resolve
+    })
+
+    defineEntity(`test-agent`, {
+      handler: async (ctx, wake) => {
+        wakePayloads.push(wake.payload)
+        handlerStartedResolve?.()
+        if (ctx.signal.aborted) {
+          signalAbortedResolve?.()
+          return
+        }
+        await new Promise<void>((resolve) => {
+          ctx.signal.addEventListener(
+            `abort`,
+            () => {
+              signalAbortedResolve?.()
+              resolve()
+            },
+            { once: true }
+          )
+        })
+      },
+    })
+
+    const notification = makeNotification({ triggerEvent: `inbox` })
+    notification.entity!.status = `running`
+    const wakePromise = processWake(notification, BASE_CONFIG)
+    await handlerStarted
+
+    mockEntityOnBatch.current?.({
+      items: [
+        ev(
+          `inbox`,
+          `m-before-sigint`,
+          `insert`,
+          { payload: `should run in a later wake` },
+          { offset: `10_500` }
+        ),
+        ev(
+          `signal`,
+          `sigint-handler`,
+          `insert`,
+          { signal: `SIGINT`, status: `unhandled` },
+          { offset: `10_600` }
+        ),
+      ],
+      offset: `10_600`,
+    })
+
+    await signalAborted
+    await wakePromise
+
+    expect(wakePayloads).toEqual([undefined])
+    const doneCalls = fetchMock.mock.calls.filter(
+      ([url, opts]) =>
+        String(url).includes(`/_electric/wakes/wake-abc`) &&
+        (opts?.body as string | undefined)?.includes(`"done":true`)
+    )
+    const body = JSON.parse(doneCalls.at(-1)![1]!.body as string) as {
+      acks: Array<{ path: string; offset: string }>
+    }
+    expect(body.acks).toEqual([
+      { path: `/streams/entity:agent-1`, offset: `10_100` },
+    ])
   })
 
   it(`does not continue fresh inbox work after SIGINT aborts an active run`, async () => {

--- a/packages/agents-runtime/test/process-wake.test.ts
+++ b/packages/agents-runtime/test/process-wake.test.ts
@@ -46,8 +46,12 @@ const {
   mockInitialManifests,
   mockEntityOnEvent,
   mockEntityOnBatch,
+  mockProducerLastSuccessfulOffset,
 } = vi.hoisted(() => ({
   mockProducerAppend: vi.fn(),
+  mockProducerLastSuccessfulOffset: {
+    current: undefined as string | undefined,
+  },
   mockProducerFlush: vi.fn().mockResolvedValue(undefined),
   mockProducerDetach: vi.fn().mockResolvedValue(undefined),
   mockConstructedProducers: [] as Array<{
@@ -131,6 +135,9 @@ vi.mock(`@durable-streams/client`, async (importOriginal) => {
     append = mockProducerAppend
     flush = mockProducerFlush
     detach = mockProducerDetach
+    get lastSuccessfulOffset() {
+      return mockProducerLastSuccessfulOffset.current
+    }
   }
   return {
     ...actual,
@@ -457,6 +464,7 @@ describe(`processWake`, () => {
     mockSourceEvents.current = []
     mockStreamOffset.value = `10_100`
     mockDbOffset.value = `10_100`
+    mockProducerLastSuccessfulOffset.current = undefined
     mockEntityOnEvent.current = null
     mockEntityOnBatch.current = null
     mockStreamHead.mockResolvedValue({
@@ -1150,6 +1158,85 @@ describe(`processWake`, () => {
     })
 
     await signalAborted
+    await wakePromise
+
+    expect(wakePayloads).toEqual([undefined])
+    const doneCalls = fetchMock.mock.calls.filter(
+      ([url, opts]) =>
+        String(url).includes(`/_electric/wakes/wake-abc`) &&
+        (opts?.body as string | undefined)?.includes(`"done":true`)
+    )
+    const body = JSON.parse(doneCalls.at(-1)![1]!.body as string) as {
+      acks: Array<{ path: string; offset: string }>
+    }
+    expect(body.acks).toEqual([
+      { path: `/streams/entity:agent-1`, offset: `10_500` },
+    ])
+  })
+
+  it(`does not ack a queued inbox when SIGINT cleanup writes advance the stream tail`, async () => {
+    const wakePayloads: Array<unknown> = []
+    let handlerStartedResolve: (() => void) | null = null
+    const handlerStarted = new Promise<void>((resolve) => {
+      handlerStartedResolve = resolve
+    })
+    let signalAbortedResolve: (() => void) | null = null
+    const signalAborted = new Promise<void>((resolve) => {
+      signalAbortedResolve = resolve
+    })
+
+    defineEntity(`test-agent`, {
+      handler: async (ctx, wake) => {
+        wakePayloads.push(wake.payload)
+        handlerStartedResolve?.()
+        await new Promise<void>((resolve) => {
+          ctx.signal.addEventListener(
+            `abort`,
+            () => {
+              signalAbortedResolve?.()
+              resolve()
+            },
+            { once: true }
+          )
+        })
+      },
+    })
+
+    const notification = makeNotification({ triggerEvent: `inbox` })
+    notification.entity!.status = `running`
+    const wakePromise = processWake(notification, BASE_CONFIG)
+    await handlerStarted
+
+    mockEntityOnBatch.current?.({
+      items: [
+        ev(
+          `signal`,
+          `sigint-handler`,
+          `insert`,
+          { signal: `SIGINT`, status: `unhandled` },
+          { offset: `10_500` }
+        ),
+      ],
+      offset: `10_500`,
+    })
+    mockEntityOnBatch.current?.({
+      items: [
+        ev(
+          `inbox`,
+          `m-after-sigint`,
+          `insert`,
+          { payload: `should run in a later wake` },
+          { offset: `10_600` }
+        ),
+      ],
+      offset: `10_600`,
+    })
+
+    await signalAborted
+    // Simulate cleanup writes (e.g. signal handled / aborted run rows) being
+    // appended after the queued inbox. Acking this offset would swallow the
+    // unprocessed inbox and prevent Durable Streams from issuing next_wake.
+    mockProducerLastSuccessfulOffset.current = `10_700`
     await wakePromise
 
     expect(wakePayloads).toEqual([undefined])

--- a/packages/agents-runtime/test/pull-wake-runner.test.ts
+++ b/packages/agents-runtime/test/pull-wake-runner.test.ts
@@ -170,6 +170,7 @@ describe(`createPullWakeRunner`, () => {
     expect(testRuntime.dispatchWake).toHaveBeenCalledWith(claimed, {
       claimHeaders: expect.any(Function),
       claimTokenHeader: `electric-claim-token`,
+      onDoneNextWake: expect.any(Function),
     })
     expect(testRuntime.drainWakes).not.toHaveBeenCalled()
     expect(runner.offset).toBe(`42`)
@@ -376,6 +377,54 @@ describe(`createPullWakeRunner`, () => {
     })
     await new Promise((resolve) => setTimeout(resolve, 50))
     expect(requestGenerations).toEqual([1, 2])
+
+    await runner.stop()
+  })
+
+  it(`reclaims immediately when a dispatched wake reports pending work on done`, async () => {
+    const event = { ...wakeEvent(`one`), generation: 1 }
+    const claimed = notification(`one`)
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>
+      Response.json(claimed)
+    )
+    vi.stubGlobal(`fetch`, fetchMock)
+    let doneNextWake: ((streamPath: string) => void) | undefined
+    const testRuntime = {
+      ...runtime(),
+      dispatchWake: vi.fn((_notification, options) => {
+        doneNextWake = options?.onDoneNextWake
+      }),
+    }
+    const streamFactory = vi.fn(async () => ({
+      offset: `42`,
+      async *jsonStream() {
+        yield event
+      },
+      closed: Promise.resolve(),
+    }))
+
+    const runner = createPullWakeRunner({
+      baseUrl: `http://server`,
+      runnerId: `runner-1`,
+      runtime: testRuntime,
+      heartbeatIntervalMs: 0,
+      eventHeartbeatThrottleMs: 0,
+      streamFactory,
+    })
+
+    runner.start()
+    await waitFor(() => {
+      expect(testRuntime.dispatchWake).toHaveBeenCalledTimes(1)
+    })
+
+    doneNextWake?.(`/chat/one/main`)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+    await waitFor(() => {
+      expect(testRuntime.dispatchWake).toHaveBeenCalledTimes(2)
+    })
 
     await runner.stop()
   })

--- a/packages/agents-runtime/test/pull-wake-runner.test.ts
+++ b/packages/agents-runtime/test/pull-wake-runner.test.ts
@@ -330,6 +330,56 @@ describe(`createPullWakeRunner`, () => {
     await runner.stop()
   })
 
+  it(`does not let a new same-stream notification jump ahead of a queued trigger`, async () => {
+    const continueStream = deferred<void>()
+    const firstClaimResponse = deferred<Response>()
+    const requestGenerations: Array<number> = []
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        requestGenerations.push(JSON.parse(String(init?.body)).generation)
+        if (requestGenerations.length === 1) return firstClaimResponse.promise
+        return Response.json(notification(`coalesced`))
+      }
+    )
+    vi.stubGlobal(`fetch`, fetchMock)
+    const testRuntime = runtime()
+    const streamFactory = vi.fn(async () => ({
+      offset: `42`,
+      async *jsonStream() {
+        yield { ...wakeEvent(`parent`), generation: 1 }
+        yield { ...wakeEvent(`parent`), generation: 2 }
+        await continueStream.promise
+        yield { ...wakeEvent(`parent`), generation: 3 }
+      },
+      closed: Promise.resolve(),
+    }))
+
+    const runner = createPullWakeRunner({
+      baseUrl: `http://server`,
+      runnerId: `runner-1`,
+      runtime: testRuntime,
+      heartbeatIntervalMs: 0,
+      eventHeartbeatThrottleMs: 0,
+      streamFactory,
+    })
+
+    runner.start()
+    await waitFor(() => {
+      expect(requestGenerations).toEqual([1])
+    })
+
+    firstClaimResponse.resolve(Response.json(notification(`one`)))
+    continueStream.resolve()
+
+    await waitFor(() => {
+      expect(requestGenerations).toEqual([1, 2])
+    })
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(requestGenerations).toEqual([1, 2])
+
+    await runner.stop()
+  })
+
   it(`skips stale wake events when claim returns no pending work`, async () => {
     const event = wakeEvent(`one`)
     const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>

--- a/packages/agents-runtime/test/pull-wake-runner.test.ts
+++ b/packages/agents-runtime/test/pull-wake-runner.test.ts
@@ -278,13 +278,13 @@ describe(`createPullWakeRunner`, () => {
     await runner.stop()
   })
 
-  it(`retries every wake skipped while the same stream is already being claimed`, async () => {
+  it(`coalesces wake notifications skipped while the same stream is already being claimed`, async () => {
     const events = [
       { ...wakeEvent(`parent`), generation: 1 },
       { ...wakeEvent(`parent`), generation: 2 },
       { ...wakeEvent(`parent`), generation: 3 },
     ]
-    const claims = [`one`, `two`, `three`].map(notification)
+    const claims = [`one`, `coalesced`].map(notification)
     const firstClaimResponse = deferred<Response>()
     const fetchMock = vi
       .fn()
@@ -293,9 +293,6 @@ describe(`createPullWakeRunner`, () => {
       )
       .mockImplementationOnce(async (_input: RequestInfo | URL) =>
         Response.json(claims[1])
-      )
-      .mockImplementationOnce(async (_input: RequestInfo | URL) =>
-        Response.json(claims[2])
       )
     vi.stubGlobal(`fetch`, fetchMock)
     const testRuntime = runtime()
@@ -324,10 +321,10 @@ describe(`createPullWakeRunner`, () => {
 
     firstClaimResponse.resolve(Response.json(claims[0]))
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(3)
+      expect(fetchMock).toHaveBeenCalledTimes(2)
     })
     await waitFor(() => {
-      expect(testRuntime.dispatchWake).toHaveBeenCalledTimes(3)
+      expect(testRuntime.dispatchWake).toHaveBeenCalledTimes(2)
     })
 
     await runner.stop()

--- a/packages/agents-runtime/test/pull-wake-runner.test.ts
+++ b/packages/agents-runtime/test/pull-wake-runner.test.ts
@@ -278,6 +278,61 @@ describe(`createPullWakeRunner`, () => {
     await runner.stop()
   })
 
+  it(`retries every wake skipped while the same stream is already being claimed`, async () => {
+    const events = [
+      { ...wakeEvent(`parent`), generation: 1 },
+      { ...wakeEvent(`parent`), generation: 2 },
+      { ...wakeEvent(`parent`), generation: 3 },
+    ]
+    const claims = [`one`, `two`, `three`].map(notification)
+    const firstClaimResponse = deferred<Response>()
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        (_input: RequestInfo | URL) => firstClaimResponse.promise
+      )
+      .mockImplementationOnce(async (_input: RequestInfo | URL) =>
+        Response.json(claims[1])
+      )
+      .mockImplementationOnce(async (_input: RequestInfo | URL) =>
+        Response.json(claims[2])
+      )
+    vi.stubGlobal(`fetch`, fetchMock)
+    const testRuntime = runtime()
+    const streamFactory = vi.fn(async () => ({
+      offset: `42`,
+      async *jsonStream() {
+        yield* events
+      },
+      closed: Promise.resolve(),
+    }))
+
+    const runner = createPullWakeRunner({
+      baseUrl: `http://server`,
+      runnerId: `runner-1`,
+      runtime: testRuntime,
+      heartbeatIntervalMs: 0,
+      eventHeartbeatThrottleMs: 0,
+      streamFactory,
+    })
+
+    runner.start()
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+    expect(testRuntime.dispatchWake).not.toHaveBeenCalled()
+
+    firstClaimResponse.resolve(Response.json(claims[0]))
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+    })
+    await waitFor(() => {
+      expect(testRuntime.dispatchWake).toHaveBeenCalledTimes(3)
+    })
+
+    await runner.stop()
+  })
+
   it(`skips stale wake events when claim returns no pending work`, async () => {
     const event = wakeEvent(`one`)
     const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>

--- a/packages/agents-server/package.json
+++ b/packages/agents-server/package.json
@@ -53,6 +53,8 @@
     "@mariozechner/pi-agent-core": "^0.70.2",
     "@opentelemetry/api": "^1.9.1",
     "@sinclair/typebox": "^0.34.48",
+    "@tanstack/db": "^0.6.7",
+    "@tanstack/electric-db-collection": "^0.3.5",
     "@whatwg-node/server": "^0.10.18",
     "ajv": "^8.18.0",
     "cron-parser": "^5.5.0",

--- a/packages/agents-server/src/entity-manager.ts
+++ b/packages/agents-server/src/entity-manager.ts
@@ -3304,10 +3304,18 @@ export class EntityManager {
   ): Promise<void> {
     return await withSpan(`electric_agents.evaluateWakes`, async (span) => {
       span.setAttribute(ATTR.WAKE_SOURCE, sourceUrl)
-      let results = this.wakeRegistry.evaluate(sourceUrl, event, this.tenantId)
+      let results = await this.wakeRegistry.evaluate(
+        sourceUrl,
+        event,
+        this.tenantId
+      )
       if (results.length === 0 && isRunFinishedWakeEvent(event)) {
         await this.wakeRegistry.loadRegistrations()
-        results = this.wakeRegistry.evaluate(sourceUrl, event, this.tenantId)
+        results = await this.wakeRegistry.evaluate(
+          sourceUrl,
+          event,
+          this.tenantId
+        )
       }
       span.setAttribute(`electric_agents.wake.subscriber_count`, results.length)
       const settled = await Promise.allSettled(

--- a/packages/agents-server/src/entity-manager.ts
+++ b/packages/agents-server/src/entity-manager.ts
@@ -431,7 +431,7 @@ export class EntityManager {
     electricSecret?: string
   ): Promise<void> {
     if (!electricUrl) {
-      throw new Error(`Electric URL is required to start WakeRegistry`)
+      throw new Error(`WakeRegistry runtime requires an Electric URL`)
     }
     await this.wakeRegistry.startSync(electricUrl, electricSecret)
   }

--- a/packages/agents-server/src/entity-manager.ts
+++ b/packages/agents-server/src/entity-manager.ts
@@ -81,6 +81,18 @@ type SpawnPersistResult = [
   PromiseSettledResult<number>,
 ]
 type SpawnPersistJob = () => Promise<SpawnPersistResult>
+
+function isRunFinishedWakeEvent(event: Record<string, unknown>): boolean {
+  if (event.type !== `run`) return false
+  const value = event.value as Record<string, unknown> | undefined
+  const headers = event.headers as Record<string, unknown> | undefined
+  const status = value?.status as string | undefined
+  const operation = headers?.operation as string | undefined
+  return (
+    operation === `update` && (status === `completed` || status === `failed`)
+  )
+}
+
 type WriteTokenValidator = (
   entity: ElectricAgentsEntity,
   token: string
@@ -3292,11 +3304,11 @@ export class EntityManager {
   ): Promise<void> {
     return await withSpan(`electric_agents.evaluateWakes`, async (span) => {
       span.setAttribute(ATTR.WAKE_SOURCE, sourceUrl)
-      const results = this.wakeRegistry.evaluate(
-        sourceUrl,
-        event,
-        this.tenantId
-      )
+      let results = this.wakeRegistry.evaluate(sourceUrl, event, this.tenantId)
+      if (results.length === 0 && isRunFinishedWakeEvent(event)) {
+        await this.wakeRegistry.loadRegistrations()
+        results = this.wakeRegistry.evaluate(sourceUrl, event, this.tenantId)
+      }
       span.setAttribute(`electric_agents.wake.subscriber_count`, results.length)
       const settled = await Promise.allSettled(
         results.map((result) => this.deliverWakeResult(result))

--- a/packages/agents-server/src/entity-manager.ts
+++ b/packages/agents-server/src/entity-manager.ts
@@ -82,17 +82,6 @@ type SpawnPersistResult = [
 ]
 type SpawnPersistJob = () => Promise<SpawnPersistResult>
 
-function isRunFinishedWakeEvent(event: Record<string, unknown>): boolean {
-  if (event.type !== `run`) return false
-  const value = event.value as Record<string, unknown> | undefined
-  const headers = event.headers as Record<string, unknown> | undefined
-  const status = value?.status as string | undefined
-  const operation = headers?.operation as string | undefined
-  return (
-    operation === `update` && (status === `completed` || status === `failed`)
-  )
-}
-
 type WriteTokenValidator = (
   entity: ElectricAgentsEntity,
   token: string
@@ -441,12 +430,10 @@ export class EntityManager {
     electricUrl?: string,
     electricSecret?: string
   ): Promise<void> {
-    if (electricUrl) {
-      await this.wakeRegistry.startSync(electricUrl, electricSecret)
-      return
+    if (!electricUrl) {
+      throw new Error(`Electric URL is required to start WakeRegistry`)
     }
-
-    await this.wakeRegistry.loadRegistrations()
+    await this.wakeRegistry.startSync(electricUrl, electricSecret)
   }
 
   setWriteTokenValidator(validator: WriteTokenValidator): void {
@@ -3309,14 +3296,6 @@ export class EntityManager {
         event,
         this.tenantId
       )
-      if (results.length === 0 && isRunFinishedWakeEvent(event)) {
-        await this.wakeRegistry.loadRegistrations()
-        results = await this.wakeRegistry.evaluate(
-          sourceUrl,
-          event,
-          this.tenantId
-        )
-      }
       span.setAttribute(`electric_agents.wake.subscriber_count`, results.length)
       const settled = await Promise.allSettled(
         results.map((result) => this.deliverWakeResult(result))

--- a/packages/agents-server/src/entity-manager.ts
+++ b/packages/agents-server/src/entity-manager.ts
@@ -4078,9 +4078,19 @@ export class EntityManager {
     // Ensure the backing stream exists
     const exists = await this.streamClient.exists(streamPath)
     if (!exists) {
-      await this.streamClient.create(streamPath, {
-        contentType: `application/json`,
-      })
+      try {
+        await this.streamClient.create(streamPath, {
+          contentType: `application/json`,
+        })
+      } catch (err) {
+        const status =
+          err instanceof Error && `status` in err
+            ? (err as { status?: unknown }).status
+            : undefined
+        if (status !== 409 && !/\b409\b/.test(String(err))) {
+          throw err
+        }
+      }
     }
 
     const fireAt = getNextCronFireAt(spec.expression, spec.timezone)

--- a/packages/agents-server/src/host.ts
+++ b/packages/agents-server/src/host.ts
@@ -114,7 +114,7 @@ export class AgentsHost {
 
     try {
       if (!this.electricUrl) {
-        throw new Error(`Electric URL is required to start WakeRegistry`)
+        throw new Error(`WakeRegistry runtime requires an Electric URL`)
       }
       await this.wakeRegistry.startSync(this.electricUrl, this.electricSecret)
       if (this.startEntityBridgeManager) {

--- a/packages/agents-server/src/host.ts
+++ b/packages/agents-server/src/host.ts
@@ -113,11 +113,10 @@ export class AgentsHost {
     this.running = true
 
     try {
-      if (this.electricUrl) {
-        await this.wakeRegistry.startSync(this.electricUrl, this.electricSecret)
-      } else {
-        await this.wakeRegistry.loadRegistrations()
+      if (!this.electricUrl) {
+        throw new Error(`Electric URL is required to start WakeRegistry`)
       }
+      await this.wakeRegistry.startSync(this.electricUrl, this.electricSecret)
       if (this.startEntityBridgeManager) {
         await this.entityProjector.start()
       }

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -6,6 +6,7 @@ import {
 import {
   and as dbAnd,
   createCollection,
+  createEffect,
   createOptimisticAction,
   eq as dbEq,
   localOnlyCollectionOptions,
@@ -160,6 +161,7 @@ export class WakeRegistry {
   > | null = null
   private mode: WakeRegistryMode = `unstarted`
   private nextLocalId = 1
+  private registrationsEffect: { dispose(): Promise<void> } | null = null
   private registrationCache = new Map<string, Array<CachedWakeRegistration>>()
   private debounceTimers = new Map<string, NodeJS.Timeout>()
   private debounceBuffers = new Map<
@@ -203,6 +205,29 @@ export class WakeRegistry {
       })
     )
     await this.requireCollection().preload()
+    this.startRegistrationEffect()
+  }
+
+  private startRegistrationEffect(): void {
+    if (this.registrationsEffect) return
+    const collection = this.requireCollection()
+    this.registrationsEffect = createEffect<
+      WakeRegistrationCollectionRow,
+      number
+    >({
+      query: (q) => q.from({ reg: collection }),
+      skipInitial: false,
+      onEnter: ({ value }) => {
+        this.syncTimeoutTimer(value)
+      },
+      onUpdate: ({ value }) => {
+        this.syncTimeoutTimer(value)
+      },
+      onExit: ({ value }) => {
+        this.clearRegistrationState(value)
+        this.timeoutDelivered.delete(value.id)
+      },
+    })
   }
 
   private allocateLocalId(): number {
@@ -246,6 +271,25 @@ export class WakeRegistry {
       dbId: row.id,
       createdAt: row.createdAt,
       timeoutConsumed: row.timeoutConsumed,
+    }
+  }
+
+  private cachedRegistrationAsCollectionRow(
+    reg: CachedWakeRegistration
+  ): WakeRegistrationCollectionRow {
+    return {
+      id: reg.dbId,
+      tenantId: reg.tenantId,
+      subscriberUrl: reg.subscriberUrl,
+      sourceUrl: reg.sourceUrl,
+      condition: reg.condition,
+      debounceMs: reg.debounceMs ?? 0,
+      timeoutMs: reg.timeoutMs ?? 0,
+      oneShot: reg.oneShot,
+      timeoutConsumed: reg.timeoutConsumed ?? false,
+      includeResponse: reg.includeResponse !== false,
+      manifestKey: reg.manifestKey ?? null,
+      createdAt: reg.createdAt ?? new Date(),
     }
   }
 
@@ -296,7 +340,6 @@ export class WakeRegistry {
     createOptimisticAction<WakeRegistrationCollectionRow>({
       onMutate: (row) => {
         this.requireCollection().insert(row)
-        this.syncTimeoutTimer(this.collectionRowAsCached(row))
       },
       mutationFn: async (_row, { transaction }) => {
         if (this.mode === `local-test`) {
@@ -352,6 +395,7 @@ export class WakeRegistry {
     const resolvedTenantId = this.resolveTenantId(tenantId)
     this.timeoutCallbacks.set(resolvedTenantId, cb)
     this.syncTenantTimeoutTimers(resolvedTenantId)
+    void this.syncTenantCollectionTimeoutTimers(resolvedTenantId)
   }
 
   setDebounceCallback(cb: WakeDebounceCallback, tenantId?: string): void {
@@ -494,11 +538,31 @@ export class WakeRegistry {
   }
 
   async stopSync(): Promise<void> {
+    await this.registrationsEffect?.dispose()
+    this.registrationsEffect = null
+    this.registrationsCollection = null
+    this.mode = `unstarted`
     this.syncUnsubscribe?.()
     this.syncUnsubscribe = null
     this.syncAbortController?.abort()
     this.syncAbortController = null
     this.syncReadyPromise = null
+    this.resetRuntimeState()
+  }
+
+  private resetRuntimeState(): void {
+    for (const timer of this.debounceTimers.values()) {
+      clearTimeout(timer)
+    }
+    this.debounceTimers.clear()
+    this.debounceBuffers.clear()
+    this.debounceRunStatus.clear()
+
+    for (const timer of this.timeoutTimers.values()) {
+      clearTimeout(timer)
+    }
+    this.timeoutTimers.clear()
+    this.timeoutDelivered.clear()
   }
 
   private async recoverSync(
@@ -586,9 +650,9 @@ export class WakeRegistry {
     })
   }
 
-  private startTimeoutTimer(reg: CachedWakeRegistration, dbId: number): void {
-    if (reg.timeoutMs == null || reg.timeoutMs <= 0) return
-    this.startTimeoutTimerWithDuration(reg, dbId, reg.timeoutMs)
+  private startTimeoutTimer(reg: WakeRegistrationCollectionRow): void {
+    if (reg.timeoutMs <= 0) return
+    this.startTimeoutTimerWithDuration(reg, reg.timeoutMs)
   }
 
   private async markTimeoutConsumed(
@@ -604,12 +668,13 @@ export class WakeRegistry {
           )
           .findOne()
       )
-      const normalized = ((
-        row as
-          | { reg?: WakeRegistrationCollectionRow }
-          | WakeRegistrationCollectionRow
-          | undefined
-      )?.reg ?? row) as WakeRegistrationCollectionRow | undefined
+      const queried = row as
+        | { reg?: WakeRegistrationCollectionRow }
+        | WakeRegistrationCollectionRow
+        | undefined
+      const normalized = (
+        queried && `reg` in queried ? queried.reg : queried
+      ) as WakeRegistrationCollectionRow | undefined
       if (!normalized) return
       const tx = this.markTimeoutConsumedAction({ row: normalized })
       await tx.isPersisted.promise
@@ -847,14 +912,13 @@ export class WakeRegistry {
   }
 
   private startTimeoutTimerWithDuration(
-    reg: CachedWakeRegistration,
-    dbId: number,
+    reg: WakeRegistrationCollectionRow,
     durationMs: number
   ): void {
     const timerKey = this.registrationKey(reg)
     const timer = setTimeout(() => {
       this.timeoutTimers.delete(timerKey)
-      this.deliverTimeoutForRegistration(reg, dbId)
+      this.deliverTimeoutForRegistration(reg)
     }, durationMs)
     this.timeoutTimers.set(timerKey, timer)
   }
@@ -966,10 +1030,16 @@ export class WakeRegistry {
     }
   }
 
-  private syncTimeoutTimer(reg: CachedWakeRegistration): void {
+  private syncTimeoutTimer(
+    registration: CachedWakeRegistration | WakeRegistrationCollectionRow
+  ): void {
+    const reg =
+      `dbId` in registration
+        ? this.cachedRegistrationAsCollectionRow(registration)
+        : registration
     const timerKey = this.registrationKey(reg)
 
-    if (reg.timeoutConsumed || reg.timeoutMs == null || reg.timeoutMs <= 0) {
+    if (reg.timeoutConsumed || reg.timeoutMs <= 0) {
       this.clearTimeoutState(timerKey)
       return
     }
@@ -978,31 +1048,30 @@ export class WakeRegistry {
       return
     }
 
-    if (!reg.createdAt) {
-      this.startTimeoutTimer(reg, reg.dbId)
-      return
-    }
-
     const remaining = reg.createdAt.getTime() + reg.timeoutMs - Date.now()
     if (remaining > 0) {
-      this.startTimeoutTimerWithDuration(reg, reg.dbId, remaining)
+      this.startTimeoutTimerWithDuration(reg, remaining)
       return
     }
 
-    if (this.timeoutDelivered.has(reg.dbId)) {
+    if (this.timeoutDelivered.has(reg.id)) {
       return
     }
 
-    this.deliverTimeoutForRegistration(reg, reg.dbId)
+    this.deliverTimeoutForRegistration(reg)
   }
 
   private deliverTimeoutForRegistration(
-    reg: CachedWakeRegistration,
-    dbId: number
+    reg: WakeRegistrationCollectionRow
   ): void {
-    if (this.deliverTimeout(this.timeoutWakeResult(reg, dbId))) {
-      this.timeoutDelivered.add(dbId)
-      void this.markTimeoutConsumed(dbId, reg.tenantId)
+    if (this.deliverTimeout(this.timeoutWakeResult(reg))) {
+      this.timeoutDelivered.add(reg.id)
+      void this.markTimeoutConsumed(reg.id, reg.tenantId).catch((error) => {
+        serverLog.warn(
+          `[wake-registry] failed to mark timeout consumed for registration ${reg.id} (${reg.tenantId}, ${reg.sourceUrl} -> ${reg.subscriberUrl}):`,
+          error
+        )
+      })
     }
   }
 
@@ -1016,14 +1085,29 @@ export class WakeRegistry {
     }
   }
 
+  private async syncTenantCollectionTimeoutTimers(
+    tenantId: string
+  ): Promise<void> {
+    if (!this.registrationsCollection) return
+    const rows = await queryOnce((q) =>
+      q
+        .from({ reg: this.requireCollection() })
+        .where(({ reg }) => dbEq(reg.tenantId, tenantId))
+    )
+    for (const queriedRow of rows) {
+      const row = ((queriedRow as { reg?: WakeRegistrationCollectionRow })
+        .reg ?? queriedRow) as WakeRegistrationCollectionRow
+      this.syncTimeoutTimer(row)
+    }
+  }
+
   private timeoutWakeResult(
-    reg: CachedWakeRegistration,
-    dbId: number
+    reg: WakeRegistrationCollectionRow
   ): WakeEvalResult {
     return {
       tenantId: reg.tenantId,
       subscriberUrl: reg.subscriberUrl,
-      registrationDbId: dbId,
+      registrationDbId: reg.id,
       sourceEventKey: `timeout`,
       wakeMessage: {
         source: reg.sourceUrl,

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -17,6 +17,20 @@ import { DEFAULT_TENANT_ID } from './tenant.js'
 import type { DrizzleDB } from './db/index.js'
 import type { Collection } from '@tanstack/db'
 
+class WakeRegistrationConflictError extends Error {
+  constructor() {
+    super(`Wake registration insert conflicted with an existing row`)
+    this.name = `WakeRegistrationConflictError`
+  }
+}
+
+class WakeRegistrationStaleError extends Error {
+  constructor() {
+    super(`Wake registration row was no longer present`)
+    this.name = `WakeRegistrationStaleError`
+  }
+}
+
 export interface WakeRegistration {
   tenantId?: string
   subscriberUrl: string
@@ -278,8 +292,7 @@ export class WakeRegistry {
         if (this.mode === `electric`) {
           const txid = await this.persistInsert(row)
           if (txid === undefined) {
-            this.requireCollection().utils.acceptMutations(transaction)
-            return
+            throw new WakeRegistrationConflictError()
           }
           await this.requireCollection().utils.awaitTxId(txid, 10_000)
           return { txid }
@@ -333,6 +346,9 @@ export class WakeRegistry {
           ...row,
           timeoutConsumed: true,
         })
+        if (txid === undefined) {
+          throw new WakeRegistrationStaleError()
+        }
         await this.requireCollection().utils.awaitTxId(txid, 10_000)
         return { txid }
       }
@@ -496,18 +512,9 @@ export class WakeRegistry {
     })
   }
 
-  private async currentTxidInTransaction(tx: any): Promise<string> {
-    const rows = await tx.execute(
-      sql<{ txid: string }>`select pg_current_xact_id()::xid::text as txid`
-    )
-    return Array.isArray(rows)
-      ? rows[0]!.txid
-      : ((rows as any).rows?.[0]?.txid ?? (rows as any)[0]!.txid)
-  }
-
   private async persistTimeoutConsumed(
     row: WakeRegistrationCollectionRow
-  ): Promise<number> {
+  ): Promise<number | undefined> {
     return await this.db.transaction(async (tx) => {
       const rows = await tx
         .update(wakeRegistrations)
@@ -519,7 +526,7 @@ export class WakeRegistry {
           )
         )
         .returning({ txid: sql<string>`pg_current_xact_id()::xid::text` })
-      return Number(rows[0]?.txid ?? (await this.currentTxidInTransaction(tx)))
+      return rows[0]?.txid === undefined ? undefined : Number(rows[0].txid)
     })
   }
 
@@ -577,7 +584,12 @@ export class WakeRegistry {
     const tx = this.registerAction(
       this.normalizeRegistration(reg, tenantId, id)
     )
-    await tx.isPersisted.promise
+    try {
+      await tx.isPersisted.promise
+    } catch (error) {
+      if (error instanceof WakeRegistrationConflictError) return
+      throw error
+    }
   }
 
   private startTimeoutTimer(reg: WakeRegistrationCollectionRow): void {
@@ -607,7 +619,12 @@ export class WakeRegistry {
       ) as WakeRegistrationCollectionRow | undefined
       if (!normalized) return
       const tx = this.markTimeoutConsumedAction({ row: normalized })
-      await tx.isPersisted.promise
+      try {
+        await tx.isPersisted.promise
+      } catch (error) {
+        if (error instanceof WakeRegistrationStaleError) return
+        throw error
+      }
       return
     }
     await this.db
@@ -875,111 +892,113 @@ export class WakeRegistry {
     tenantId?: string
   ): Promise<Array<WakeEvalResult>> {
     const resolvedTenantId = this.resolveTenantId(tenantId)
-    {
-      const queriedRegs = await queryOnce((q) =>
-        q
-          .from({ reg: this.requireCollection() })
-          .where(({ reg }) =>
-            dbAnd(
-              dbEq(reg.tenantId, resolvedTenantId),
-              dbEq(reg.sourceUrl, sourceUrl)
-            )
+    const queriedRegs = await queryOnce((q) =>
+      q
+        .from({ reg: this.requireCollection() })
+        .where(({ reg }) =>
+          dbAnd(
+            dbEq(reg.tenantId, resolvedTenantId),
+            dbEq(reg.sourceUrl, sourceUrl)
           )
-      )
-      const regs = queriedRegs.map(
-        (queriedReg) =>
-          ((queriedReg as { reg?: WakeRegistrationCollectionRow }).reg ??
-            queriedReg) as WakeRegistrationCollectionRow
-      )
-      if (regs.length === 0) return []
+        )
+    )
+    const regs = queriedRegs.map(
+      (queriedReg) =>
+        ((queriedReg as { reg?: WakeRegistrationCollectionRow }).reg ??
+          queriedReg) as WakeRegistrationCollectionRow
+    )
+    if (regs.length === 0) return []
 
-      const results: Array<WakeEvalResult> = []
-      const oneShotRows: Array<WakeRegistrationCollectionRow> = []
+    const results: Array<WakeEvalResult> = []
+    const oneShotRows: Array<WakeRegistrationCollectionRow> = []
 
-      for (const reg of regs) {
-        const match = this.matchCondition(reg, event)
-        if (!match) continue
+    for (const reg of regs) {
+      const match = this.matchCondition(reg, event)
+      if (!match) continue
 
-        const timerKey = this.registrationKey(reg)
-        const timeoutTimer = this.timeoutTimers.get(timerKey)
-        if (timeoutTimer) {
-          clearTimeout(timeoutTimer)
-          this.timeoutTimers.delete(timerKey)
-          void this.markTimeoutConsumed(reg.id, reg.tenantId)
-        }
-
-        if (reg.debounceMs > 0) {
-          const buffer = this.debounceBuffers.get(timerKey) ?? []
-          buffer.push(match.change)
-          this.debounceBuffers.set(timerKey, buffer)
-
-          if (match.runFinishedStatus) {
-            this.debounceRunStatus.set(timerKey, match.runFinishedStatus)
-          }
-
-          const existing = this.debounceTimers.get(timerKey)
-          if (existing) clearTimeout(existing)
-
-          const timer = setTimeout(() => {
-            this.debounceTimers.delete(timerKey)
-            const flushed = this.debounceBuffers.get(timerKey)
-            if (flushed && flushed.length > 0) {
-              this.debounceBuffers.delete(timerKey)
-              const runStatus = this.debounceRunStatus.get(timerKey)
-              this.debounceRunStatus.delete(timerKey)
-              this.deliverDebounce({
-                tenantId: reg.tenantId,
-                subscriberUrl: reg.subscriberUrl,
-                registrationDbId: reg.id,
-                sourceEventKey: flushed[flushed.length - 1]!.key,
-                wakeMessage: {
-                  source: sourceUrl,
-                  timeout: false,
-                  changes: flushed,
-                },
-                runFinishedStatus: runStatus,
-                includeResponse: reg.includeResponse,
-              })
-            }
-          }, reg.debounceMs)
-          this.debounceTimers.set(timerKey, timer)
-        } else {
-          results.push({
-            tenantId: reg.tenantId,
-            subscriberUrl: reg.subscriberUrl,
-            registrationDbId: reg.id,
-            sourceEventKey: wakeSourceEventId(event),
-            wakeMessage: {
-              source: sourceUrl,
-              timeout: false,
-              changes: [match.change],
-            },
-            runFinishedStatus: match.runFinishedStatus,
-            includeResponse: reg.includeResponse,
-          })
-        }
-
-        if (reg.oneShot) {
-          oneShotRows.push(reg)
-        }
-      }
-
-      if (oneShotRows.length > 0) {
-        const tx = this.deleteRowsAction({
-          rows: oneShotRows,
-          persist: { kind: `oneShot` },
-        })
-        void tx.isPersisted.promise.catch((error) => {
+      const timerKey = this.registrationKey(reg)
+      const timeoutTimer = this.timeoutTimers.get(timerKey)
+      if (timeoutTimer) {
+        clearTimeout(timeoutTimer)
+        this.timeoutTimers.delete(timerKey)
+        void this.markTimeoutConsumed(reg.id, reg.tenantId).catch((error) => {
           console.warn(
-            `[wake-registry] failed to persist one-shot cleanup:`,
+            `[wake-registry] failed to persist timeout consumption:`,
             error
           )
         })
       }
 
-      return results
+      if (reg.debounceMs > 0) {
+        const buffer = this.debounceBuffers.get(timerKey) ?? []
+        buffer.push(match.change)
+        this.debounceBuffers.set(timerKey, buffer)
+
+        if (match.runFinishedStatus) {
+          this.debounceRunStatus.set(timerKey, match.runFinishedStatus)
+        }
+
+        const existing = this.debounceTimers.get(timerKey)
+        if (existing) clearTimeout(existing)
+
+        const timer = setTimeout(() => {
+          this.debounceTimers.delete(timerKey)
+          const flushed = this.debounceBuffers.get(timerKey)
+          if (flushed && flushed.length > 0) {
+            this.debounceBuffers.delete(timerKey)
+            const runStatus = this.debounceRunStatus.get(timerKey)
+            this.debounceRunStatus.delete(timerKey)
+            this.deliverDebounce({
+              tenantId: reg.tenantId,
+              subscriberUrl: reg.subscriberUrl,
+              registrationDbId: reg.id,
+              sourceEventKey: flushed[flushed.length - 1]!.key,
+              wakeMessage: {
+                source: sourceUrl,
+                timeout: false,
+                changes: flushed,
+              },
+              runFinishedStatus: runStatus,
+              includeResponse: reg.includeResponse,
+            })
+          }
+        }, reg.debounceMs)
+        this.debounceTimers.set(timerKey, timer)
+      } else {
+        results.push({
+          tenantId: reg.tenantId,
+          subscriberUrl: reg.subscriberUrl,
+          registrationDbId: reg.id,
+          sourceEventKey: wakeSourceEventId(event),
+          wakeMessage: {
+            source: sourceUrl,
+            timeout: false,
+            changes: [match.change],
+          },
+          runFinishedStatus: match.runFinishedStatus,
+          includeResponse: reg.includeResponse,
+        })
+      }
+
+      if (reg.oneShot) {
+        oneShotRows.push(reg)
+      }
     }
-    return []
+
+    if (oneShotRows.length > 0) {
+      const tx = this.deleteRowsAction({
+        rows: oneShotRows,
+        persist: { kind: `oneShot` },
+      })
+      void tx.isPersisted.promise.catch((error) => {
+        console.warn(
+          `[wake-registry] failed to persist one-shot cleanup:`,
+          error
+        )
+      })
+    }
+
+    return results
   }
 
   /** Flush any pending debounce buffers for a subscriber and return them. */

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -297,7 +297,17 @@ export class WakeRegistry {
           if (txid === undefined) {
             throw new WakeRegistrationConflictError(row)
           }
-          await this.requireCollection().utils.awaitTxId(txid, 10_000)
+          try {
+            await this.requireCollection().utils.awaitTxId(txid, 10_000)
+          } catch (error) {
+            if (
+              error instanceof Error &&
+              error.name === `TimeoutWaitingForTxIdError`
+            ) {
+              return { txid }
+            }
+            throw error
+          }
           return { txid }
         }
         throw new Error(`WakeRegistry registerAction called before startup`)

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -409,7 +409,7 @@ export class WakeRegistry {
     this.mode = `electric`
     this.registrationsCollection = createCollection(
       electricCollectionOptions({
-        id: `wake-registrations:${this.tenantId ?? `all`}`,
+        id: `wake-registrations:${this.tenantId ?? `all`}:${electricUrlWithPath(electricUrl, `/v1/shape`).toString()}`,
         getKey: (row: any) => row.id as number,
         shapeOptions: {
           url: electricUrlWithPath(electricUrl, `/v1/shape`).toString(),

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -95,6 +95,11 @@ export interface WakeRegistrationCollectionRow {
 
 type WakeRegistryMode = `unstarted` | `local-test` | `electric`
 
+type PersistInsertResult = {
+  txid: number
+  row: WakeRegistrationCollectionRow
+}
+
 type DeleteRowsInput = {
   rows: Array<WakeRegistrationCollectionRow>
   persist:
@@ -293,24 +298,25 @@ export class WakeRegistry {
           return
         }
         if (this.mode === `electric`) {
-          const txid = await this.persistInsert(row)
-          if (txid === undefined) {
-            this.requireCollection().utils.acceptMutations(transaction)
-            return
+          const result = await this.persistInsert(row)
+          if (result.row.id !== row.id) {
+            const collection = this.requireCollection()
+            collection.delete(row.id)
+            collection.insert(result.row)
           }
           try {
-            await this.requireCollection().utils.awaitTxId(txid, 10_000)
+            await this.requireCollection().utils.awaitTxId(result.txid, 10_000)
           } catch (error) {
             if (
               error instanceof Error &&
               error.name === `TimeoutWaitingForTxIdError`
             ) {
               this.requireCollection().utils.acceptMutations(transaction)
-              return { txid }
+              return { txid: result.txid }
             }
             throw error
           }
-          return { txid }
+          return { txid: result.txid }
         }
         throw new Error(`WakeRegistry registerAction called before startup`)
       },
@@ -429,6 +435,7 @@ export class WakeRegistry {
   async startSync(electricUrl: string, electricSecret?: string): Promise<void> {
     if (this.registrationsCollection) {
       await this.registrationsCollection.preload()
+      this.startRegistrationEffect()
       return
     }
 
@@ -469,16 +476,26 @@ export class WakeRegistry {
       } as any)
     ) as any
 
-    await this.requireCollection().preload()
+    try {
+      await this.requireCollection().preload()
+    } catch (error) {
+      const collection = this.registrationsCollection
+      this.registrationsCollection = null
+      this.mode = `unstarted`
+      await collection?.cleanup?.()
+      throw error
+    }
     this.startRegistrationEffect()
   }
 
   async stopSync(): Promise<void> {
+    const collection = this.registrationsCollection
     await this.registrationsEffect?.dispose()
     this.registrationsEffect = null
     this.registrationsCollection = null
     this.mode = `unstarted`
     this.resetRuntimeState()
+    await collection?.cleanup?.()
   }
 
   private resetRuntimeState(): void {
@@ -528,7 +545,7 @@ export class WakeRegistry {
 
   private async persistInsert(
     row: WakeRegistrationCollectionRow
-  ): Promise<number | undefined> {
+  ): Promise<PersistInsertResult> {
     return await this.db.transaction(async (tx) => {
       const rows = await tx
         .insert(wakeRegistrations)
@@ -546,9 +563,53 @@ export class WakeRegistry {
           manifestKey: row.manifestKey,
           createdAt: row.createdAt,
         })
-        .onConflictDoNothing()
-        .returning({ txid: sql<string>`pg_current_xact_id()::xid::text` })
-      return rows[0]?.txid === undefined ? undefined : Number(rows[0].txid)
+        .onConflictDoUpdate({
+          target: [
+            wakeRegistrations.tenantId,
+            wakeRegistrations.subscriberUrl,
+            wakeRegistrations.sourceUrl,
+            wakeRegistrations.oneShot,
+            wakeRegistrations.debounceMs,
+            wakeRegistrations.timeoutMs,
+            wakeRegistrations.condition,
+            wakeRegistrations.manifestKey,
+          ],
+          set: { createdAt: sql`${wakeRegistrations.createdAt}` },
+        })
+        .returning({
+          id: wakeRegistrations.id,
+          tenantId: wakeRegistrations.tenantId,
+          subscriberUrl: wakeRegistrations.subscriberUrl,
+          sourceUrl: wakeRegistrations.sourceUrl,
+          condition: wakeRegistrations.condition,
+          debounceMs: wakeRegistrations.debounceMs,
+          timeoutMs: wakeRegistrations.timeoutMs,
+          oneShot: wakeRegistrations.oneShot,
+          timeoutConsumed: wakeRegistrations.timeoutConsumed,
+          includeResponse: wakeRegistrations.includeResponse,
+          manifestKey: wakeRegistrations.manifestKey,
+          createdAt: wakeRegistrations.createdAt,
+          txid: sql<string>`pg_current_xact_id()::xid::text`,
+        })
+      const inserted = rows[0]
+      if (!inserted) throw new Error(`Wake registration insert returned no row`)
+      return {
+        txid: Number(inserted.txid),
+        row: {
+          id: inserted.id,
+          tenantId: inserted.tenantId,
+          subscriberUrl: inserted.subscriberUrl,
+          sourceUrl: inserted.sourceUrl,
+          condition: inserted.condition as WakeRegistration[`condition`],
+          debounceMs: inserted.debounceMs,
+          timeoutMs: inserted.timeoutMs,
+          oneShot: inserted.oneShot,
+          timeoutConsumed: inserted.timeoutConsumed,
+          includeResponse: inserted.includeResponse,
+          manifestKey: inserted.manifestKey,
+          createdAt: inserted.createdAt,
+        },
+      }
     })
   }
 

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -8,7 +8,7 @@ import {
   localOnlyCollectionOptions,
   queryOnce,
 } from '@tanstack/db'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, inArray, sql } from 'drizzle-orm'
 import { electricCollectionOptions } from '@tanstack/electric-db-collection'
 import { wakeRegistrations } from './db/schema.js'
 import { serverLog } from './utils/log.js'
@@ -295,7 +295,8 @@ export class WakeRegistry {
         if (this.mode === `electric`) {
           const txid = await this.persistInsert(row)
           if (txid === undefined) {
-            throw new WakeRegistrationConflictError(row)
+            this.requireCollection().utils.acceptMutations(transaction)
+            return
           }
           try {
             await this.requireCollection().utils.awaitTxId(txid, 10_000)
@@ -304,6 +305,7 @@ export class WakeRegistry {
               error instanceof Error &&
               error.name === `TimeoutWaitingForTxIdError`
             ) {
+              this.requireCollection().utils.acceptMutations(transaction)
               return { txid }
             }
             throw error
@@ -323,18 +325,29 @@ export class WakeRegistry {
         collection.delete(row.id)
       }
     },
-    mutationFn: async ({ rows }, { transaction }) => {
+    mutationFn: async (input, { transaction }) => {
       if (this.mode === `local-test`) {
         this.requireCollection().utils.acceptMutations(transaction)
         return
       }
       if (this.mode === `electric`) {
-        const txid = await this.persistDeleteRows(rows)
+        const txid = await this.persistDeleteRows(input)
         if (txid === undefined) {
           this.requireCollection().utils.acceptMutations(transaction)
           return
         }
-        await this.requireCollection().utils.awaitTxId(txid, 10_000)
+        try {
+          await this.requireCollection().utils.awaitTxId(txid, 10_000)
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.name === `TimeoutWaitingForTxIdError`
+          ) {
+            this.requireCollection().utils.acceptMutations(transaction)
+            return { txid }
+          }
+          throw error
+        }
         return { txid }
       }
       throw new Error(`WakeRegistry deleteRowsAction called before startup`)
@@ -557,25 +570,53 @@ export class WakeRegistry {
     })
   }
 
-  private async persistDeleteRows(
-    rows: Array<WakeRegistrationCollectionRow>
-  ): Promise<number | undefined> {
-    if (rows.length === 0) return undefined
-    return await this.db.transaction(async (tx) => {
-      let txid: string | undefined
-      for (const row of rows) {
-        const deleted = await tx
-          .delete(wakeRegistrations)
-          .where(
-            and(
-              eq(wakeRegistrations.tenantId, row.tenantId),
-              eq(wakeRegistrations.id, row.id)
+  private deletePredicate(input: DeleteRowsInput) {
+    switch (input.persist.kind) {
+      case `manifestKey`:
+        return and(
+          eq(wakeRegistrations.tenantId, input.persist.tenantId),
+          eq(wakeRegistrations.subscriberUrl, input.persist.subscriberUrl),
+          eq(wakeRegistrations.manifestKey, input.persist.manifestKey)
+        )
+      case `subscriber`:
+        return and(
+          eq(wakeRegistrations.tenantId, input.persist.tenantId),
+          eq(wakeRegistrations.subscriberUrl, input.persist.subscriberUrl)
+        )
+      case `source`:
+        return and(
+          eq(wakeRegistrations.tenantId, input.persist.tenantId),
+          eq(wakeRegistrations.sourceUrl, input.persist.sourceUrl)
+        )
+      case `subscriberAndSource`:
+        return and(
+          eq(wakeRegistrations.tenantId, input.persist.tenantId),
+          eq(wakeRegistrations.subscriberUrl, input.persist.subscriberUrl),
+          eq(wakeRegistrations.sourceUrl, input.persist.sourceUrl)
+        )
+      case `oneShot`:
+        return input.rows.length === 0
+          ? undefined
+          : inArray(
+              wakeRegistrations.id,
+              input.rows.map((row) => row.id)
             )
-          )
-          .returning({ txid: sql<string>`pg_current_xact_id()::xid::text` })
-        txid = deleted[0]?.txid ?? txid
-      }
-      return txid === undefined ? undefined : Number(txid)
+    }
+  }
+
+  private async persistDeleteRows(
+    input: DeleteRowsInput
+  ): Promise<number | undefined> {
+    const predicate = this.deletePredicate(input)
+    if (!predicate) return undefined
+    return await this.db.transaction(async (tx) => {
+      const deleted = await tx
+        .delete(wakeRegistrations)
+        .where(predicate)
+        .returning({ txid: sql<string>`pg_current_xact_id()::xid::text` })
+      return deleted[0]?.txid === undefined
+        ? undefined
+        : Number(deleted[0].txid)
     })
   }
 
@@ -689,6 +730,17 @@ export class WakeRegistry {
       )
   }
 
+  private async deleteRows(input: DeleteRowsInput): Promise<void> {
+    if (this.registrationsCollection && input.rows.length > 0) {
+      const tx = this.deleteRowsAction(input)
+      await tx.isPersisted.promise
+      return
+    }
+    if (this.mode === `electric`) {
+      await this.persistDeleteRows(input)
+    }
+  }
+
   async unregisterByManifestKey(
     subscriberUrl: string,
     manifestKey: string,
@@ -702,7 +754,7 @@ export class WakeRegistry {
           row.subscriberUrl === subscriberUrl &&
           row.manifestKey === manifestKey
       )
-      const tx = this.deleteRowsAction({
+      await this.deleteRows({
         rows,
         persist: {
           kind: `manifestKey`,
@@ -711,7 +763,6 @@ export class WakeRegistry {
           manifestKey,
         },
       })
-      await tx.isPersisted.promise
       return
     }
 
@@ -738,7 +789,7 @@ export class WakeRegistry {
           row.tenantId === resolvedTenantId &&
           row.subscriberUrl === subscriberUrl
       )
-      const tx = this.deleteRowsAction({
+      await this.deleteRows({
         rows,
         persist: {
           kind: `subscriber`,
@@ -746,7 +797,6 @@ export class WakeRegistry {
           subscriberUrl,
         },
       })
-      await tx.isPersisted.promise
       return
     }
 
@@ -768,11 +818,10 @@ export class WakeRegistry {
     if (this.registrationsCollection) {
       const resolvedTenantId = this.resolveTenantId(tenantId)
       const rows = await this.rowsForSource(resolvedTenantId, sourceUrl)
-      const tx = this.deleteRowsAction({
+      await this.deleteRows({
         rows,
         persist: { kind: `source`, tenantId: resolvedTenantId, sourceUrl },
       })
-      await tx.isPersisted.promise
       return
     }
 
@@ -800,7 +849,7 @@ export class WakeRegistry {
           row.subscriberUrl === subscriberUrl &&
           row.sourceUrl === sourceUrl
       )
-      const tx = this.deleteRowsAction({
+      await this.deleteRows({
         rows,
         persist: {
           kind: `subscriberAndSource`,
@@ -809,7 +858,6 @@ export class WakeRegistry {
           sourceUrl,
         },
       })
-      await tx.isPersisted.promise
       return
     }
 

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -483,6 +483,20 @@ export class WakeRegistry {
     this.timeoutDelivered.clear()
   }
 
+  private async allocateRegistrationId(): Promise<number> {
+    if (this.mode !== `electric`) {
+      return this.allocateLocalId()
+    }
+
+    for (let attempt = 0; attempt < 100; attempt++) {
+      const id = await this.allocateRuntimeId()
+      const existing = await this.rowsByPredicate((row) => row.id === id)
+      if (existing.length === 0) return id
+    }
+
+    throw new Error(`Failed to allocate unused wake registration id`)
+  }
+
   private async allocateRuntimeId(): Promise<number> {
     const rows = await this.db.execute(
       sql<{
@@ -614,10 +628,7 @@ export class WakeRegistry {
       )
       if (existing.length > 0) return
     }
-    const id =
-      this.mode === `electric`
-        ? await this.allocateRuntimeId()
-        : this.allocateLocalId()
+    const id = await this.allocateRegistrationId()
     const tx = this.registerAction(
       this.normalizeRegistration(reg, tenantId, id)
     )

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -239,7 +239,7 @@ export class WakeRegistry {
       oneShot: reg.oneShot,
       timeoutConsumed: false,
       includeResponse: reg.includeResponse !== false,
-      manifestKey: reg.manifestKey ?? null,
+      manifestKey: reg.manifestKey ?? ``,
       createdAt: new Date(),
     }
   }
@@ -299,11 +299,6 @@ export class WakeRegistry {
         }
         if (this.mode === `electric`) {
           const result = await this.persistInsert(row)
-          if (result.row.id !== row.id) {
-            const collection = this.requireCollection()
-            collection.delete(row.id)
-            collection.insert(result.row)
-          }
           try {
             await this.requireCollection().utils.awaitTxId(result.txid, 10_000)
           } catch (error) {
@@ -560,7 +555,7 @@ export class WakeRegistry {
           oneShot: row.oneShot,
           timeoutConsumed: row.timeoutConsumed,
           includeResponse: row.includeResponse,
-          manifestKey: row.manifestKey,
+          manifestKey: row.manifestKey ?? ``,
           createdAt: row.createdAt,
         })
         .onConflictDoUpdate({
@@ -574,7 +569,12 @@ export class WakeRegistry {
             wakeRegistrations.condition,
             wakeRegistrations.manifestKey,
           ],
-          set: { createdAt: sql`${wakeRegistrations.createdAt}` },
+          set: {
+            id: row.id,
+            timeoutConsumed: row.timeoutConsumed,
+            includeResponse: row.includeResponse,
+            createdAt: sql`${wakeRegistrations.createdAt}`,
+          },
         })
         .returning({
           id: wakeRegistrations.id,

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -3,6 +3,14 @@ import {
   isChangeMessage,
   isControlMessage,
 } from '@electric-sql/client'
+import {
+  and as dbAnd,
+  createCollection,
+  createOptimisticAction,
+  eq as dbEq,
+  localOnlyCollectionOptions,
+  queryOnce,
+} from '@tanstack/db'
 import { and, eq } from 'drizzle-orm'
 import { wakeRegistrations } from './db/schema.js'
 import { serverLog } from './utils/log.js'
@@ -10,6 +18,7 @@ import { electricUrlWithPath } from './utils/electric-url.js'
 import { DEFAULT_TENANT_ID } from './tenant.js'
 import type { DrizzleDB } from './db/index.js'
 import type { Message, Row, Value } from '@electric-sql/client'
+import type { Collection } from '@tanstack/db'
 
 export interface WakeRegistration {
   tenantId?: string
@@ -57,6 +66,23 @@ export interface WakeEvalResult {
 
 export type WakeTimeoutCallback = (result: WakeEvalResult) => void
 export type WakeDebounceCallback = (result: WakeEvalResult) => void
+
+export interface WakeRegistrationCollectionRow {
+  id: number
+  tenantId: string
+  subscriberUrl: string
+  sourceUrl: string
+  condition: WakeRegistration[`condition`]
+  debounceMs: number
+  timeoutMs: number
+  oneShot: boolean
+  timeoutConsumed: boolean
+  includeResponse: boolean
+  manifestKey: string | null
+  createdAt: Date
+}
+
+type WakeRegistryMode = `unstarted` | `local-test` | `electric`
 
 interface CachedWakeRegistration extends WakeRegistration {
   tenantId: string
@@ -107,6 +133,13 @@ function sqlStringLiteral(value: string): string {
 
 export class WakeRegistry {
   private db: DrizzleDB
+  private registrationsCollection: Collection<
+    WakeRegistrationCollectionRow,
+    number,
+    any
+  > | null = null
+  private mode: WakeRegistryMode = `unstarted`
+  private nextLocalId = 1
   private registrationCache = new Map<string, Array<CachedWakeRegistration>>()
   private debounceTimers = new Map<string, NodeJS.Timeout>()
   private debounceBuffers = new Map<
@@ -132,6 +165,87 @@ export class WakeRegistry {
     this.db = db
   }
 
+  requireCollection(): Collection<WakeRegistrationCollectionRow, number, any> {
+    if (!this.registrationsCollection) {
+      throw new Error(`WakeRegistry has not been started`)
+    }
+    return this.registrationsCollection
+  }
+
+  async startLocalForTests(): Promise<void> {
+    if (this.registrationsCollection) return
+    this.mode = `local-test`
+    this.registrationsCollection = createCollection(
+      localOnlyCollectionOptions<WakeRegistrationCollectionRow, number>({
+        id: `wake-registrations-local:${this.tenantId ?? `all`}`,
+        getKey: (row) => row.id,
+        initialData: [],
+      })
+    )
+    await this.requireCollection().preload()
+  }
+
+  private allocateLocalId(): number {
+    return this.nextLocalId++
+  }
+
+  private normalizeRegistration(
+    reg: WakeRegistration,
+    tenantId: string,
+    id: number
+  ): WakeRegistrationCollectionRow {
+    return {
+      id,
+      tenantId,
+      subscriberUrl: reg.subscriberUrl,
+      sourceUrl: reg.sourceUrl,
+      condition: reg.condition,
+      debounceMs: reg.debounceMs ?? 0,
+      timeoutMs: reg.timeoutMs ?? 0,
+      oneShot: reg.oneShot,
+      timeoutConsumed: false,
+      includeResponse: reg.includeResponse !== false,
+      manifestKey: reg.manifestKey ?? null,
+      createdAt: new Date(),
+    }
+  }
+
+  private collectionRowAsCached(
+    row: WakeRegistrationCollectionRow
+  ): CachedWakeRegistration {
+    return {
+      tenantId: row.tenantId,
+      subscriberUrl: row.subscriberUrl,
+      sourceUrl: row.sourceUrl,
+      condition: row.condition,
+      debounceMs: row.debounceMs || undefined,
+      timeoutMs: row.timeoutMs || undefined,
+      oneShot: row.oneShot,
+      includeResponse: row.includeResponse === false ? false : undefined,
+      manifestKey: row.manifestKey ?? undefined,
+      dbId: row.id,
+      createdAt: row.createdAt,
+      timeoutConsumed: row.timeoutConsumed,
+    }
+  }
+
+  private registerAction =
+    createOptimisticAction<WakeRegistrationCollectionRow>({
+      onMutate: (row) => {
+        this.requireCollection().insert(row)
+        this.syncTimeoutTimer(this.collectionRowAsCached(row))
+      },
+      mutationFn: async (_row, { transaction }) => {
+        if (this.mode === `local-test`) {
+          this.requireCollection().utils.acceptMutations(transaction)
+          return
+        }
+        throw new Error(
+          `WakeRegistry registerAction runtime persistence is not initialized`
+        )
+      },
+    })
+
   setTimeoutCallback(cb: WakeTimeoutCallback, tenantId?: string): void {
     const resolvedTenantId = this.resolveTenantId(tenantId)
     this.timeoutCallbacks.set(resolvedTenantId, cb)
@@ -152,7 +266,9 @@ export class WakeRegistry {
     return `${tenantId}:${sourceUrl}`
   }
 
-  private registrationKey(reg: CachedWakeRegistration): string {
+  private registrationKey(
+    reg: CachedWakeRegistration | WakeRegistrationCollectionRow
+  ): string {
     return [
       reg.tenantId,
       reg.subscriberUrl,
@@ -327,6 +443,14 @@ export class WakeRegistry {
 
   async register(reg: WakeRegistration): Promise<void> {
     const tenantId = this.resolveTenantId(reg.tenantId)
+    if (this.registrationsCollection) {
+      const id = this.allocateLocalId()
+      const tx = this.registerAction(
+        this.normalizeRegistration(reg, tenantId, id)
+      )
+      await tx.isPersisted.promise
+      return
+    }
     const result = await this.db
       .insert(wakeRegistrations)
       .values({
@@ -580,6 +704,15 @@ export class WakeRegistry {
     this.registrationCache.clear()
   }
 
+  private replaceCachedRegistrations(
+    registrations: Array<CachedWakeRegistration>
+  ): void {
+    this.resetCachedRegistrations()
+    for (const registration of registrations) {
+      this.upsertCachedRegistration(registration)
+    }
+  }
+
   private findCachedRegistration(
     dbId: number
   ): { cacheKey: string; index: number; reg: CachedWakeRegistration } | null {
@@ -762,12 +895,113 @@ export class WakeRegistry {
     this.upsertCachedRegistration(this.normalizeShapeRow(message.value))
   }
 
-  evaluate(
+  async evaluate(
     sourceUrl: string,
     event: Record<string, unknown>,
     tenantId?: string
-  ): Array<WakeEvalResult> {
+  ): Promise<Array<WakeEvalResult>> {
     const resolvedTenantId = this.resolveTenantId(tenantId)
+    if (this.registrationsCollection) {
+      const queriedRegs = await queryOnce((q) =>
+        q
+          .from({ reg: this.requireCollection() })
+          .where(({ reg }) =>
+            dbAnd(
+              dbEq(reg.tenantId, resolvedTenantId),
+              dbEq(reg.sourceUrl, sourceUrl)
+            )
+          )
+      )
+      const regs = queriedRegs.map(
+        (queriedReg) =>
+          ((queriedReg as { reg?: WakeRegistrationCollectionRow }).reg ??
+            queriedReg) as WakeRegistrationCollectionRow
+      )
+      if (regs.length === 0) return []
+
+      const results: Array<WakeEvalResult> = []
+      const oneShotIds: Array<number> = []
+
+      for (const reg of regs) {
+        const match = this.matchCondition(reg, event)
+        if (!match) continue
+
+        const timerKey = this.registrationKey(reg)
+        const timeoutTimer = this.timeoutTimers.get(timerKey)
+        if (timeoutTimer) {
+          clearTimeout(timeoutTimer)
+          this.timeoutTimers.delete(timerKey)
+          void this.markTimeoutConsumed(reg.id, reg.tenantId)
+        }
+
+        if (reg.debounceMs > 0) {
+          const buffer = this.debounceBuffers.get(timerKey) ?? []
+          buffer.push(match.change)
+          this.debounceBuffers.set(timerKey, buffer)
+
+          if (match.runFinishedStatus) {
+            this.debounceRunStatus.set(timerKey, match.runFinishedStatus)
+          }
+
+          const existing = this.debounceTimers.get(timerKey)
+          if (existing) clearTimeout(existing)
+
+          const timer = setTimeout(() => {
+            this.debounceTimers.delete(timerKey)
+            const flushed = this.debounceBuffers.get(timerKey)
+            if (flushed && flushed.length > 0) {
+              this.debounceBuffers.delete(timerKey)
+              const runStatus = this.debounceRunStatus.get(timerKey)
+              this.debounceRunStatus.delete(timerKey)
+              this.deliverDebounce({
+                tenantId: reg.tenantId,
+                subscriberUrl: reg.subscriberUrl,
+                registrationDbId: reg.id,
+                sourceEventKey: flushed[flushed.length - 1]!.key,
+                wakeMessage: {
+                  source: sourceUrl,
+                  timeout: false,
+                  changes: flushed,
+                },
+                runFinishedStatus: runStatus,
+                includeResponse: reg.includeResponse,
+              })
+            }
+          }, reg.debounceMs)
+          this.debounceTimers.set(timerKey, timer)
+        } else {
+          results.push({
+            tenantId: reg.tenantId,
+            subscriberUrl: reg.subscriberUrl,
+            registrationDbId: reg.id,
+            sourceEventKey: wakeSourceEventId(event),
+            wakeMessage: {
+              source: sourceUrl,
+              timeout: false,
+              changes: [match.change],
+            },
+            runFinishedStatus: match.runFinishedStatus,
+            includeResponse: reg.includeResponse,
+          })
+        }
+
+        if (reg.oneShot) {
+          oneShotIds.push(reg.id)
+        }
+      }
+
+      for (let j = oneShotIds.length - 1; j >= 0; j--) {
+        const id = oneShotIds[j]!
+        const removed = regs.find((reg) => reg.id === id)
+        if (removed) {
+          this.clearRegistrationState(this.collectionRowAsCached(removed))
+          this.timeoutDelivered.delete(removed.id)
+          this.requireCollection().delete(removed.id)
+        }
+      }
+
+      return results
+    }
     const cacheKey = this.cacheKey(resolvedTenantId, sourceUrl)
     const regs = this.registrationCache.get(cacheKey)
     if (!regs || regs.length === 0) return []
@@ -906,7 +1140,7 @@ export class WakeRegistry {
   }
 
   private matchCondition(
-    reg: WakeRegistration,
+    reg: WakeRegistration | WakeRegistrationCollectionRow,
     event: Record<string, unknown>
   ): {
     change: WakeEvalResult[`wakeMessage`][`changes`][number]

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -84,6 +84,26 @@ export interface WakeRegistrationCollectionRow {
 
 type WakeRegistryMode = `unstarted` | `local-test` | `electric`
 
+type DeleteRowsInput = {
+  rows: Array<WakeRegistrationCollectionRow>
+  persist:
+    | {
+        kind: `manifestKey`
+        tenantId: string
+        subscriberUrl: string
+        manifestKey: string
+      }
+    | { kind: `subscriber`; tenantId: string; subscriberUrl: string }
+    | { kind: `source`; tenantId: string; sourceUrl: string }
+    | {
+        kind: `subscriberAndSource`
+        tenantId: string
+        subscriberUrl: string
+        sourceUrl: string
+      }
+    | { kind: `oneShot` }
+}
+
 interface CachedWakeRegistration extends WakeRegistration {
   tenantId: string
   dbId: number
@@ -229,6 +249,49 @@ export class WakeRegistry {
     }
   }
 
+  private normalizeQueriedRows(
+    rows: Array<
+      WakeRegistrationCollectionRow | { reg: WakeRegistrationCollectionRow }
+    >
+  ): Array<WakeRegistrationCollectionRow> {
+    return rows.map(
+      (row) =>
+        ((row as { reg?: WakeRegistrationCollectionRow }).reg ??
+          row) as WakeRegistrationCollectionRow
+    )
+  }
+
+  private async rowsByPredicate(
+    predicate: (row: WakeRegistrationCollectionRow) => boolean
+  ): Promise<Array<WakeRegistrationCollectionRow>> {
+    const rows = await queryOnce((q) =>
+      q.from({ reg: this.requireCollection() })
+    )
+    return this.normalizeQueriedRows(
+      rows as Array<
+        WakeRegistrationCollectionRow | { reg: WakeRegistrationCollectionRow }
+      >
+    ).filter(predicate)
+  }
+
+  private async rowsForSource(
+    tenantId: string,
+    sourceUrl: string
+  ): Promise<Array<WakeRegistrationCollectionRow>> {
+    const rows = await queryOnce((q) =>
+      q
+        .from({ reg: this.requireCollection() })
+        .where(({ reg }) =>
+          dbAnd(dbEq(reg.tenantId, tenantId), dbEq(reg.sourceUrl, sourceUrl))
+        )
+    )
+    return this.normalizeQueriedRows(
+      rows as Array<
+        WakeRegistrationCollectionRow | { reg: WakeRegistrationCollectionRow }
+      >
+    )
+  }
+
   private registerAction =
     createOptimisticAction<WakeRegistrationCollectionRow>({
       onMutate: (row) => {
@@ -245,6 +308,45 @@ export class WakeRegistry {
         )
       },
     })
+
+  private deleteRowsAction = createOptimisticAction<DeleteRowsInput>({
+    onMutate: ({ rows }) => {
+      const collection = this.requireCollection()
+      for (const row of rows) {
+        this.clearRegistrationState(row)
+        this.timeoutDelivered.delete(row.id)
+        collection.delete(row.id)
+      }
+    },
+    mutationFn: async ({ persist }, { transaction }) => {
+      if (this.mode === `local-test` || persist.kind === `oneShot`) {
+        this.requireCollection().utils.acceptMutations(transaction)
+        return
+      }
+      throw new Error(
+        `WakeRegistry deleteRowsAction runtime persistence is not initialized`
+      )
+    },
+  })
+
+  private markTimeoutConsumedAction = createOptimisticAction<{
+    row: WakeRegistrationCollectionRow
+  }>({
+    onMutate: ({ row }) => {
+      this.requireCollection().update(row.id, (draft) => {
+        draft.timeoutConsumed = true
+      })
+    },
+    mutationFn: async (_input, { transaction }) => {
+      if (this.mode === `local-test`) {
+        this.requireCollection().utils.acceptMutations(transaction)
+        return
+      }
+      throw new Error(
+        `WakeRegistry markTimeoutConsumedAction runtime persistence is not initialized`
+      )
+    },
+  })
 
   setTimeoutCallback(cb: WakeTimeoutCallback, tenantId?: string): void {
     const resolvedTenantId = this.resolveTenantId(tenantId)
@@ -493,6 +595,26 @@ export class WakeRegistry {
     dbId: number,
     tenantId: string
   ): Promise<void> {
+    if (this.registrationsCollection) {
+      const row = await queryOnce((q) =>
+        q
+          .from({ reg: this.requireCollection() })
+          .where(({ reg }) =>
+            dbAnd(dbEq(reg.tenantId, tenantId), dbEq(reg.id, dbId))
+          )
+          .findOne()
+      )
+      const normalized = ((
+        row as
+          | { reg?: WakeRegistrationCollectionRow }
+          | WakeRegistrationCollectionRow
+          | undefined
+      )?.reg ?? row) as WakeRegistrationCollectionRow | undefined
+      if (!normalized) return
+      const tx = this.markTimeoutConsumedAction({ row: normalized })
+      await tx.isPersisted.promise
+      return
+    }
     await this.db
       .update(wakeRegistrations)
       .set({ timeoutConsumed: true })
@@ -509,6 +631,27 @@ export class WakeRegistry {
     manifestKey: string,
     tenantId?: string
   ): Promise<void> {
+    if (this.registrationsCollection) {
+      const resolvedTenantId = this.resolveTenantId(tenantId)
+      const rows = await this.rowsByPredicate(
+        (row) =>
+          row.tenantId === resolvedTenantId &&
+          row.subscriberUrl === subscriberUrl &&
+          row.manifestKey === manifestKey
+      )
+      const tx = this.deleteRowsAction({
+        rows,
+        persist: {
+          kind: `manifestKey`,
+          tenantId: resolvedTenantId,
+          subscriberUrl,
+          manifestKey,
+        },
+      })
+      await tx.isPersisted.promise
+      return
+    }
+
     const resolvedTenantId = this.resolveTenantId(tenantId)
     await this.db
       .delete(wakeRegistrations)
@@ -541,6 +684,25 @@ export class WakeRegistry {
     subscriberUrl: string,
     tenantId?: string
   ): Promise<void> {
+    if (this.registrationsCollection) {
+      const resolvedTenantId = this.resolveTenantId(tenantId)
+      const rows = await this.rowsByPredicate(
+        (row) =>
+          row.tenantId === resolvedTenantId &&
+          row.subscriberUrl === subscriberUrl
+      )
+      const tx = this.deleteRowsAction({
+        rows,
+        persist: {
+          kind: `subscriber`,
+          tenantId: resolvedTenantId,
+          subscriberUrl,
+        },
+      })
+      await tx.isPersisted.promise
+      return
+    }
+
     const resolvedTenantId = this.resolveTenantId(tenantId)
     await this.db
       .delete(wakeRegistrations)
@@ -570,6 +732,17 @@ export class WakeRegistry {
     sourceUrl: string,
     tenantId?: string
   ): Promise<void> {
+    if (this.registrationsCollection) {
+      const resolvedTenantId = this.resolveTenantId(tenantId)
+      const rows = await this.rowsForSource(resolvedTenantId, sourceUrl)
+      const tx = this.deleteRowsAction({
+        rows,
+        persist: { kind: `source`, tenantId: resolvedTenantId, sourceUrl },
+      })
+      await tx.isPersisted.promise
+      return
+    }
+
     const resolvedTenantId = this.resolveTenantId(tenantId)
     await this.db
       .delete(wakeRegistrations)
@@ -595,6 +768,27 @@ export class WakeRegistry {
     sourceUrl: string,
     tenantId?: string
   ): Promise<void> {
+    if (this.registrationsCollection) {
+      const resolvedTenantId = this.resolveTenantId(tenantId)
+      const rows = await this.rowsByPredicate(
+        (row) =>
+          row.tenantId === resolvedTenantId &&
+          row.subscriberUrl === subscriberUrl &&
+          row.sourceUrl === sourceUrl
+      )
+      const tx = this.deleteRowsAction({
+        rows,
+        persist: {
+          kind: `subscriberAndSource`,
+          tenantId: resolvedTenantId,
+          subscriberUrl,
+          sourceUrl,
+        },
+      })
+      await tx.isPersisted.promise
+      return
+    }
+
     const resolvedTenantId = this.resolveTenantId(tenantId)
     await this.db
       .delete(wakeRegistrations)
@@ -683,7 +877,9 @@ export class WakeRegistry {
     }
   }
 
-  private clearRegistrationState(reg: CachedWakeRegistration): void {
+  private clearRegistrationState(
+    reg: CachedWakeRegistration | WakeRegistrationCollectionRow
+  ): void {
     const timerKey = this.registrationKey(reg)
     this.clearDebounceState(timerKey)
     this.clearTimeoutState(timerKey)
@@ -920,7 +1116,7 @@ export class WakeRegistry {
       if (regs.length === 0) return []
 
       const results: Array<WakeEvalResult> = []
-      const oneShotIds: Array<number> = []
+      const oneShotRows: Array<WakeRegistrationCollectionRow> = []
 
       for (const reg of regs) {
         const match = this.matchCondition(reg, event)
@@ -986,18 +1182,21 @@ export class WakeRegistry {
         }
 
         if (reg.oneShot) {
-          oneShotIds.push(reg.id)
+          oneShotRows.push(reg)
         }
       }
 
-      for (let j = oneShotIds.length - 1; j >= 0; j--) {
-        const id = oneShotIds[j]!
-        const removed = regs.find((reg) => reg.id === id)
-        if (removed) {
-          this.clearRegistrationState(this.collectionRowAsCached(removed))
-          this.timeoutDelivered.delete(removed.id)
-          this.requireCollection().delete(removed.id)
-        }
+      if (oneShotRows.length > 0) {
+        const tx = this.deleteRowsAction({
+          rows: oneShotRows,
+          persist: { kind: `oneShot` },
+        })
+        void tx.isPersisted.promise.catch((error) => {
+          console.warn(
+            `[wake-registry] failed to persist one-shot cleanup:`,
+            error
+          )
+        })
       }
 
       return results

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -1,8 +1,4 @@
-import {
-  ShapeStream,
-  isChangeMessage,
-  isControlMessage,
-} from '@electric-sql/client'
+import { snakeCamelMapper } from '@electric-sql/client'
 import {
   and as dbAnd,
   createCollection,
@@ -12,13 +8,13 @@ import {
   localOnlyCollectionOptions,
   queryOnce,
 } from '@tanstack/db'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
+import { electricCollectionOptions } from '@tanstack/electric-db-collection'
 import { wakeRegistrations } from './db/schema.js'
 import { serverLog } from './utils/log.js'
 import { electricUrlWithPath } from './utils/electric-url.js'
 import { DEFAULT_TENANT_ID } from './tenant.js'
 import type { DrizzleDB } from './db/index.js'
-import type { Message, Row, Value } from '@electric-sql/client'
 import type { Collection } from '@tanstack/db'
 
 export interface WakeRegistration {
@@ -105,28 +101,6 @@ type DeleteRowsInput = {
     | { kind: `oneShot` }
 }
 
-interface CachedWakeRegistration extends WakeRegistration {
-  tenantId: string
-  dbId: number
-  createdAt?: Date
-  timeoutConsumed?: boolean
-}
-
-interface WakeRegistrationShapeRow extends Row<Date> {
-  id: number
-  tenant_id: string
-  subscriber_url: string
-  source_url: string
-  condition: WakeRegistration[`condition`] & Value<Date>
-  debounce_ms: number
-  timeout_ms: number
-  one_shot: boolean
-  timeout_consumed: boolean
-  include_response: boolean
-  manifest_key: string | null
-  created_at: Date
-}
-
 function wakeSourceEventId(event: Record<string, unknown>): string {
   const headers =
     typeof event.headers === `object` && event.headers !== null
@@ -162,7 +136,6 @@ export class WakeRegistry {
   private mode: WakeRegistryMode = `unstarted`
   private nextLocalId = 1
   private registrationsEffect: { dispose(): Promise<void> } | null = null
-  private registrationCache = new Map<string, Array<CachedWakeRegistration>>()
   private debounceTimers = new Map<string, NodeJS.Timeout>()
   private debounceBuffers = new Map<
     string,
@@ -173,12 +146,6 @@ export class WakeRegistry {
   private timeoutDelivered = new Set<number>()
   private timeoutCallbacks = new Map<string, WakeTimeoutCallback>()
   private debounceCallbacks = new Map<string, WakeDebounceCallback>()
-  private syncElectricUrl: string | null = null
-  private syncElectricSecret: string | undefined
-  private syncAbortController: AbortController | null = null
-  private syncUnsubscribe: (() => void) | null = null
-  private syncReadyPromise: Promise<void> | null = null
-  private syncRecoveryPromise: Promise<void> | null = null
 
   constructor(
     db: DrizzleDB,
@@ -255,44 +222,6 @@ export class WakeRegistry {
     }
   }
 
-  private collectionRowAsCached(
-    row: WakeRegistrationCollectionRow
-  ): CachedWakeRegistration {
-    return {
-      tenantId: row.tenantId,
-      subscriberUrl: row.subscriberUrl,
-      sourceUrl: row.sourceUrl,
-      condition: row.condition,
-      debounceMs: row.debounceMs || undefined,
-      timeoutMs: row.timeoutMs || undefined,
-      oneShot: row.oneShot,
-      includeResponse: row.includeResponse === false ? false : undefined,
-      manifestKey: row.manifestKey ?? undefined,
-      dbId: row.id,
-      createdAt: row.createdAt,
-      timeoutConsumed: row.timeoutConsumed,
-    }
-  }
-
-  private cachedRegistrationAsCollectionRow(
-    reg: CachedWakeRegistration
-  ): WakeRegistrationCollectionRow {
-    return {
-      id: reg.dbId,
-      tenantId: reg.tenantId,
-      subscriberUrl: reg.subscriberUrl,
-      sourceUrl: reg.sourceUrl,
-      condition: reg.condition,
-      debounceMs: reg.debounceMs ?? 0,
-      timeoutMs: reg.timeoutMs ?? 0,
-      oneShot: reg.oneShot,
-      timeoutConsumed: reg.timeoutConsumed ?? false,
-      includeResponse: reg.includeResponse !== false,
-      manifestKey: reg.manifestKey ?? null,
-      createdAt: reg.createdAt ?? new Date(),
-    }
-  }
-
   private normalizeQueriedRows(
     rows: Array<
       WakeRegistrationCollectionRow | { reg: WakeRegistrationCollectionRow }
@@ -341,14 +270,21 @@ export class WakeRegistry {
       onMutate: (row) => {
         this.requireCollection().insert(row)
       },
-      mutationFn: async (_row, { transaction }) => {
+      mutationFn: async (row, { transaction }) => {
         if (this.mode === `local-test`) {
           this.requireCollection().utils.acceptMutations(transaction)
           return
         }
-        throw new Error(
-          `WakeRegistry registerAction runtime persistence is not initialized`
-        )
+        if (this.mode === `electric`) {
+          const txid = await this.persistInsert(row)
+          if (txid === undefined) {
+            this.requireCollection().utils.acceptMutations(transaction)
+            return
+          }
+          await this.requireCollection().utils.awaitTxId(txid, 10_000)
+          return { txid }
+        }
+        throw new Error(`WakeRegistry registerAction called before startup`)
       },
     })
 
@@ -361,14 +297,21 @@ export class WakeRegistry {
         collection.delete(row.id)
       }
     },
-    mutationFn: async ({ persist }, { transaction }) => {
-      if (this.mode === `local-test` || persist.kind === `oneShot`) {
+    mutationFn: async ({ rows }, { transaction }) => {
+      if (this.mode === `local-test`) {
         this.requireCollection().utils.acceptMutations(transaction)
         return
       }
-      throw new Error(
-        `WakeRegistry deleteRowsAction runtime persistence is not initialized`
-      )
+      if (this.mode === `electric`) {
+        const txid = await this.persistDeleteRows(rows)
+        if (txid === undefined) {
+          this.requireCollection().utils.acceptMutations(transaction)
+          return
+        }
+        await this.requireCollection().utils.awaitTxId(txid, 10_000)
+        return { txid }
+      }
+      throw new Error(`WakeRegistry deleteRowsAction called before startup`)
     },
   })
 
@@ -380,13 +323,21 @@ export class WakeRegistry {
         draft.timeoutConsumed = true
       })
     },
-    mutationFn: async (_input, { transaction }) => {
+    mutationFn: async ({ row }, { transaction }) => {
       if (this.mode === `local-test`) {
         this.requireCollection().utils.acceptMutations(transaction)
         return
       }
+      if (this.mode === `electric`) {
+        const txid = await this.persistTimeoutConsumed({
+          ...row,
+          timeoutConsumed: true,
+        })
+        await this.requireCollection().utils.awaitTxId(txid, 10_000)
+        return { txid }
+      }
       throw new Error(
-        `WakeRegistry markTimeoutConsumedAction runtime persistence is not initialized`
+        `WakeRegistry markTimeoutConsumedAction called before startup`
       )
     },
   })
@@ -408,13 +359,7 @@ export class WakeRegistry {
     throw new Error(`WakeRegistry tenantId is required in shared mode`)
   }
 
-  private cacheKey(tenantId: string, sourceUrl: string): string {
-    return `${tenantId}:${sourceUrl}`
-  }
-
-  private registrationKey(
-    reg: CachedWakeRegistration | WakeRegistrationCollectionRow
-  ): string {
+  private registrationKey(reg: WakeRegistrationCollectionRow): string {
     return [
       reg.tenantId,
       reg.subscriberUrl,
@@ -440,101 +385,50 @@ export class WakeRegistry {
   }
 
   async startSync(electricUrl: string, electricSecret?: string): Promise<void> {
-    if (this.syncReadyPromise) {
-      await this.syncReadyPromise
+    if (this.registrationsCollection) {
+      await this.registrationsCollection.preload()
       return
     }
 
-    this.syncElectricUrl = electricUrl
-    this.syncElectricSecret = electricSecret
-
-    const abortController = new AbortController()
-    const stream = new ShapeStream<WakeRegistrationShapeRow>({
-      url: electricUrlWithPath(electricUrl, `/v1/shape`).toString(),
-      params: {
-        table: `wake_registrations`,
-        ...(this.tenantId
-          ? { where: `tenant_id = ${sqlStringLiteral(this.tenantId)}` }
-          : {}),
-        ...(electricSecret ? { secret: electricSecret } : {}),
-        columns: [
-          `id`,
-          `tenant_id`,
-          `subscriber_url`,
-          `source_url`,
-          `condition`,
-          `debounce_ms`,
-          `timeout_ms`,
-          `one_shot`,
-          `timeout_consumed`,
-          `include_response`,
-          `manifest_key`,
-          `created_at`,
-        ],
-        replica: `full`,
-      },
-      parser: {
-        timestamptz: (value: string) => new Date(value),
-      },
-      signal: abortController.signal,
-      onError: (error) => {
-        if (abortController.signal.aborted) {
-          return {}
-        }
-        if (this.syncReadyPromise) {
-          void this.recoverSync(error, `shape stream error`)
-        }
-        return {}
-      },
-    })
-
-    this.syncAbortController = abortController
-    this.syncReadyPromise = new Promise<void>((resolve, reject) => {
-      let settled = false
-
-      this.syncUnsubscribe = stream.subscribe(
-        async (messages) => {
-          try {
-            for (const message of messages) {
-              await this.applyShapeMessage(message)
-              if (
-                !settled &&
-                isControlMessage(message) &&
-                message.headers.control === `up-to-date`
-              ) {
-                settled = true
-                resolve()
-              }
-            }
-          } catch (error) {
-            if (!settled) {
-              settled = true
-              reject(error)
-              return
-            }
-            serverLog.error(
-              `[wake-registry] failed to apply shape change:`,
-              error
-            )
-          }
+    this.mode = `electric`
+    this.registrationsCollection = createCollection(
+      electricCollectionOptions({
+        id: `wake-registrations:${this.tenantId ?? `all`}`,
+        getKey: (row: any) => row.id as number,
+        shapeOptions: {
+          url: electricUrlWithPath(electricUrl, `/v1/shape`).toString(),
+          params: {
+            table: `wake_registrations`,
+            ...(this.tenantId
+              ? { where: `tenant_id = ${sqlStringLiteral(this.tenantId)}` }
+              : {}),
+            ...(electricSecret ? { secret: electricSecret } : {}),
+            columns: [
+              `id`,
+              `tenant_id`,
+              `subscriber_url`,
+              `source_url`,
+              `condition`,
+              `debounce_ms`,
+              `timeout_ms`,
+              `one_shot`,
+              `timeout_consumed`,
+              `include_response`,
+              `manifest_key`,
+              `created_at`,
+            ],
+            replica: `full`,
+          },
+          parser: {
+            timestamptz: (value: string) => new Date(value),
+          },
+          columnMapper: snakeCamelMapper(),
         },
-        (error) => {
-          if (!settled) {
-            settled = true
-            reject(error)
-            return
-          }
-          void this.recoverSync(error, `subscription error`)
-        }
-      )
-    })
+      } as any)
+    ) as any
 
-    try {
-      await this.syncReadyPromise
-    } catch (error) {
-      await this.stopSync()
-      throw error
-    }
+    await this.requireCollection().preload()
+    this.startRegistrationEffect()
   }
 
   async stopSync(): Promise<void> {
@@ -542,11 +436,6 @@ export class WakeRegistry {
     this.registrationsEffect = null
     this.registrationsCollection = null
     this.mode = `unstarted`
-    this.syncUnsubscribe?.()
-    this.syncUnsubscribe = null
-    this.syncAbortController?.abort()
-    this.syncAbortController = null
-    this.syncReadyPromise = null
     this.resetRuntimeState()
   }
 
@@ -565,89 +454,130 @@ export class WakeRegistry {
     this.timeoutDelivered.clear()
   }
 
-  private async recoverSync(
-    error: unknown,
-    source: `shape stream error` | `subscription error`
-  ): Promise<void> {
-    if (this.syncRecoveryPromise) {
-      return this.syncRecoveryPromise
+  private async allocateRuntimeId(): Promise<number> {
+    const rows = await this.db.execute(
+      sql<{
+        id: string
+      }>`select nextval('wake_registrations_id_seq')::text as id`
+    )
+    const value = Array.isArray(rows)
+      ? rows[0]?.id
+      : ((rows as any).rows?.[0]?.id ?? (rows as any)[0]?.id)
+    const id = Number(value)
+    if (!Number.isInteger(id)) {
+      throw new Error(`Failed to allocate wake registration id`)
     }
+    return id
+  }
 
-    const electricUrl = this.syncElectricUrl
-    if (!electricUrl) {
-      serverLog.error(
-        `[wake-registry] Electric sync failed (${source}):`,
-        error
-      )
-      return
-    }
+  private async persistInsert(
+    row: WakeRegistrationCollectionRow
+  ): Promise<number | undefined> {
+    return await this.db.transaction(async (tx) => {
+      const rows = await tx
+        .insert(wakeRegistrations)
+        .values({
+          id: row.id,
+          tenantId: row.tenantId,
+          subscriberUrl: row.subscriberUrl,
+          sourceUrl: row.sourceUrl,
+          condition: row.condition,
+          debounceMs: row.debounceMs,
+          timeoutMs: row.timeoutMs,
+          oneShot: row.oneShot,
+          timeoutConsumed: row.timeoutConsumed,
+          includeResponse: row.includeResponse,
+          manifestKey: row.manifestKey,
+          createdAt: row.createdAt,
+        })
+        .onConflictDoNothing()
+        .returning({ txid: sql<string>`pg_current_xact_id()::xid::text` })
+      return rows[0]?.txid === undefined ? undefined : Number(rows[0].txid)
+    })
+  }
 
-    this.syncRecoveryPromise = (async () => {
-      serverLog.error(
-        `[wake-registry] Electric sync failed (${source}):`,
-        error
-      )
+  private async currentTxidInTransaction(tx: any): Promise<string> {
+    const rows = await tx.execute(
+      sql<{ txid: string }>`select pg_current_xact_id()::xid::text as txid`
+    )
+    return Array.isArray(rows)
+      ? rows[0]!.txid
+      : ((rows as any).rows?.[0]?.txid ?? (rows as any)[0]!.txid)
+  }
 
-      await this.stopSync()
-      await this.loadRegistrations()
-
-      try {
-        await this.startSync(electricUrl, this.syncElectricSecret)
-        serverLog.info(`[wake-registry] Electric sync recovered`)
-      } catch (recoveryError) {
-        serverLog.error(
-          `[wake-registry] Electric sync recovery failed:`,
-          recoveryError
+  private async persistTimeoutConsumed(
+    row: WakeRegistrationCollectionRow
+  ): Promise<number> {
+    return await this.db.transaction(async (tx) => {
+      const rows = await tx
+        .update(wakeRegistrations)
+        .set({ timeoutConsumed: row.timeoutConsumed })
+        .where(
+          and(
+            eq(wakeRegistrations.tenantId, row.tenantId),
+            eq(wakeRegistrations.id, row.id)
+          )
         )
-      } finally {
-        this.syncRecoveryPromise = null
-      }
-    })()
+        .returning({ txid: sql<string>`pg_current_xact_id()::xid::text` })
+      return Number(rows[0]?.txid ?? (await this.currentTxidInTransaction(tx)))
+    })
+  }
 
-    return this.syncRecoveryPromise
+  private async persistDeleteRows(
+    rows: Array<WakeRegistrationCollectionRow>
+  ): Promise<number | undefined> {
+    if (rows.length === 0) return undefined
+    return await this.db.transaction(async (tx) => {
+      let txid: string | undefined
+      for (const row of rows) {
+        const deleted = await tx
+          .delete(wakeRegistrations)
+          .where(
+            and(
+              eq(wakeRegistrations.tenantId, row.tenantId),
+              eq(wakeRegistrations.id, row.id)
+            )
+          )
+          .returning({ txid: sql<string>`pg_current_xact_id()::xid::text` })
+        txid = deleted[0]?.txid ?? txid
+      }
+      return txid === undefined ? undefined : Number(txid)
+    })
+  }
+
+  private registrationMatches(
+    row: WakeRegistrationCollectionRow,
+    reg: WakeRegistration,
+    tenantId: string
+  ): boolean {
+    return (
+      row.tenantId === tenantId &&
+      row.subscriberUrl === reg.subscriberUrl &&
+      row.sourceUrl === reg.sourceUrl &&
+      JSON.stringify(row.condition) === JSON.stringify(reg.condition) &&
+      row.debounceMs === (reg.debounceMs ?? 0) &&
+      row.timeoutMs === (reg.timeoutMs ?? 0) &&
+      row.oneShot === reg.oneShot &&
+      row.manifestKey === (reg.manifestKey ?? null)
+    )
   }
 
   async register(reg: WakeRegistration): Promise<void> {
     const tenantId = this.resolveTenantId(reg.tenantId)
     if (this.registrationsCollection) {
-      const id = this.allocateLocalId()
-      const tx = this.registerAction(
-        this.normalizeRegistration(reg, tenantId, id)
+      const existing = await this.rowsByPredicate((row) =>
+        this.registrationMatches(row, reg, tenantId)
       )
-      await tx.isPersisted.promise
-      return
+      if (existing.length > 0) return
     }
-    const result = await this.db
-      .insert(wakeRegistrations)
-      .values({
-        tenantId,
-        subscriberUrl: reg.subscriberUrl,
-        sourceUrl: reg.sourceUrl,
-        condition: reg.condition,
-        debounceMs: reg.debounceMs ?? 0,
-        timeoutMs: reg.timeoutMs ?? 0,
-        oneShot: reg.oneShot,
-        includeResponse: reg.includeResponse !== false,
-        manifestKey: reg.manifestKey ?? null,
-      })
-      .onConflictDoNothing()
-      .returning({ id: wakeRegistrations.id })
-
-    if (result.length === 0) {
-      // Another path (e.g. manifest-sync) may have created the row first.
-      // Refresh the cache so this process still sees the effective registration.
-      await this.loadRegistrations()
-      return
-    }
-
-    const dbId = result[0]!.id
-    this.upsertCachedRegistration({
-      ...reg,
-      tenantId,
-      dbId,
-      createdAt: new Date(),
-      timeoutConsumed: false,
-    })
+    const id =
+      this.mode === `electric`
+        ? await this.allocateRuntimeId()
+        : this.allocateLocalId()
+    const tx = this.registerAction(
+      this.normalizeRegistration(reg, tenantId, id)
+    )
+    await tx.isPersisted.promise
   }
 
   private startTimeoutTimer(reg: WakeRegistrationCollectionRow): void {
@@ -727,22 +657,6 @@ export class WakeRegistry {
           eq(wakeRegistrations.manifestKey, manifestKey)
         )
       )
-
-    const toRemove = Array.from(this.registrationCache.values()).flatMap(
-      (regs) =>
-        regs
-          .filter(
-            (r) =>
-              r.tenantId === resolvedTenantId &&
-              r.subscriberUrl === subscriberUrl &&
-              r.manifestKey === manifestKey
-          )
-          .map((r) => r.dbId)
-    )
-
-    for (const dbId of toRemove) {
-      this.removeCachedRegistrationByDbId(dbId)
-    }
   }
 
   async unregisterBySubscriber(
@@ -777,20 +691,6 @@ export class WakeRegistry {
           eq(wakeRegistrations.subscriberUrl, subscriberUrl)
         )
       )
-
-    const toRemove = Array.from(this.registrationCache.values()).flatMap(
-      (regs) =>
-        regs
-          .filter(
-            (r) =>
-              r.tenantId === resolvedTenantId &&
-              r.subscriberUrl === subscriberUrl
-          )
-          .map((r) => r.dbId)
-    )
-    for (const dbId of toRemove) {
-      this.removeCachedRegistrationByDbId(dbId)
-    }
   }
 
   async unregisterBySource(
@@ -817,15 +717,6 @@ export class WakeRegistry {
           eq(wakeRegistrations.sourceUrl, sourceUrl)
         )
       )
-
-    const key = this.cacheKey(resolvedTenantId, sourceUrl)
-    const regs = this.registrationCache.get(key)
-    if (regs) {
-      for (const reg of [...regs]) {
-        this.removeCachedRegistrationByDbId(reg.dbId)
-      }
-      this.registrationCache.delete(key)
-    }
   }
 
   async unregisterBySubscriberAndSource(
@@ -864,51 +755,6 @@ export class WakeRegistry {
           eq(wakeRegistrations.sourceUrl, sourceUrl)
         )
       )
-
-    const regs = this.registrationCache.get(
-      this.cacheKey(resolvedTenantId, sourceUrl)
-    )
-    if (regs) {
-      const toRemove = regs
-        .filter(
-          (r) =>
-            r.tenantId === resolvedTenantId && r.subscriberUrl === subscriberUrl
-        )
-        .map((r) => r.dbId)
-      for (const dbId of toRemove) {
-        this.removeCachedRegistrationByDbId(dbId)
-      }
-    }
-  }
-
-  async loadRegistrations(): Promise<void> {
-    const rows =
-      this.tenantId === null
-        ? await this.db.select().from(wakeRegistrations)
-        : await this.db
-            .select()
-            .from(wakeRegistrations)
-            .where(eq(wakeRegistrations.tenantId, this.tenantId))
-
-    this.resetCachedRegistrations()
-
-    for (const row of rows) {
-      const reg: CachedWakeRegistration = {
-        tenantId: row.tenantId,
-        subscriberUrl: row.subscriberUrl,
-        sourceUrl: row.sourceUrl,
-        condition: row.condition as WakeRegistration[`condition`],
-        debounceMs: row.debounceMs || undefined,
-        timeoutMs: row.timeoutMs || undefined,
-        oneShot: row.oneShot,
-        includeResponse: row.includeResponse === false ? false : undefined,
-        manifestKey: row.manifestKey ?? undefined,
-        dbId: row.id,
-        createdAt: row.createdAt,
-        timeoutConsumed: row.timeoutConsumed,
-      }
-      this.upsertCachedRegistration(reg)
-    }
   }
 
   private startTimeoutTimerWithDuration(
@@ -941,102 +787,14 @@ export class WakeRegistry {
     }
   }
 
-  private clearRegistrationState(
-    reg: CachedWakeRegistration | WakeRegistrationCollectionRow
-  ): void {
+  private clearRegistrationState(reg: WakeRegistrationCollectionRow): void {
     const timerKey = this.registrationKey(reg)
     this.clearDebounceState(timerKey)
     this.clearTimeoutState(timerKey)
   }
 
-  private resetCachedRegistrations(): void {
-    for (const timer of this.debounceTimers.values()) {
-      clearTimeout(timer)
-    }
-    this.debounceTimers.clear()
-    this.debounceBuffers.clear()
-    this.debounceRunStatus.clear()
-
-    for (const timer of this.timeoutTimers.values()) {
-      clearTimeout(timer)
-    }
-    this.timeoutTimers.clear()
-    this.registrationCache.clear()
-  }
-
-  private replaceCachedRegistrations(
-    registrations: Array<CachedWakeRegistration>
-  ): void {
-    this.resetCachedRegistrations()
-    for (const registration of registrations) {
-      this.upsertCachedRegistration(registration)
-    }
-  }
-
-  private findCachedRegistration(
-    dbId: number
-  ): { cacheKey: string; index: number; reg: CachedWakeRegistration } | null {
-    for (const [cacheKey, regs] of this.registrationCache) {
-      const index = regs.findIndex((reg) => reg.dbId === dbId)
-      if (index >= 0) {
-        return {
-          cacheKey,
-          index,
-          reg: regs[index]!,
-        }
-      }
-    }
-
-    return null
-  }
-
-  private upsertCachedRegistration(reg: CachedWakeRegistration): void {
-    const existing = this.findCachedRegistration(reg.dbId)
-    const nextKey = this.registrationKey(reg)
-
-    if (existing) {
-      const previousKey = this.registrationKey(existing.reg)
-      const regs = this.registrationCache.get(existing.cacheKey)
-      if (regs) {
-        regs.splice(existing.index, 1)
-        if (regs.length === 0) {
-          this.registrationCache.delete(existing.cacheKey)
-        }
-      }
-      if (previousKey !== nextKey) {
-        this.clearRegistrationState(existing.reg)
-      }
-    }
-
-    const cacheKey = this.cacheKey(reg.tenantId, reg.sourceUrl)
-    const cached = this.registrationCache.get(cacheKey) ?? []
-    cached.push(reg)
-    this.registrationCache.set(cacheKey, cached)
-    this.syncTimeoutTimer(reg)
-  }
-
-  private removeCachedRegistrationByDbId(dbId: number): void {
-    const existing = this.findCachedRegistration(dbId)
-    if (!existing) return
-
-    this.clearRegistrationState(existing.reg)
-    this.timeoutDelivered.delete(dbId)
-
-    const regs = this.registrationCache.get(existing.cacheKey)
-    if (!regs) return
-    regs.splice(existing.index, 1)
-    if (regs.length === 0) {
-      this.registrationCache.delete(existing.cacheKey)
-    }
-  }
-
-  private syncTimeoutTimer(
-    registration: CachedWakeRegistration | WakeRegistrationCollectionRow
-  ): void {
-    const reg =
-      `dbId` in registration
-        ? this.cachedRegistrationAsCollectionRow(registration)
-        : registration
+  private syncTimeoutTimer(registration: WakeRegistrationCollectionRow): void {
+    const reg = registration
     const timerKey = this.registrationKey(reg)
 
     if (reg.timeoutConsumed || reg.timeoutMs <= 0) {
@@ -1076,13 +834,7 @@ export class WakeRegistry {
   }
 
   private syncTenantTimeoutTimers(tenantId: string): void {
-    for (const regs of this.registrationCache.values()) {
-      for (const reg of regs) {
-        if (reg.tenantId === tenantId) {
-          this.syncTimeoutTimer(reg)
-        }
-      }
-    }
+    void this.syncTenantCollectionTimeoutTimers(tenantId)
   }
 
   private async syncTenantCollectionTimeoutTimers(
@@ -1117,71 +869,13 @@ export class WakeRegistry {
     }
   }
 
-  private normalizeShapeRow(
-    row: WakeRegistrationShapeRow
-  ): CachedWakeRegistration {
-    return {
-      tenantId:
-        (row as { tenant_id?: string }).tenant_id ?? this.resolveTenantId(),
-      subscriberUrl: row.subscriber_url,
-      sourceUrl: row.source_url,
-      condition: row.condition,
-      debounceMs: row.debounce_ms || undefined,
-      timeoutMs: row.timeout_ms || undefined,
-      oneShot: row.one_shot,
-      includeResponse: row.include_response === false ? false : undefined,
-      manifestKey: row.manifest_key ?? undefined,
-      dbId: row.id,
-      createdAt: row.created_at,
-      timeoutConsumed: row.timeout_consumed,
-    }
-  }
-
-  private async applyShapeMessage(
-    message: Message<WakeRegistrationShapeRow>
-  ): Promise<void> {
-    if (isControlMessage(message)) {
-      if (message.headers.control === `must-refetch`) {
-        this.resetCachedRegistrations()
-      }
-      return
-    }
-
-    if (!isChangeMessage(message)) {
-      return
-    }
-
-    if (message.headers.operation === `delete`) {
-      // Shape keys are protocol-level identifiers and are not guaranteed to be
-      // the table primary key. The wake_registrations shape uses
-      // `replica: full`, so deletes should carry the deleted row in old_value;
-      // use that row id to remove the matching in-memory registration. If the
-      // id is unavailable, reset the cache so we fail closed rather than
-      // keeping a stale wake registration alive.
-      const oldValue = (
-        message as unknown as {
-          old_value?: { id?: unknown }
-        }
-      ).old_value
-      const oldId = Number(oldValue?.id)
-      if (Number.isFinite(oldId)) {
-        this.removeCachedRegistrationByDbId(oldId)
-      } else {
-        this.resetCachedRegistrations()
-      }
-      return
-    }
-
-    this.upsertCachedRegistration(this.normalizeShapeRow(message.value))
-  }
-
   async evaluate(
     sourceUrl: string,
     event: Record<string, unknown>,
     tenantId?: string
   ): Promise<Array<WakeEvalResult>> {
     const resolvedTenantId = this.resolveTenantId(tenantId)
-    if (this.registrationsCollection) {
+    {
       const queriedRegs = await queryOnce((q) =>
         q
           .from({ reg: this.requireCollection() })
@@ -1285,103 +979,7 @@ export class WakeRegistry {
 
       return results
     }
-    const cacheKey = this.cacheKey(resolvedTenantId, sourceUrl)
-    const regs = this.registrationCache.get(cacheKey)
-    if (!regs || regs.length === 0) return []
-
-    const results: Array<WakeEvalResult> = []
-    const toRemove: Array<number> = []
-
-    for (let i = 0; i < regs.length; i++) {
-      const reg = regs[i]!
-      const match = this.matchCondition(reg, event)
-      if (!match) continue
-
-      const timerKey = this.registrationKey(reg)
-      const timeoutTimer = this.timeoutTimers.get(timerKey)
-      if (timeoutTimer) {
-        clearTimeout(timeoutTimer)
-        this.timeoutTimers.delete(timerKey)
-        void this.markTimeoutConsumed(reg.dbId, reg.tenantId)
-      }
-
-      if (reg.debounceMs != null && reg.debounceMs > 0) {
-        const buffer = this.debounceBuffers.get(timerKey) ?? []
-        buffer.push(match.change)
-        this.debounceBuffers.set(timerKey, buffer)
-
-        // Preserve the latest runFinished status for debounced delivery
-        if (match.runFinishedStatus) {
-          this.debounceRunStatus.set(timerKey, match.runFinishedStatus)
-        }
-
-        const existing = this.debounceTimers.get(timerKey)
-        if (existing) clearTimeout(existing)
-
-        const timer = setTimeout(() => {
-          this.debounceTimers.delete(timerKey)
-          const flushed = this.debounceBuffers.get(timerKey)
-          if (flushed && flushed.length > 0) {
-            this.debounceBuffers.delete(timerKey)
-            const runStatus = this.debounceRunStatus.get(timerKey)
-            this.debounceRunStatus.delete(timerKey)
-            this.deliverDebounce({
-              tenantId: reg.tenantId,
-              subscriberUrl: reg.subscriberUrl,
-              registrationDbId: reg.dbId,
-              sourceEventKey: flushed[flushed.length - 1]!.key,
-              wakeMessage: {
-                source: sourceUrl,
-                timeout: false,
-                changes: flushed,
-              },
-              runFinishedStatus: runStatus,
-              includeResponse: reg.includeResponse,
-            })
-          }
-        }, reg.debounceMs)
-        this.debounceTimers.set(timerKey, timer)
-      } else {
-        results.push({
-          tenantId: reg.tenantId,
-          subscriberUrl: reg.subscriberUrl,
-          registrationDbId: reg.dbId,
-          sourceEventKey: wakeSourceEventId(event),
-          wakeMessage: {
-            source: sourceUrl,
-            timeout: false,
-            changes: [match.change],
-          },
-          runFinishedStatus: match.runFinishedStatus,
-          includeResponse: reg.includeResponse,
-        })
-      }
-
-      if (reg.oneShot) {
-        toRemove.push(i)
-      }
-    }
-
-    for (let j = toRemove.length - 1; j >= 0; j--) {
-      const removed = regs.splice(toRemove[j]!, 1)
-      if (removed[0]) {
-        this.clearRegistrationState(removed[0])
-        this.timeoutDelivered.delete(removed[0].dbId)
-        void this.db
-          .delete(wakeRegistrations)
-          .where(
-            and(
-              eq(wakeRegistrations.tenantId, removed[0].tenantId),
-              eq(wakeRegistrations.id, removed[0].dbId)
-            )
-          )
-      }
-    }
-    if (regs.length === 0) {
-      this.registrationCache.delete(cacheKey)
-    }
-
-    return results
+    return []
   }
 
   /** Flush any pending debounce buffers for a subscriber and return them. */

--- a/packages/agents-server/src/wake-registry.ts
+++ b/packages/agents-server/src/wake-registry.ts
@@ -18,7 +18,7 @@ import type { DrizzleDB } from './db/index.js'
 import type { Collection } from '@tanstack/db'
 
 class WakeRegistrationConflictError extends Error {
-  constructor() {
+  constructor(readonly row: WakeRegistrationCollectionRow) {
     super(`Wake registration insert conflicted with an existing row`)
     this.name = `WakeRegistrationConflictError`
   }
@@ -140,6 +140,8 @@ function sqlStringLiteral(value: string): string {
   return `'${value.replace(/'/g, `''`)}'`
 }
 
+let nextWakeRegistryCollectionInstance = 1
+
 export class WakeRegistry {
   private db: DrizzleDB
   private registrationsCollection: Collection<
@@ -160,6 +162,7 @@ export class WakeRegistry {
   private timeoutDelivered = new Set<number>()
   private timeoutCallbacks = new Map<string, WakeTimeoutCallback>()
   private debounceCallbacks = new Map<string, WakeDebounceCallback>()
+  private readonly collectionInstance = nextWakeRegistryCollectionInstance++
 
   constructor(
     db: DrizzleDB,
@@ -292,7 +295,7 @@ export class WakeRegistry {
         if (this.mode === `electric`) {
           const txid = await this.persistInsert(row)
           if (txid === undefined) {
-            throw new WakeRegistrationConflictError()
+            throw new WakeRegistrationConflictError(row)
           }
           await this.requireCollection().utils.awaitTxId(txid, 10_000)
           return { txid }
@@ -409,7 +412,7 @@ export class WakeRegistry {
     this.mode = `electric`
     this.registrationsCollection = createCollection(
       electricCollectionOptions({
-        id: `wake-registrations:${this.tenantId ?? `all`}:${electricUrlWithPath(electricUrl, `/v1/shape`).toString()}`,
+        id: `wake-registrations:${this.tenantId ?? `all`}:${electricUrlWithPath(electricUrl, `/v1/shape`).toString()}:${this.collectionInstance}`,
         getKey: (row: any) => row.id as number,
         shapeOptions: {
           url: electricUrlWithPath(electricUrl, `/v1/shape`).toString(),
@@ -552,21 +555,45 @@ export class WakeRegistry {
     })
   }
 
+  private registrationRowsMatch(
+    row: WakeRegistrationCollectionRow,
+    other: WakeRegistrationCollectionRow
+  ): boolean {
+    return (
+      row.tenantId === other.tenantId &&
+      row.subscriberUrl === other.subscriberUrl &&
+      row.sourceUrl === other.sourceUrl &&
+      JSON.stringify(row.condition) === JSON.stringify(other.condition) &&
+      row.debounceMs === other.debounceMs &&
+      row.timeoutMs === other.timeoutMs &&
+      row.oneShot === other.oneShot &&
+      row.manifestKey === other.manifestKey
+    )
+  }
+
   private registrationMatches(
     row: WakeRegistrationCollectionRow,
     reg: WakeRegistration,
     tenantId: string
   ): boolean {
-    return (
-      row.tenantId === tenantId &&
-      row.subscriberUrl === reg.subscriberUrl &&
-      row.sourceUrl === reg.sourceUrl &&
-      JSON.stringify(row.condition) === JSON.stringify(reg.condition) &&
-      row.debounceMs === (reg.debounceMs ?? 0) &&
-      row.timeoutMs === (reg.timeoutMs ?? 0) &&
-      row.oneShot === reg.oneShot &&
-      row.manifestKey === (reg.manifestKey ?? null)
+    return this.registrationRowsMatch(
+      row,
+      this.normalizeRegistration(reg, tenantId, row.id)
     )
+  }
+
+  private async waitForRegistrationVisible(
+    row: WakeRegistrationCollectionRow,
+    timeoutMs = 10_000
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    do {
+      const rows = await this.rowsByPredicate((candidate) =>
+        this.registrationRowsMatch(candidate, row)
+      )
+      if (rows.length > 0) return
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    } while (Date.now() < deadline)
   }
 
   async register(reg: WakeRegistration): Promise<void> {
@@ -587,7 +614,10 @@ export class WakeRegistry {
     try {
       await tx.isPersisted.promise
     } catch (error) {
-      if (error instanceof WakeRegistrationConflictError) return
+      if (error instanceof WakeRegistrationConflictError) {
+        await this.waitForRegistrationVisible(error.row)
+        return
+      }
       throw error
     }
   }

--- a/packages/agents-server/test/horton-pull-wake-e2e.test.ts
+++ b/packages/agents-server/test/horton-pull-wake-e2e.test.ts
@@ -10,6 +10,7 @@ import {
   waitFor,
 } from './test-utils'
 import {
+  TEST_ELECTRIC_URL,
   TEST_POSTGRES_URL,
   resetElectricAgentsTestBackend,
 } from './test-backend'
@@ -266,7 +267,7 @@ describe(`pull-wake Horton e2e with mocked LLM`, () => {
       durableStreamsUrl: durableStreamTestServerUrl(dsServer.url),
       port: 0,
       postgresUrl: TEST_POSTGRES_URL,
-      electricUrl: undefined,
+      electricUrl: TEST_ELECTRIC_URL,
       authenticateRequest: (req) =>
         req.headers.get(`authorization`) === authHeaders.authorization
           ? testPrincipal
@@ -276,6 +277,7 @@ describe(`pull-wake Horton e2e with mocked LLM`, () => {
     streamBaseUrl = electricAgentsServer.streamClient.baseUrl
     builtinAgentsServer = new BuiltinAgentsServer({
       agentServerUrl: baseUrl,
+      durableStreamsFetchCache: false,
       mockStreamFn,
       pullWake: {
         runnerId,

--- a/packages/agents-server/test/host.test.ts
+++ b/packages/agents-server/test/host.test.ts
@@ -86,7 +86,10 @@ describe(`AgentsHost`, () => {
     const host = new AgentsHost({
       db: createMockDb(),
       pgClient: vi.fn() as any,
+      electricUrl: `http://electric.test`,
     })
+
+    vi.spyOn(host.wakeRegistry, `startSync`).mockResolvedValue(undefined)
 
     const runtime = await host.registerTenant({
       serviceId: `svc-before-start`,
@@ -98,6 +101,8 @@ describe(`AgentsHost`, () => {
     const loadTenantBridges = vi
       .spyOn(host.entityProjector, `loadTenantBridges`)
       .mockResolvedValue(undefined)
+    vi.spyOn(host.entityProjector, `start`).mockResolvedValue(undefined)
+    vi.spyOn(host.entityProjector, `stop`).mockResolvedValue(undefined)
     vi.spyOn(host.scheduler, `start`).mockResolvedValue(undefined)
     vi.spyOn(host.scheduler, `stop`).mockResolvedValue(undefined)
     vi.spyOn(host.tagStreamOutboxDrainer, `start`).mockImplementation(() => {})

--- a/packages/agents-server/test/pg-sync-wake-delivery.test.ts
+++ b/packages/agents-server/test/pg-sync-wake-delivery.test.ts
@@ -38,7 +38,7 @@ describe(`pgSync wake delivery matching`, () => {
       oneShot: false,
     })
 
-    const insertResults = registry.evaluate(
+    const insertResults = await registry.evaluate(
       `/_electric/pg-sync/test`,
       event(`insert`),
       `default`
@@ -49,7 +49,11 @@ describe(`pgSync wake delivery matching`, () => {
       oldValue: { id: `entity-1`, status: `spawning` },
     })
     expect(
-      registry.evaluate(`/_electric/pg-sync/test`, event(`delete`), `default`)
+      await registry.evaluate(
+        `/_electric/pg-sync/test`,
+        event(`delete`),
+        `default`
+      )
     ).toEqual([])
   })
 
@@ -69,14 +73,22 @@ describe(`pgSync wake delivery matching`, () => {
     })
 
     expect(
-      registry
-        .evaluate(`/_electric/pg-sync/test`, event(`insert`), `default`)
-        .map((r) => r.subscriberUrl)
+      (
+        await registry.evaluate(
+          `/_electric/pg-sync/test`,
+          event(`insert`),
+          `default`
+        )
+      ).map((r) => r.subscriberUrl)
     ).toEqual([`/horton/a`])
     expect(
-      registry
-        .evaluate(`/_electric/pg-sync/test`, event(`delete`), `default`)
-        .map((r) => r.subscriberUrl)
+      (
+        await registry.evaluate(
+          `/_electric/pg-sync/test`,
+          event(`delete`),
+          `default`
+        )
+      ).map((r) => r.subscriberUrl)
     ).toEqual([`/horton/b`])
   })
 
@@ -90,10 +102,14 @@ describe(`pgSync wake delivery matching`, () => {
     })
 
     expect(
-      registry.evaluate(`/_electric/pg-sync/test`, event(`insert`), `default`)
+      await registry.evaluate(
+        `/_electric/pg-sync/test`,
+        event(`insert`),
+        `default`
+      )
     ).toHaveLength(1)
     expect(
-      registry.evaluate(
+      await registry.evaluate(
         `/_electric/pg-sync/test`,
         { ...event(`insert`), type: `other` },
         `default`

--- a/packages/agents-server/test/pg-sync-wake-delivery.test.ts
+++ b/packages/agents-server/test/pg-sync-wake-delivery.test.ts
@@ -31,6 +31,7 @@ function event(operation: `insert` | `update` | `delete`, key = operation) {
 describe(`pgSync wake delivery matching`, () => {
   it(`insert wakes insert subscriber and delete does not wake insert-only subscriber`, async () => {
     const registry = new WakeRegistry(createDb() as any, `default`)
+    await registry.startLocalForTests()
     await registry.register({
       subscriberUrl: `/horton/a`,
       sourceUrl: `/_electric/pg-sync/test`,
@@ -59,6 +60,7 @@ describe(`pgSync wake delivery matching`, () => {
 
   it(`splits two subscribers on the same source by operation`, async () => {
     const registry = new WakeRegistry(createDb() as any, `default`)
+    await registry.startLocalForTests()
     await registry.register({
       subscriberUrl: `/horton/a`,
       sourceUrl: `/_electric/pg-sync/test`,
@@ -94,6 +96,7 @@ describe(`pgSync wake delivery matching`, () => {
 
   it(`filters pgSync events by collection`, async () => {
     const registry = new WakeRegistry(createDb() as any, `default`)
+    await registry.startLocalForTests()
     await registry.register({
       subscriberUrl: `/horton/a`,
       sourceUrl: `/_electric/pg-sync/test`,

--- a/packages/agents-server/test/pull-wake-subscription-stack.test.ts
+++ b/packages/agents-server/test/pull-wake-subscription-stack.test.ts
@@ -98,6 +98,69 @@ describe(`pull-wake subscription stack`, () => {
     })
   })
 
+  it(`emits another runner wake when ack leaves later work pending`, async () => {
+    dsServer = new DurableStreamTestServer({
+      port: 0,
+      longPollTimeout: 100,
+      webhooks: true,
+    })
+    await dsServer.start()
+    const streamBaseUrl = durableStreamTestServerUrl(dsServer.url)
+    const client = new StreamClient(streamBaseUrl)
+
+    await client.ensure(`/runners/runner-1/wake`, {
+      contentType: `application/json`,
+    })
+    await client.ensure(`/horton/one/main`, {
+      contentType: `application/json`,
+    })
+    await client.putSubscription(`runner:runner-1:one`, {
+      type: `pull-wake`,
+      streams: [`/horton/one/main`],
+      wake_stream: `/runners/runner-1/wake`,
+    })
+
+    const first = await client.append(
+      `/horton/one/main`,
+      JSON.stringify({ type: `message`, value: `first` })
+    )
+    const claim = await client.claimSubscription(
+      `runner:runner-1:one`,
+      `worker-1`
+    )
+    expect(claim).toMatchObject({
+      generation: 1,
+      token: expect.any(String),
+      streams: [expect.objectContaining({ has_pending: true })],
+    })
+
+    await client.append(
+      `/horton/one/main`,
+      JSON.stringify({ type: `message`, value: `second` })
+    )
+
+    const ack = await client.ackSubscription(
+      `runner:runner-1:one`,
+      claim!.token,
+      {
+        wake_id: claim!.wake_id,
+        generation: claim!.generation,
+        acks: [{ path: `horton/one/main`, offset: first.offset }],
+        done: true,
+      }
+    )
+    expect(ack).toMatchObject({ ok: true, next_wake: true })
+
+    const wakes = await readJsonStream<Record<string, unknown>>(
+      streamBaseUrl,
+      `/runners/runner-1/wake`
+    )
+    expect(wakes).toEqual([
+      expect.objectContaining({ generation: 1 }),
+      expect.objectContaining({ generation: 2 }),
+    ])
+  })
+
   it(`proxies pre-existing runner wake events to pull-wake runners`, async () => {
     dsServer = new DurableStreamTestServer({
       port: 0,

--- a/packages/agents-server/test/scheduler-integration.test.ts
+++ b/packages/agents-server/test/scheduler-integration.test.ts
@@ -7,11 +7,13 @@ import {
   readStreamEvents,
   waitFor,
 } from './test-utils'
-import {
-  TEST_ELECTRIC_URL,
-  TEST_POSTGRES_URL,
-  resetElectricAgentsTestBackend,
-} from './test-backend'
+import { configureElectricAgentsTestBackendEnv } from './test-backend-env'
+
+configureElectricAgentsTestBackendEnv(`agent-server-scheduler`, 20)
+
+let TEST_ELECTRIC_URL = ``
+let TEST_POSTGRES_URL = ``
+let resetElectricAgentsTestBackend: () => Promise<void>
 
 describe(`Scheduler Integration`, () => {
   let dsServer: DurableStreamTestServer
@@ -85,6 +87,11 @@ describe(`Scheduler Integration`, () => {
   }
 
   beforeAll(async () => {
+    const backend = await import(`./test-backend`)
+    TEST_ELECTRIC_URL = backend.TEST_ELECTRIC_URL
+    TEST_POSTGRES_URL = backend.TEST_POSTGRES_URL
+    resetElectricAgentsTestBackend = backend.resetElectricAgentsTestBackend
+
     dsServer = new DurableStreamTestServer({
       port: 0,
       longPollTimeout: 500,
@@ -289,7 +296,7 @@ describe(`Scheduler Integration`, () => {
         }),
       }
     )
-    expect(scheduleRes.status).toBe(200)
+    expect(scheduleRes.status, await scheduleRes.clone().text()).toBe(200)
 
     await waitFor(
       async () => {

--- a/packages/agents-server/test/scheduler-integration.test.ts
+++ b/packages/agents-server/test/scheduler-integration.test.ts
@@ -9,7 +9,9 @@ import {
 } from './test-utils'
 import { configureElectricAgentsTestBackendEnv } from './test-backend-env'
 
-configureElectricAgentsTestBackendEnv(`agent-server-scheduler`, 20)
+configureElectricAgentsTestBackendEnv(`agent-server-scheduler`, 20, {
+  force: true,
+})
 
 let TEST_ELECTRIC_URL = ``
 let TEST_POSTGRES_URL = ``
@@ -88,8 +90,8 @@ describe(`Scheduler Integration`, () => {
 
   beforeAll(async () => {
     const backend = await import(`./test-backend`)
-    TEST_ELECTRIC_URL = backend.TEST_ELECTRIC_URL
-    TEST_POSTGRES_URL = backend.TEST_POSTGRES_URL
+    TEST_ELECTRIC_URL = process.env.ELECTRIC_URL ?? backend.TEST_ELECTRIC_URL
+    TEST_POSTGRES_URL = process.env.DATABASE_URL ?? backend.TEST_POSTGRES_URL
     resetElectricAgentsTestBackend = backend.resetElectricAgentsTestBackend
 
     dsServer = new DurableStreamTestServer({

--- a/packages/agents-server/test/scheduler-integration.test.ts
+++ b/packages/agents-server/test/scheduler-integration.test.ts
@@ -1,21 +1,92 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import postgres from 'postgres'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { getCronStreamPath } from '@electric-ax/agents-runtime'
 import { DurableStreamTestServer } from '@durable-streams/server'
+import { runMigrations } from '../src/db'
 import { ElectricAgentsServer } from '../src/server'
 import {
   durableStreamTestServerUrl,
   readStreamEvents,
   waitFor,
 } from './test-utils'
-import { configureElectricAgentsTestBackendEnv } from './test-backend-env'
+import {
+  ELECTRIC_AGENTS_COMPOSE_FILE,
+  getElectricAgentsComposeProject,
+  getElectricAgentsDevPorts,
+} from './electric-agents-compose-utils'
 
-configureElectricAgentsTestBackendEnv(`agent-server-scheduler`, 20, {
-  force: true,
-})
+const execFileAsync = promisify(execFile)
+const { postgresPort, electricPort } = getElectricAgentsDevPorts()
+const TEST_POSTGRES_PORT = postgresPort + 20
+const TEST_ELECTRIC_PORT = electricPort + 20
+const TEST_COMPOSE_PROJECT = `${getElectricAgentsComposeProject()}-agent-server-scheduler`
+const TEST_POSTGRES_URL = `postgres://electric_agents:electric_agents@localhost:${TEST_POSTGRES_PORT}/electric_agents`
+const TEST_ELECTRIC_URL = `http://localhost:${TEST_ELECTRIC_PORT}`
+const TEST_BACKEND_ENV = {
+  ...process.env,
+  ELECTRIC_AGENTS_COMPOSE_PROJECT: TEST_COMPOSE_PROJECT,
+  PG_HOST_PORT: String(TEST_POSTGRES_PORT),
+  ELECTRIC_HOST_PORT: String(TEST_ELECTRIC_PORT),
+  JAEGER_UI_PORT: `0`,
+  JAEGER_OTLP_HTTP_PORT: `0`,
+  JAEGER_OTLP_GRPC_PORT: `0`,
+  DATABASE_URL: TEST_POSTGRES_URL,
+  ELECTRIC_URL: TEST_ELECTRIC_URL,
+  ELECTRIC_AGENTS_TEST_BACKEND_MANAGED: `1`,
+}
 
-let TEST_ELECTRIC_URL = ``
-let TEST_POSTGRES_URL = ``
-let resetElectricAgentsTestBackend: () => Promise<void>
+async function startTestBackend(): Promise<void> {
+  await execFileAsync(
+    `docker`,
+    [
+      `compose`,
+      `-p`,
+      TEST_COMPOSE_PROJECT,
+      `-f`,
+      ELECTRIC_AGENTS_COMPOSE_FILE,
+      `up`,
+      `-d`,
+      `--wait`,
+    ],
+    { env: TEST_BACKEND_ENV }
+  )
+}
+
+async function stopTestBackend(): Promise<void> {
+  await execFileAsync(
+    `docker`,
+    [
+      `compose`,
+      `-p`,
+      TEST_COMPOSE_PROJECT,
+      `-f`,
+      ELECTRIC_AGENTS_COMPOSE_FILE,
+      `down`,
+      `-v`,
+    ],
+    { env: TEST_BACKEND_ENV }
+  )
+}
+
+async function resetTestBackend(): Promise<void> {
+  await startTestBackend()
+  const pg = postgres(TEST_POSTGRES_URL, {
+    max: 1,
+    onnotice: () => {},
+  })
+  try {
+    await pg.unsafe(`
+      DROP SCHEMA IF EXISTS drizzle CASCADE;
+      DROP SCHEMA IF EXISTS public CASCADE;
+      CREATE SCHEMA public AUTHORIZATION CURRENT_USER;
+    `)
+  } finally {
+    await pg.end()
+  }
+  await runMigrations(TEST_POSTGRES_URL)
+}
 
 describe(`Scheduler Integration`, () => {
   let dsServer: DurableStreamTestServer
@@ -89,22 +160,21 @@ describe(`Scheduler Integration`, () => {
   }
 
   beforeAll(async () => {
-    const backend = await import(`./test-backend`)
-    TEST_ELECTRIC_URL = process.env.ELECTRIC_URL ?? backend.TEST_ELECTRIC_URL
-    TEST_POSTGRES_URL = process.env.DATABASE_URL ?? backend.TEST_POSTGRES_URL
-    resetElectricAgentsTestBackend = backend.resetElectricAgentsTestBackend
-
     dsServer = new DurableStreamTestServer({
       port: 0,
       longPollTimeout: 500,
       webhooks: true,
     })
-    await Promise.all([resetElectricAgentsTestBackend(), dsServer.start()])
+    await Promise.all([resetTestBackend(), dsServer.start()])
     await startElectricAgentsServer()
   }, 120_000)
 
   afterAll(async () => {
-    await Promise.allSettled([stopElectricAgentsServer(), dsServer.stop()])
+    await Promise.allSettled([
+      stopElectricAgentsServer(),
+      dsServer.stop(),
+      stopTestBackend(),
+    ])
   }, 120_000)
 
   it(`delayed_send survives server restart and lands exactly once`, async () => {

--- a/packages/agents-server/test/server-start.test.ts
+++ b/packages/agents-server/test/server-start.test.ts
@@ -147,9 +147,6 @@ vi.mock(`../src/wake-registry`, () => ({
     stopSync(): Promise<void> {
       return Promise.resolve()
     }
-    loadRegistrations(): Promise<void> {
-      return Promise.resolve()
-    }
   },
 }))
 
@@ -279,6 +276,19 @@ describe(`ElectricAgentsServer.start`, () => {
     }
   })
 
+  it(`fails host startup without Electric URL for wake registry sync`, async () => {
+    server = new ElectricAgentsServer({
+      durableStreamsUrl: `http://durable.test`,
+      port: 0,
+      postgresUrl: TEST_POSTGRES_URL,
+      electricUrl: undefined,
+    })
+
+    await expect(server.start()).rejects.toThrow(
+      `WakeRegistry runtime requires an Electric URL`
+    )
+  })
+
   it(`rejects startup and cleans up when scheduler startup fails`, async () => {
     schedulerStartMock.mockRejectedValueOnce(new Error(`scheduler exploded`))
 
@@ -286,6 +296,7 @@ describe(`ElectricAgentsServer.start`, () => {
       durableStreamsUrl: `http://durable.test`,
       port: 0,
       postgresUrl: TEST_POSTGRES_URL,
+      electricUrl: `http://electric.test`,
     })
 
     await expect(server.start()).rejects.toThrow(`scheduler exploded`)
@@ -313,6 +324,7 @@ describe(`ElectricAgentsServer.start`, () => {
       durableStreamsUrl: `http://durable.test`,
       port: 0,
       postgresUrl: `postgres://electric_agents:electric_agents@localhost:5432/electric_agents`,
+      electricUrl: `http://electric.test`,
     })
 
     await expect(server.start()).resolves.toMatch(/^http:\/\//)
@@ -354,6 +366,7 @@ describe(`ElectricAgentsServer.start`, () => {
       durableStreamsUrl: `http://durable.test`,
       port: 0,
       postgresUrl: `postgres://electric_agents:electric_agents@localhost:5432/electric_agents`,
+      electricUrl: `http://electric.test`,
     })
 
     await expect(server.start()).resolves.toMatch(/^http:\/\//)
@@ -376,6 +389,7 @@ describe(`ElectricAgentsServer.start`, () => {
       mockStreamFn: streamFn as any,
       port: 0,
       postgresUrl: TEST_POSTGRES_URL,
+      electricUrl: `http://electric.test`,
     })
 
     await expect(server.start()).resolves.toMatch(/^http:\/\//)
@@ -399,6 +413,7 @@ describe(`ElectricAgentsServer.start`, () => {
       mockStreamFn: streamFn as any,
       port: 0,
       postgresUrl: TEST_POSTGRES_URL,
+      electricUrl: `http://electric.test`,
     })
 
     await expect(server.start()).resolves.toMatch(/^http:\/\//)

--- a/packages/agents-server/test/test-backend-env.ts
+++ b/packages/agents-server/test/test-backend-env.ts
@@ -5,19 +5,32 @@ import {
 
 export function configureElectricAgentsTestBackendEnv(
   namespace: string,
-  portOffset: number
+  portOffset: number,
+  opts: { force?: boolean } = {}
 ): void {
   const { postgresPort, electricPort } = getElectricAgentsDevPorts()
   const scopedPostgresPort = postgresPort + portOffset
   const scopedElectricPort = electricPort + portOffset
 
-  process.env.ELECTRIC_AGENTS_COMPOSE_PROJECT ??= `${getElectricAgentsComposeProject()}-${namespace}`
-  process.env.PG_HOST_PORT ??= String(scopedPostgresPort)
-  process.env.ELECTRIC_HOST_PORT ??= String(scopedElectricPort)
-  process.env.JAEGER_UI_PORT ??= `0`
-  process.env.JAEGER_OTLP_HTTP_PORT ??= `0`
-  process.env.JAEGER_OTLP_GRPC_PORT ??= `0`
-  process.env.DATABASE_URL ??= `postgres://electric_agents:electric_agents@localhost:${scopedPostgresPort}/electric_agents`
-  process.env.ELECTRIC_URL ??= `http://localhost:${scopedElectricPort}`
-  process.env.ELECTRIC_AGENTS_TEST_BACKEND_MANAGED ??= `1`
+  const setEnv = (key: string, value: string): void => {
+    if (opts.force || process.env[key] === undefined) {
+      process.env[key] = value
+    }
+  }
+
+  setEnv(
+    `ELECTRIC_AGENTS_COMPOSE_PROJECT`,
+    `${getElectricAgentsComposeProject()}-${namespace}`
+  )
+  setEnv(`PG_HOST_PORT`, String(scopedPostgresPort))
+  setEnv(`ELECTRIC_HOST_PORT`, String(scopedElectricPort))
+  setEnv(`JAEGER_UI_PORT`, `0`)
+  setEnv(`JAEGER_OTLP_HTTP_PORT`, `0`)
+  setEnv(`JAEGER_OTLP_GRPC_PORT`, `0`)
+  setEnv(
+    `DATABASE_URL`,
+    `postgres://electric_agents:electric_agents@localhost:${scopedPostgresPort}/electric_agents`
+  )
+  setEnv(`ELECTRIC_URL`, `http://localhost:${scopedElectricPort}`)
+  setEnv(`ELECTRIC_AGENTS_TEST_BACKEND_MANAGED`, `1`)
 }

--- a/packages/agents-server/test/test-backend-env.ts
+++ b/packages/agents-server/test/test-backend-env.ts
@@ -5,32 +5,19 @@ import {
 
 export function configureElectricAgentsTestBackendEnv(
   namespace: string,
-  portOffset: number,
-  opts: { force?: boolean } = {}
+  portOffset: number
 ): void {
   const { postgresPort, electricPort } = getElectricAgentsDevPorts()
   const scopedPostgresPort = postgresPort + portOffset
   const scopedElectricPort = electricPort + portOffset
 
-  const setEnv = (key: string, value: string): void => {
-    if (opts.force || process.env[key] === undefined) {
-      process.env[key] = value
-    }
-  }
-
-  setEnv(
-    `ELECTRIC_AGENTS_COMPOSE_PROJECT`,
-    `${getElectricAgentsComposeProject()}-${namespace}`
-  )
-  setEnv(`PG_HOST_PORT`, String(scopedPostgresPort))
-  setEnv(`ELECTRIC_HOST_PORT`, String(scopedElectricPort))
-  setEnv(`JAEGER_UI_PORT`, `0`)
-  setEnv(`JAEGER_OTLP_HTTP_PORT`, `0`)
-  setEnv(`JAEGER_OTLP_GRPC_PORT`, `0`)
-  setEnv(
-    `DATABASE_URL`,
-    `postgres://electric_agents:electric_agents@localhost:${scopedPostgresPort}/electric_agents`
-  )
-  setEnv(`ELECTRIC_URL`, `http://localhost:${scopedElectricPort}`)
-  setEnv(`ELECTRIC_AGENTS_TEST_BACKEND_MANAGED`, `1`)
+  process.env.ELECTRIC_AGENTS_COMPOSE_PROJECT ??= `${getElectricAgentsComposeProject()}-${namespace}`
+  process.env.PG_HOST_PORT ??= String(scopedPostgresPort)
+  process.env.ELECTRIC_HOST_PORT ??= String(scopedElectricPort)
+  process.env.JAEGER_UI_PORT ??= `0`
+  process.env.JAEGER_OTLP_HTTP_PORT ??= `0`
+  process.env.JAEGER_OTLP_GRPC_PORT ??= `0`
+  process.env.DATABASE_URL ??= `postgres://electric_agents:electric_agents@localhost:${scopedPostgresPort}/electric_agents`
+  process.env.ELECTRIC_URL ??= `http://localhost:${scopedElectricPort}`
+  process.env.ELECTRIC_AGENTS_TEST_BACKEND_MANAGED ??= `1`
 }

--- a/packages/agents-server/test/test-backend.ts
+++ b/packages/agents-server/test/test-backend.ts
@@ -19,30 +19,17 @@ export const TEST_POSTGRES_URL =
 export const TEST_ELECTRIC_URL =
   process.env.ELECTRIC_URL ?? `http://localhost:3060`
 
-function currentPostgresUrl(): string {
-  return (
-    process.env.DATABASE_URL ??
-    `postgres://electric_agents:electric_agents@localhost:5432/electric_agents`
-  )
-}
+const hasExplicitBackendConfig =
+  process.env.ELECTRIC_AGENTS_TEST_BACKEND_MANAGED !== `1` &&
+  (process.env.DATABASE_URL !== undefined ||
+    process.env.ELECTRIC_URL !== undefined ||
+    process.env.CLICKHOUSE_URL !== undefined)
 
-function hasExplicitBackendConfig(): boolean {
-  return (
-    process.env.ELECTRIC_AGENTS_TEST_BACKEND_MANAGED !== `1` &&
-    (process.env.DATABASE_URL !== undefined ||
-      process.env.ELECTRIC_URL !== undefined ||
-      process.env.CLICKHOUSE_URL !== undefined)
-  )
-}
-
-const ensureBackendPromises = new Map<string, Promise<void>>()
-
-function currentResetLockDir(): string {
-  return path.join(
-    os.tmpdir(),
-    `${getElectricAgentsComposeProject()}-agent-server-test-backend.lock`
-  )
-}
+let ensureBackendPromise: Promise<void> | null = null
+const resetLockDir = path.join(
+  os.tmpdir(),
+  `${getElectricAgentsComposeProject()}-agent-server-test-backend.lock`
+)
 
 async function startElectricAgentsTestBackend(): Promise<void> {
   await execFileAsync(
@@ -177,7 +164,7 @@ async function ensureExpectedSchema(postgresUrl: string): Promise<void> {
 
   if (process.env.ELECTRIC_AGENTS_TEST_BACKEND_MANAGED === `1`) {
     await stopElectricAgentsTestBackendAndRemoveVolumes()
-    ensureBackendPromises.delete(postgresUrl)
+    ensureBackendPromise = null
     await ensureElectricAgentsTestBackend()
     await runMigrations(postgresUrl)
     if (await matchesCurrentSchema()) {
@@ -191,16 +178,14 @@ async function ensureExpectedSchema(postgresUrl: string): Promise<void> {
   )
 }
 export async function ensureElectricAgentsTestBackend(): Promise<void> {
-  const postgresUrl = currentPostgresUrl()
-  const existing = ensureBackendPromises.get(postgresUrl)
-  if (existing) {
-    await existing
+  if (ensureBackendPromise) {
+    await ensureBackendPromise
     return
   }
 
-  const ensureBackendPromise = (async () => {
+  ensureBackendPromise = (async () => {
     try {
-      const pg = postgres(postgresUrl, {
+      const pg = postgres(TEST_POSTGRES_URL, {
         max: 1,
         onnotice: () => {},
         connect_timeout: 2,
@@ -212,31 +197,29 @@ export async function ensureElectricAgentsTestBackend(): Promise<void> {
         await pg.end({ timeout: 2 })
       }
     } catch (error) {
-      if (hasExplicitBackendConfig()) {
+      if (hasExplicitBackendConfig) {
         const details = error instanceof Error ? error.message : String(error)
         throw new Error(
-          `Explicit Electric Agents test backend is unreachable at ${postgresUrl}: ${details}`
+          `Explicit Electric Agents test backend is unreachable at ${TEST_POSTGRES_URL}: ${details}`
         )
       }
       await startElectricAgentsTestBackend()
     }
   })()
-  ensureBackendPromises.set(postgresUrl, ensureBackendPromise)
 
   try {
     await ensureBackendPromise
   } catch (error) {
-    ensureBackendPromises.delete(postgresUrl)
+    ensureBackendPromise = null
     throw error
   }
 }
 
 export async function resetElectricAgentsTestBackend(): Promise<void> {
   await ensureElectricAgentsTestBackend()
-  const postgresUrl = currentPostgresUrl()
 
   await withResetLock(async () => {
-    const pg = postgres(postgresUrl, {
+    const pg = postgres(TEST_POSTGRES_URL, {
       max: 1,
       onnotice: () => {},
     })
@@ -251,13 +234,12 @@ export async function resetElectricAgentsTestBackend(): Promise<void> {
       await pg.end()
     }
 
-    await runMigrations(postgresUrl)
-    await ensureExpectedSchema(postgresUrl)
+    await runMigrations(TEST_POSTGRES_URL)
+    await ensureExpectedSchema(TEST_POSTGRES_URL)
   })
 }
 
 async function withResetLock<T>(fn: () => Promise<T>): Promise<T> {
-  const resetLockDir = currentResetLockDir()
   for (;;) {
     try {
       await mkdir(resetLockDir)

--- a/packages/agents-server/test/test-backend.ts
+++ b/packages/agents-server/test/test-backend.ts
@@ -19,17 +19,30 @@ export const TEST_POSTGRES_URL =
 export const TEST_ELECTRIC_URL =
   process.env.ELECTRIC_URL ?? `http://localhost:3060`
 
-const hasExplicitBackendConfig =
-  process.env.ELECTRIC_AGENTS_TEST_BACKEND_MANAGED !== `1` &&
-  (process.env.DATABASE_URL !== undefined ||
-    process.env.ELECTRIC_URL !== undefined ||
-    process.env.CLICKHOUSE_URL !== undefined)
+function currentPostgresUrl(): string {
+  return (
+    process.env.DATABASE_URL ??
+    `postgres://electric_agents:electric_agents@localhost:5432/electric_agents`
+  )
+}
 
-let ensureBackendPromise: Promise<void> | null = null
-const resetLockDir = path.join(
-  os.tmpdir(),
-  `${getElectricAgentsComposeProject()}-agent-server-test-backend.lock`
-)
+function hasExplicitBackendConfig(): boolean {
+  return (
+    process.env.ELECTRIC_AGENTS_TEST_BACKEND_MANAGED !== `1` &&
+    (process.env.DATABASE_URL !== undefined ||
+      process.env.ELECTRIC_URL !== undefined ||
+      process.env.CLICKHOUSE_URL !== undefined)
+  )
+}
+
+const ensureBackendPromises = new Map<string, Promise<void>>()
+
+function currentResetLockDir(): string {
+  return path.join(
+    os.tmpdir(),
+    `${getElectricAgentsComposeProject()}-agent-server-test-backend.lock`
+  )
+}
 
 async function startElectricAgentsTestBackend(): Promise<void> {
   await execFileAsync(
@@ -164,7 +177,7 @@ async function ensureExpectedSchema(postgresUrl: string): Promise<void> {
 
   if (process.env.ELECTRIC_AGENTS_TEST_BACKEND_MANAGED === `1`) {
     await stopElectricAgentsTestBackendAndRemoveVolumes()
-    ensureBackendPromise = null
+    ensureBackendPromises.delete(postgresUrl)
     await ensureElectricAgentsTestBackend()
     await runMigrations(postgresUrl)
     if (await matchesCurrentSchema()) {
@@ -178,14 +191,16 @@ async function ensureExpectedSchema(postgresUrl: string): Promise<void> {
   )
 }
 export async function ensureElectricAgentsTestBackend(): Promise<void> {
-  if (ensureBackendPromise) {
-    await ensureBackendPromise
+  const postgresUrl = currentPostgresUrl()
+  const existing = ensureBackendPromises.get(postgresUrl)
+  if (existing) {
+    await existing
     return
   }
 
-  ensureBackendPromise = (async () => {
+  const ensureBackendPromise = (async () => {
     try {
-      const pg = postgres(TEST_POSTGRES_URL, {
+      const pg = postgres(postgresUrl, {
         max: 1,
         onnotice: () => {},
         connect_timeout: 2,
@@ -197,29 +212,31 @@ export async function ensureElectricAgentsTestBackend(): Promise<void> {
         await pg.end({ timeout: 2 })
       }
     } catch (error) {
-      if (hasExplicitBackendConfig) {
+      if (hasExplicitBackendConfig()) {
         const details = error instanceof Error ? error.message : String(error)
         throw new Error(
-          `Explicit Electric Agents test backend is unreachable at ${TEST_POSTGRES_URL}: ${details}`
+          `Explicit Electric Agents test backend is unreachable at ${postgresUrl}: ${details}`
         )
       }
       await startElectricAgentsTestBackend()
     }
   })()
+  ensureBackendPromises.set(postgresUrl, ensureBackendPromise)
 
   try {
     await ensureBackendPromise
   } catch (error) {
-    ensureBackendPromise = null
+    ensureBackendPromises.delete(postgresUrl)
     throw error
   }
 }
 
 export async function resetElectricAgentsTestBackend(): Promise<void> {
   await ensureElectricAgentsTestBackend()
+  const postgresUrl = currentPostgresUrl()
 
   await withResetLock(async () => {
-    const pg = postgres(TEST_POSTGRES_URL, {
+    const pg = postgres(postgresUrl, {
       max: 1,
       onnotice: () => {},
     })
@@ -234,12 +251,13 @@ export async function resetElectricAgentsTestBackend(): Promise<void> {
       await pg.end()
     }
 
-    await runMigrations(TEST_POSTGRES_URL)
-    await ensureExpectedSchema(TEST_POSTGRES_URL)
+    await runMigrations(postgresUrl)
+    await ensureExpectedSchema(postgresUrl)
   })
 }
 
 async function withResetLock<T>(fn: () => Promise<T>): Promise<T> {
+  const resetLockDir = currentResetLockDir()
   for (;;) {
     try {
       await mkdir(resetLockDir)

--- a/packages/agents-server/test/wake-registry-sync.test.ts
+++ b/packages/agents-server/test/wake-registry-sync.test.ts
@@ -1,14 +1,85 @@
+import { execFile } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
+import { promisify } from 'node:util'
+import postgres from 'postgres'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { eq } from 'drizzle-orm'
-import { createDb } from '../src/db'
+import { createDb, runMigrations } from '../src/db'
 import { wakeRegistrations } from '../src/db/schema'
 import { WakeRegistry } from '../src/wake-registry'
 import {
-  TEST_ELECTRIC_URL,
-  TEST_POSTGRES_URL,
-  ensureElectricAgentsTestBackend,
-} from './test-backend'
+  ELECTRIC_AGENTS_COMPOSE_FILE,
+  getElectricAgentsComposeProject,
+  getElectricAgentsDevPorts,
+} from './electric-agents-compose-utils'
+
+const execFileAsync = promisify(execFile)
+const { postgresPort, electricPort } = getElectricAgentsDevPorts()
+const TEST_POSTGRES_PORT = postgresPort + 40
+const TEST_ELECTRIC_PORT = electricPort + 40
+const TEST_COMPOSE_PROJECT = `${getElectricAgentsComposeProject()}-wake-registry-sync`
+const TEST_POSTGRES_URL = `postgres://electric_agents:electric_agents@localhost:${TEST_POSTGRES_PORT}/electric_agents`
+const TEST_ELECTRIC_URL = `http://localhost:${TEST_ELECTRIC_PORT}`
+const TEST_BACKEND_ENV = {
+  ...process.env,
+  ELECTRIC_AGENTS_COMPOSE_PROJECT: TEST_COMPOSE_PROJECT,
+  PG_HOST_PORT: String(TEST_POSTGRES_PORT),
+  ELECTRIC_HOST_PORT: String(TEST_ELECTRIC_PORT),
+  JAEGER_UI_PORT: `0`,
+  JAEGER_OTLP_HTTP_PORT: `0`,
+  JAEGER_OTLP_GRPC_PORT: `0`,
+  DATABASE_URL: TEST_POSTGRES_URL,
+  ELECTRIC_URL: TEST_ELECTRIC_URL,
+  ELECTRIC_AGENTS_TEST_BACKEND_MANAGED: `1`,
+}
+
+async function startTestBackend(): Promise<void> {
+  await execFileAsync(
+    `docker`,
+    [
+      `compose`,
+      `-p`,
+      TEST_COMPOSE_PROJECT,
+      `-f`,
+      ELECTRIC_AGENTS_COMPOSE_FILE,
+      `up`,
+      `-d`,
+      `--wait`,
+    ],
+    { env: TEST_BACKEND_ENV }
+  )
+}
+
+async function stopTestBackend(): Promise<void> {
+  await execFileAsync(
+    `docker`,
+    [
+      `compose`,
+      `-p`,
+      TEST_COMPOSE_PROJECT,
+      `-f`,
+      ELECTRIC_AGENTS_COMPOSE_FILE,
+      `down`,
+      `-v`,
+    ],
+    { env: TEST_BACKEND_ENV }
+  )
+}
+
+async function resetTestBackend(): Promise<void> {
+  await startTestBackend()
+  const pg = postgres(TEST_POSTGRES_URL, { max: 1, onnotice: () => {} })
+  try {
+    await pg.unsafe(`
+      DROP SCHEMA IF EXISTS drizzle CASCADE;
+      DROP SCHEMA IF EXISTS public CASCADE;
+      CREATE SCHEMA public AUTHORIZATION CURRENT_USER;
+    `)
+  } finally {
+    await pg.end()
+  }
+  await runMigrations(TEST_POSTGRES_URL)
+}
 
 type DbConnection = ReturnType<typeof createDb>
 
@@ -17,14 +88,14 @@ let db: DbConnection[`db`]
 
 describe(`WakeRegistry Electric collection sync`, () => {
   beforeAll(async () => {
-    await ensureElectricAgentsTestBackend()
+    await resetTestBackend()
     connection = createDb(TEST_POSTGRES_URL)
     db = connection.db
-  }, 60_000)
+  }, 120_000)
 
   afterAll(async () => {
-    await connection?.client.end()
-  })
+    await Promise.allSettled([connection?.client.end(), stopTestBackend()])
+  }, 120_000)
 
   it(`syncs wake rows from Postgres through Electric`, async () => {
     const suffix = randomUUID()

--- a/packages/agents-server/test/wake-registry-sync.test.ts
+++ b/packages/agents-server/test/wake-registry-sync.test.ts
@@ -4,22 +4,28 @@ import { eq } from 'drizzle-orm'
 import { createDb } from '../src/db'
 import { wakeRegistrations } from '../src/db/schema'
 import { WakeRegistry } from '../src/wake-registry'
-import {
-  TEST_ELECTRIC_URL,
-  TEST_POSTGRES_URL,
-  resetElectricAgentsTestBackend,
-} from './test-backend'
+import { configureElectricAgentsTestBackendEnv } from './test-backend-env'
+import type { createDb as createDbType } from '../src/db'
 
-const connection = createDb(TEST_POSTGRES_URL)
-const db = connection.db
+configureElectricAgentsTestBackendEnv(`agent-server-sync`, 10)
+
+type DbConnection = ReturnType<typeof createDbType>
+
+let connection: DbConnection
+let db: DbConnection[`db`]
+let testElectricUrl: string
 
 describe(`WakeRegistry Electric collection sync`, () => {
   beforeAll(async () => {
-    await resetElectricAgentsTestBackend()
-  })
+    const backend = await import(`./test-backend`)
+    await backend.resetElectricAgentsTestBackend()
+    testElectricUrl = backend.TEST_ELECTRIC_URL
+    connection = createDb(backend.TEST_POSTGRES_URL)
+    db = connection.db
+  }, 60_000)
 
   afterAll(async () => {
-    await connection.client.end()
+    await connection?.client.end()
   })
 
   it(`syncs wake rows from Postgres through Electric`, async () => {
@@ -37,15 +43,22 @@ describe(`WakeRegistry Electric collection sync`, () => {
       .returning()
 
     const registry = new WakeRegistry(db as any)
-    await registry.startSync(TEST_ELECTRIC_URL)
+    await registry.startSync(testElectricUrl)
 
     try {
-      const results = await registry.evaluate(sourceUrl, {
+      let results: Awaited<ReturnType<WakeRegistry[`evaluate`]>> = []
+      const event = {
         type: `run`,
         key: `run-1`,
         value: { status: `completed` },
         headers: { operation: `update` },
-      })
+      }
+      const deadline = Date.now() + 5_000
+      do {
+        results = await registry.evaluate(sourceUrl, event)
+        if (results.length > 0) break
+        await new Promise((resolve) => setTimeout(resolve, 50))
+      } while (Date.now() < deadline)
 
       expect(results).toHaveLength(1)
       expect(results[0]!.registrationDbId).toBe(rows[0]!.id)
@@ -55,5 +68,5 @@ describe(`WakeRegistry Electric collection sync`, () => {
         .delete(wakeRegistrations)
         .where(eq(wakeRegistrations.sourceUrl, sourceUrl))
     }
-  })
+  }, 15_000)
 })

--- a/packages/agents-server/test/wake-registry-sync.test.ts
+++ b/packages/agents-server/test/wake-registry-sync.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { eq } from 'drizzle-orm'
 import { createDb } from '../src/db'
@@ -21,34 +22,38 @@ describe(`WakeRegistry Electric collection sync`, () => {
     await connection.client.end()
   })
 
-  it(`syncs a registered wake through Postgres and Electric`, async () => {
+  it(`syncs wake rows from Postgres through Electric`, async () => {
+    const suffix = randomUUID()
+    const subscriberUrl = `/parent/sync-${suffix}`
+    const sourceUrl = `/child/sync-${suffix}`
+    const rows = await db
+      .insert(wakeRegistrations)
+      .values({
+        subscriberUrl,
+        sourceUrl,
+        condition: `runFinished`,
+        oneShot: false,
+      })
+      .returning()
+
     const registry = new WakeRegistry(db as any)
     await registry.startSync(TEST_ELECTRIC_URL)
 
-    await registry.register({
-      subscriberUrl: `/parent/p1`,
-      sourceUrl: `/child/c1`,
-      condition: `runFinished`,
-      oneShot: false,
-    })
+    try {
+      const results = await registry.evaluate(sourceUrl, {
+        type: `run`,
+        key: `run-1`,
+        value: { status: `completed` },
+        headers: { operation: `update` },
+      })
 
-    const rows = await db
-      .select()
-      .from(wakeRegistrations)
-      .where(eq(wakeRegistrations.sourceUrl, `/child/c1`))
-
-    expect(rows).toHaveLength(1)
-
-    const results = await registry.evaluate(`/child/c1`, {
-      type: `run`,
-      key: `run-1`,
-      value: { status: `completed` },
-      headers: { operation: `update` },
-    })
-
-    expect(results).toHaveLength(1)
-    expect(results[0]!.registrationDbId).toBe(rows[0]!.id)
-
-    await registry.stopSync()
+      expect(results).toHaveLength(1)
+      expect(results[0]!.registrationDbId).toBe(rows[0]!.id)
+    } finally {
+      await registry.stopSync()
+      await db
+        .delete(wakeRegistrations)
+        .where(eq(wakeRegistrations.sourceUrl, sourceUrl))
+    }
   })
 })

--- a/packages/agents-server/test/wake-registry-sync.test.ts
+++ b/packages/agents-server/test/wake-registry-sync.test.ts
@@ -30,6 +30,9 @@ describe(`WakeRegistry Electric collection sync`, () => {
     const suffix = randomUUID()
     const subscriberUrl = `/parent/sync-${suffix}`
     const sourceUrl = `/child/sync-${suffix}`
+    const registry = new WakeRegistry(db as any)
+    await registry.startSync(TEST_ELECTRIC_URL)
+
     const rows = await db
       .insert(wakeRegistrations)
       .values({
@@ -40,9 +43,6 @@ describe(`WakeRegistry Electric collection sync`, () => {
       })
       .returning()
 
-    const registry = new WakeRegistry(db as any)
-    await registry.startSync(TEST_ELECTRIC_URL)
-
     try {
       let results: Awaited<ReturnType<WakeRegistry[`evaluate`]>> = []
       const event = {
@@ -51,11 +51,11 @@ describe(`WakeRegistry Electric collection sync`, () => {
         value: { status: `completed` },
         headers: { operation: `update` },
       }
-      const deadline = Date.now() + 5_000
+      const deadline = Date.now() + 15_000
       do {
         results = await registry.evaluate(sourceUrl, event)
         if (results.length > 0) break
-        await new Promise((resolve) => setTimeout(resolve, 50))
+        await new Promise((resolve) => setTimeout(resolve, 100))
       } while (Date.now() < deadline)
 
       expect(results).toHaveLength(1)
@@ -66,5 +66,5 @@ describe(`WakeRegistry Electric collection sync`, () => {
         .delete(wakeRegistrations)
         .where(eq(wakeRegistrations.sourceUrl, sourceUrl))
     }
-  }, 15_000)
+  }, 25_000)
 })

--- a/packages/agents-server/test/wake-registry-sync.test.ts
+++ b/packages/agents-server/test/wake-registry-sync.test.ts
@@ -123,7 +123,7 @@ describe(`WakeRegistry Electric sync`, () => {
     await startPromise
 
     expect(
-      registry.evaluate(`/child/c1`, {
+      await registry.evaluate(`/child/c1`, {
         type: `run`,
         key: `run-1`,
         value: { status: `completed` },
@@ -141,7 +141,7 @@ describe(`WakeRegistry Electric sync`, () => {
     ])
 
     expect(
-      registry.evaluate(`/child/c1`, {
+      await registry.evaluate(`/child/c1`, {
         type: `run`,
         key: `run-2`,
         value: { status: `completed` },

--- a/packages/agents-server/test/wake-registry-sync.test.ts
+++ b/packages/agents-server/test/wake-registry-sync.test.ts
@@ -1,155 +1,54 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { createDb } from '../src/db'
+import { wakeRegistrations } from '../src/db/schema'
 import { WakeRegistry } from '../src/wake-registry'
+import {
+  TEST_ELECTRIC_URL,
+  TEST_POSTGRES_URL,
+  resetElectricAgentsTestBackend,
+} from './test-backend'
 
-const { shapeStreamState } = vi.hoisted(() => ({
-  shapeStreamState: {
-    latest: null as null | {
-      emit: (messages: Array<Record<string, unknown>>) => Promise<void>
-      signal?: AbortSignal
-    },
-  },
-}))
+const connection = createDb(TEST_POSTGRES_URL)
+const db = connection.db
 
-vi.mock(`@electric-sql/client`, () => ({
-  isControlMessage: (message: { headers?: Record<string, unknown> }) =>
-    typeof message.headers?.control === `string`,
-  isChangeMessage: (message: { headers?: Record<string, unknown> }) =>
-    typeof message.headers?.operation === `string`,
-  ShapeStream: class MockShapeStream {
-    private onMessages:
-      | ((messages: Array<Record<string, unknown>>) => Promise<void> | void)
-      | null = null
-
-    constructor(options: { signal?: AbortSignal }) {
-      shapeStreamState.latest = {
-        signal: options.signal,
-        emit: async (messages) => {
-          await this.onMessages?.(messages)
-        },
-      }
-    }
-
-    subscribe(
-      callback: (messages: Array<Record<string, unknown>>) => Promise<void>,
-      _onError?: (error: Error) => void
-    ): () => void {
-      this.onMessages = callback
-      return () => {
-        this.onMessages = null
-      }
-    }
-  },
-}))
-
-function createMockDb(): any {
-  return {
-    insert: () => ({
-      values: () => ({
-        onConflictDoNothing: () => ({
-          returning: () => Promise.resolve([{ id: 1 }]),
-        }),
-      }),
-    }),
-    delete: () => ({
-      where: () => Promise.resolve(),
-    }),
-    update: () => ({
-      set: () => ({
-        where: () => Promise.resolve(),
-      }),
-    }),
-    select: () => ({
-      from: () => Promise.resolve([]),
-    }),
-  }
-}
-
-describe(`WakeRegistry Electric sync`, () => {
-  it(`ignores malformed shape messages without headers while waiting for up-to-date`, async () => {
-    const registry = new WakeRegistry(createMockDb())
-
-    const startPromise = registry.startSync(`http://electric.test`)
-
-    await expect(
-      shapeStreamState.latest!.emit([
-        {
-          key: `ignored-malformed-message`,
-        },
-        {
-          headers: {
-            control: `up-to-date`,
-          },
-        },
-      ])
-    ).resolves.toBeUndefined()
-
-    await expect(startPromise).resolves.toBeUndefined()
-
-    await registry.stopSync()
+describe(`WakeRegistry Electric collection sync`, () => {
+  beforeAll(async () => {
+    await resetElectricAgentsTestBackend()
   })
 
-  it(`hydrates and updates the cache from shape changes`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+  afterAll(async () => {
+    await connection.client.end()
+  })
 
-    const startPromise = registry.startSync(`http://electric.test`)
+  it(`syncs a registered wake through Postgres and Electric`, async () => {
+    const registry = new WakeRegistry(db as any)
+    await registry.startSync(TEST_ELECTRIC_URL)
 
-    await shapeStreamState.latest!.emit([
-      {
-        key: `1`,
-        value: {
-          id: 1,
-          subscriber_url: `/parent/p1`,
-          source_url: `/child/c1`,
-          condition: `runFinished`,
-          debounce_ms: 0,
-          timeout_ms: 0,
-          one_shot: false,
-          timeout_consumed: false,
-          include_response: true,
-          manifest_key: null,
-          created_at: new Date(),
-        },
-        headers: {
-          operation: `insert`,
-        },
-      },
-      {
-        headers: {
-          control: `up-to-date`,
-        },
-      },
-    ])
+    await registry.register({
+      subscriberUrl: `/parent/p1`,
+      sourceUrl: `/child/c1`,
+      condition: `runFinished`,
+      oneShot: false,
+    })
 
-    await startPromise
+    const rows = await db
+      .select()
+      .from(wakeRegistrations)
+      .where(eq(wakeRegistrations.sourceUrl, `/child/c1`))
 
-    expect(
-      await registry.evaluate(`/child/c1`, {
-        type: `run`,
-        key: `run-1`,
-        value: { status: `completed` },
-        headers: { operation: `update` },
-      })
-    ).toHaveLength(1)
+    expect(rows).toHaveLength(1)
 
-    await shapeStreamState.latest!.emit([
-      {
-        key: `1`,
-        headers: {
-          operation: `delete`,
-        },
-      },
-    ])
+    const results = await registry.evaluate(`/child/c1`, {
+      type: `run`,
+      key: `run-1`,
+      value: { status: `completed` },
+      headers: { operation: `update` },
+    })
 
-    expect(
-      await registry.evaluate(`/child/c1`, {
-        type: `run`,
-        key: `run-2`,
-        value: { status: `completed` },
-        headers: { operation: `update` },
-      })
-    ).toHaveLength(0)
+    expect(results).toHaveLength(1)
+    expect(results[0]!.registrationDbId).toBe(rows[0]!.id)
 
     await registry.stopSync()
-    expect(shapeStreamState.latest!.signal?.aborted).toBe(true)
   })
 })

--- a/packages/agents-server/test/wake-registry-sync.test.ts
+++ b/packages/agents-server/test/wake-registry-sync.test.ts
@@ -4,23 +4,21 @@ import { eq } from 'drizzle-orm'
 import { createDb } from '../src/db'
 import { wakeRegistrations } from '../src/db/schema'
 import { WakeRegistry } from '../src/wake-registry'
-import { configureElectricAgentsTestBackendEnv } from './test-backend-env'
-import type { createDb as createDbType } from '../src/db'
+import {
+  TEST_ELECTRIC_URL,
+  TEST_POSTGRES_URL,
+  ensureElectricAgentsTestBackend,
+} from './test-backend'
 
-configureElectricAgentsTestBackendEnv(`agent-server-sync`, 10)
-
-type DbConnection = ReturnType<typeof createDbType>
+type DbConnection = ReturnType<typeof createDb>
 
 let connection: DbConnection
 let db: DbConnection[`db`]
-let testElectricUrl: string
 
 describe(`WakeRegistry Electric collection sync`, () => {
   beforeAll(async () => {
-    const backend = await import(`./test-backend`)
-    await backend.resetElectricAgentsTestBackend()
-    testElectricUrl = backend.TEST_ELECTRIC_URL
-    connection = createDb(backend.TEST_POSTGRES_URL)
+    await ensureElectricAgentsTestBackend()
+    connection = createDb(TEST_POSTGRES_URL)
     db = connection.db
   }, 60_000)
 
@@ -43,7 +41,7 @@ describe(`WakeRegistry Electric collection sync`, () => {
       .returning()
 
     const registry = new WakeRegistry(db as any)
-    await registry.startSync(testElectricUrl)
+    await registry.startSync(TEST_ELECTRIC_URL)
 
     try {
       let results: Awaited<ReturnType<WakeRegistry[`evaluate`]>> = []

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -92,12 +92,15 @@ describe(`Wake Registry`, () => {
     expect(results[0]!.sourceEventKey).toBe(`update:run-1`)
   })
 
-  it(`keeps optimistic register row when runtime insert conflicts invisibly`, async () => {
+  it(`reconciles invisible insert conflicts to the canonical database row`, async () => {
     const registry = await createLocalRegistry()
     ;(registry as any).mode = `electric`
     ;(registry as any).allocateRuntimeId = async () => 42
-    ;(registry as any).persistInsert = async () => undefined
-    ;(registry as any).waitForRegistrationVisible = async () => {}
+    ;(registry as any).persistInsert = async (row: any) => ({
+      txid: 123,
+      row: { ...row, id: 7 },
+    })
+    ;(registry as any).requireCollection().utils.awaitTxId = async () => {}
 
     await registry.register({
       subscriberUrl: `/parent/p1`,
@@ -114,13 +117,14 @@ describe(`Wake Registry`, () => {
     })
 
     expect(results).toHaveLength(1)
+    expect(results[0]!.registrationDbId).toBe(7)
   })
 
   it(`keeps registrations locally visible when Electric tx visibility times out`, async () => {
     const registry = await createLocalRegistry()
     ;(registry as any).mode = `electric`
     ;(registry as any).allocateRuntimeId = async () => 42
-    ;(registry as any).persistInsert = async () => 123
+    ;(registry as any).persistInsert = async (row: any) => ({ txid: 123, row })
     const timeout = new Error(`timed out`)
     timeout.name = `TimeoutWaitingForTxIdError`
     ;(registry as any).requireCollection().utils.awaitTxId = async () => {
@@ -198,6 +202,32 @@ describe(`Wake Registry`, () => {
         subscriberUrl: `/parent/missing`,
       },
     })
+  })
+
+  it(`cleans up the Electric collection on stopSync`, async () => {
+    const registry = await createLocalRegistry()
+    const cleanup = vi.fn(async () => undefined)
+    const dispose = vi.fn(async () => undefined)
+    ;(registry as any).registrationsCollection = { cleanup }
+    ;(registry as any).registrationsEffect = { dispose }
+
+    await registry.stopSync()
+
+    expect(dispose).toHaveBeenCalledTimes(1)
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  it(`starts the registration effect after retrying an existing collection preload`, async () => {
+    const registry = await createLocalRegistry()
+    const preload = vi.fn(async () => undefined)
+    const startEffect = vi.fn()
+    ;(registry as any).registrationsCollection = { preload }
+    ;(registry as any).startRegistrationEffect = startEffect
+
+    await registry.startSync(`http://electric.test`)
+
+    expect(preload).toHaveBeenCalledTimes(1)
+    expect(startEffect).toHaveBeenCalledTimes(1)
   })
 
   it(`does not await an invisible txid when runtime timeout update matches no rows`, async () => {

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -225,6 +225,7 @@ describe(`Wake Registry`, () => {
       (result) => delivered.push(result),
       `tenant-late`
     )
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(delivered).toHaveLength(1)
     expect(delivered[0]!.tenantId).toBe(`tenant-late`)
@@ -276,38 +277,6 @@ describe(`Wake Registry`, () => {
     expect(results).toHaveLength(1)
     expect(results[0]!.registrationDbId).toBeTypeOf(`number`)
     expect(results[0]!.sourceEventKey).toBe(`insert:tick-7`)
-  })
-
-  it(`removes cached registrations from shape delete old_value ids`, async () => {
-    const registry = await createLocalRegistry()
-    await registry.register({
-      subscriberUrl: `/watcher/w1`,
-      sourceUrl: `/_cron/abc`,
-      condition: { on: `change` },
-      oneShot: false,
-    })
-
-    const before = await registry.evaluate(`/_cron/abc`, {
-      type: `cron_tick`,
-      key: `tick-7`,
-      value: {},
-      headers: { operation: `insert` },
-    })
-    expect(before).toHaveLength(1)
-
-    await (registry as any).applyShapeMessage({
-      key: `shape-key-is-not-the-registration-id`,
-      old_value: { id: before[0]!.registrationDbId },
-      headers: { operation: `delete` },
-    })
-
-    const after = await registry.evaluate(`/_cron/abc`, {
-      type: `cron_tick`,
-      key: `tick-8`,
-      value: {},
-      headers: { operation: `insert` },
-    })
-    expect(after).toHaveLength(0)
   })
 
   it(`keeps distinct registrations distinct for the same source event`, async () => {
@@ -642,7 +611,7 @@ describe(`Wake Registry`, () => {
     expect(r2).toHaveLength(1)
   })
 
-  it(`register() rejects when DB insert fails so callers can catch`, async () => {
+  it(`local register does not require a backing DB insert`, async () => {
     const failingDb = {
       ...createMockDb(),
       insert: () => ({
@@ -654,6 +623,7 @@ describe(`Wake Registry`, () => {
       }),
     }
     const registry = new WakeRegistry(failingDb)
+    await registry.startLocalForTests()
 
     await expect(
       registry.register({
@@ -662,7 +632,7 @@ describe(`Wake Registry`, () => {
         condition: `runFinished`,
         oneShot: false,
       })
-    ).rejects.toThrow(`connection refused`)
+    ).resolves.toBeUndefined()
   })
 
   it(`rebuilds registry from register calls`, async () => {
@@ -930,7 +900,7 @@ describe(`Wake Registry`, () => {
     expect(results[0]!.includeResponse).toBe(false)
   })
 
-  it(`includeResponse defaults to undefined when not set`, async () => {
+  it(`includeResponse defaults to true when not set`, async () => {
     const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/parent/p1`,
@@ -947,7 +917,7 @@ describe(`Wake Registry`, () => {
     })
 
     expect(results).toHaveLength(1)
-    expect(results[0]!.includeResponse).toBeUndefined()
+    expect(results[0]!.includeResponse).toBe(true)
   })
 
   it(`debounced runFinished preserves runFinishedStatus and includeResponse`, async () => {
@@ -1208,9 +1178,11 @@ describe(`Wake Registry Integration`, () => {
 
     const wakeEvents = await waitForWakeEvents(parent.streams.main, 3)
     expect(wakeEvents).toHaveLength(3)
-    expect(new Set(wakeEvents.map((event) => event.value?.source))).toEqual(
-      new Set(children.map((child) => child.url))
-    )
+    expect(
+      new Set(
+        wakeEvents.map((event) => (event.value as { source?: string }).source)
+      )
+    ).toEqual(new Set(children.map((child) => child.url)))
   }, 15_000)
 
   it(`spawn with wake registers condition and delivers wake on child run completion`, async () => {

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -92,15 +92,19 @@ describe(`Wake Registry`, () => {
     expect(results[0]!.sourceEventKey).toBe(`update:run-1`)
   })
 
-  it(`reconciles invisible insert conflicts to the canonical database row`, async () => {
+  it(`reconciles invisible insert conflicts to the locally allocated database row`, async () => {
     const registry = await createLocalRegistry()
     ;(registry as any).mode = `electric`
     ;(registry as any).allocateRuntimeId = async () => 42
     ;(registry as any).persistInsert = async (row: any) => ({
       txid: 123,
-      row: { ...row, id: 7 },
+      row,
     })
-    ;(registry as any).requireCollection().utils.awaitTxId = async () => {}
+    const timeout = new Error(`timed out`)
+    timeout.name = `TimeoutWaitingForTxIdError`
+    ;(registry as any).requireCollection().utils.awaitTxId = async () => {
+      throw timeout
+    }
 
     await registry.register({
       subscriberUrl: `/parent/p1`,
@@ -117,7 +121,7 @@ describe(`Wake Registry`, () => {
     })
 
     expect(results).toHaveLength(1)
-    expect(results[0]!.registrationDbId).toBe(7)
+    expect(results[0]!.registrationDbId).toBe(42)
   })
 
   it(`keeps registrations locally visible when Electric tx visibility times out`, async () => {

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -92,7 +92,7 @@ describe(`Wake Registry`, () => {
     expect(results[0]!.sourceEventKey).toBe(`update:run-1`)
   })
 
-  it(`drops optimistic register row when runtime insert conflicts invisibly`, async () => {
+  it(`keeps optimistic register row when runtime insert conflicts invisibly`, async () => {
     const registry = await createLocalRegistry()
     ;(registry as any).mode = `electric`
     ;(registry as any).allocateRuntimeId = async () => 42
@@ -113,7 +113,7 @@ describe(`Wake Registry`, () => {
       headers: { operation: `update` },
     })
 
-    expect(results).toHaveLength(0)
+    expect(results).toHaveLength(1)
   })
 
   it(`keeps registrations locally visible when Electric tx visibility times out`, async () => {

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -85,6 +85,54 @@ describe(`Wake Registry`, () => {
     expect(results[0]!.sourceEventKey).toBe(`update:run-1`)
   })
 
+  it(`timeout effect delivers timeout wake once and marks row consumed`, async () => {
+    const registry = new WakeRegistry(createMockDb())
+    await registry.startLocalForTests()
+    const delivered: Array<WakeEvalResult> = []
+    registry.setTimeoutCallback((result) => delivered.push(result))
+
+    await registry.register({
+      subscriberUrl: `/parent/p1`,
+      sourceUrl: `/child/c1`,
+      condition: `runFinished`,
+      oneShot: false,
+      timeoutMs: 25,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0]!.wakeMessage.timeout).toBe(true)
+
+    await new Promise((resolve) => setTimeout(resolve, 80))
+    expect(delivered).toHaveLength(1)
+  })
+
+  it(`local timeout effect does not consume timeout before callback is registered`, async () => {
+    const registry = new WakeRegistry(createMockDb())
+    await registry.startLocalForTests()
+    const delivered: Array<WakeEvalResult> = []
+
+    await registry.register({
+      subscriberUrl: `/parent/p1`,
+      sourceUrl: `/child/c1`,
+      condition: `runFinished`,
+      oneShot: false,
+      timeoutMs: 25,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    expect(delivered).toHaveLength(0)
+
+    registry.setTimeoutCallback((result) => delivered.push(result))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0]!.sourceEventKey).toBe(`timeout`)
+  })
+
   it(`keeps shared registrations scoped by tenant`, async () => {
     const registry = new WakeRegistry(createMockDb(), null)
     await registry.register({

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -92,6 +92,47 @@ describe(`Wake Registry`, () => {
     expect(results[0]!.sourceEventKey).toBe(`update:run-1`)
   })
 
+  it(`drops optimistic register row when runtime insert conflicts invisibly`, async () => {
+    const registry = await createLocalRegistry()
+    ;(registry as any).mode = `electric`
+    ;(registry as any).allocateRuntimeId = async () => 42
+    ;(registry as any).persistInsert = async () => undefined
+
+    await registry.register({
+      subscriberUrl: `/parent/p1`,
+      sourceUrl: `/child/conflict`,
+      condition: `runFinished`,
+      oneShot: false,
+    })
+
+    const results = await registry.evaluate(`/child/conflict`, {
+      type: `run`,
+      key: `run-1`,
+      value: { status: `completed` },
+      headers: { operation: `update` },
+    })
+
+    expect(results).toHaveLength(0)
+  })
+
+  it(`does not await an invisible txid when runtime timeout update matches no rows`, async () => {
+    const registry = await createLocalRegistry()
+
+    await registry.register({
+      subscriberUrl: `/parent/p1`,
+      sourceUrl: `/child/stale-timeout`,
+      condition: `runFinished`,
+      oneShot: false,
+      timeoutMs: 1_000,
+    })
+    ;(registry as any).mode = `electric`
+    ;(registry as any).persistTimeoutConsumed = async () => undefined
+
+    await expect(
+      (registry as any).markTimeoutConsumed(1, `default`)
+    ).resolves.toBeUndefined()
+  })
+
   it(`timeout effect delivers timeout wake once and marks row consumed`, async () => {
     const registry = await createLocalRegistry()
     const delivered: Array<WakeEvalResult> = []

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -116,6 +116,90 @@ describe(`Wake Registry`, () => {
     expect(results).toHaveLength(0)
   })
 
+  it(`keeps registrations locally visible when Electric tx visibility times out`, async () => {
+    const registry = await createLocalRegistry()
+    ;(registry as any).mode = `electric`
+    ;(registry as any).allocateRuntimeId = async () => 42
+    ;(registry as any).persistInsert = async () => 123
+    const timeout = new Error(`timed out`)
+    timeout.name = `TimeoutWaitingForTxIdError`
+    ;(registry as any).requireCollection().utils.awaitTxId = async () => {
+      throw timeout
+    }
+
+    await registry.register({
+      subscriberUrl: `/parent/p1`,
+      sourceUrl: `/child/slow-visible`,
+      condition: `runFinished`,
+      oneShot: false,
+    })
+
+    const results = await registry.evaluate(`/child/slow-visible`, {
+      type: `run`,
+      key: `run-1`,
+      value: { status: `completed` },
+      headers: { operation: `update` },
+    })
+
+    expect(results).toHaveLength(1)
+  })
+
+  it(`keeps committed one-shot deletes locally deleted when Electric tx visibility times out`, async () => {
+    const registry = await createLocalRegistry()
+
+    await registry.register({
+      subscriberUrl: `/parent/p1`,
+      sourceUrl: `/child/one-shot-timeout`,
+      condition: `runFinished`,
+      oneShot: true,
+    })
+    ;(registry as any).mode = `electric`
+    ;(registry as any).persistDeleteRows = async () => 123
+    const timeout = new Error(`timed out`)
+    timeout.name = `TimeoutWaitingForTxIdError`
+    ;(registry as any).requireCollection().utils.awaitTxId = async () => {
+      throw timeout
+    }
+
+    const first = await registry.evaluate(`/child/one-shot-timeout`, {
+      type: `run`,
+      key: `run-1`,
+      value: { status: `completed` },
+      headers: { operation: `update` },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const second = await registry.evaluate(`/child/one-shot-timeout`, {
+      type: `run`,
+      key: `run-2`,
+      value: { status: `completed` },
+      headers: { operation: `update` },
+    })
+
+    expect(first).toHaveLength(1)
+    expect(second).toHaveLength(0)
+  })
+
+  it(`persists unregister predicates even when matching rows are not locally visible`, async () => {
+    const registry = await createLocalRegistry()
+    ;(registry as any).mode = `electric`
+    let persisted: unknown
+    ;(registry as any).persistDeleteRows = async (input: unknown) => {
+      persisted = input
+      return undefined
+    }
+
+    await registry.unregisterBySubscriber(`/parent/missing`)
+
+    expect(persisted).toEqual({
+      rows: [],
+      persist: {
+        kind: `subscriber`,
+        tenantId: `default`,
+        subscriberUrl: `/parent/missing`,
+      },
+    })
+  })
+
   it(`does not await an invisible txid when runtime timeout update matches no rows`, async () => {
     const registry = await createLocalRegistry()
 

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -694,6 +694,45 @@ describe(`Wake Registry`, () => {
     ).toBe(2)
   })
 
+  it(`reloads wake registrations and retries runFinished evaluation on cache miss`, async () => {
+    const wakeResult = {
+      tenantId: `default`,
+      subscriberUrl: `/parent/p1`,
+      registrationDbId: 12,
+      sourceEventKey: `run-1`,
+      wakeMessage: {
+        source: `/child/c1`,
+        timeout: false,
+        changes: [{ collection: `runs`, kind: `update`, key: `run-1` }],
+      },
+      runFinishedStatus: `completed`,
+    }
+    const wakeRegistry = {
+      evaluate: vi
+        .fn()
+        .mockReturnValueOnce([])
+        .mockReturnValueOnce([wakeResult]),
+      loadRegistrations: vi.fn().mockResolvedValue(undefined),
+    }
+    const deliverWakeResult = vi.fn().mockResolvedValue(undefined)
+    const manager = {
+      tenantId: `default`,
+      wakeRegistry,
+      deliverWakeResult,
+    } as any
+
+    await EntityManager.prototype.evaluateWakes.call(manager, `/child/c1`, {
+      type: `run`,
+      key: `run-1`,
+      value: { status: `completed` },
+      headers: { operation: `update` },
+    })
+
+    expect(wakeRegistry.loadRegistrations).toHaveBeenCalledTimes(1)
+    expect(wakeRegistry.evaluate).toHaveBeenCalledTimes(2)
+    expect(deliverWakeResult).toHaveBeenCalledWith(wakeResult)
+  })
+
   it(`deliverWakeResult keys fanout by registrationDbId and sourceEventKey`, async () => {
     const appendIdempotent = vi.fn().mockResolvedValue(undefined)
     const manager = {
@@ -967,6 +1006,77 @@ describe(`Wake Registry Integration`, () => {
     )
     expect(subRes.status).toBeLessThan(300)
   }
+
+  it(`delivers concurrent runFinished wakes from multiple children to the same parent`, async () => {
+    const ts = Date.now()
+    const typeName = `wakemulti${ts}`
+
+    const typeRes = await fetch(`${baseUrl}/_electric/entity-types`, {
+      method: `POST`,
+      headers: { 'content-type': `application/json` },
+      body: JSON.stringify({
+        name: typeName,
+        description: `multiple child runFinished wake test`,
+      }),
+    })
+    expect(typeRes.status).toBe(201)
+
+    const parentRes = await fetch(
+      `${baseUrl}/_electric/entities/${typeName}/parent-${ts}`,
+      {
+        method: `PUT`,
+        headers: { 'content-type': `application/json` },
+        body: JSON.stringify({}),
+      }
+    )
+    expect(parentRes.status).toBe(201)
+    const parent = (await parentRes.json()) as {
+      url: string
+      streams: { main: string }
+    }
+
+    const manager = getElectricAgentsManager()
+    const children: Array<{ url: string; streams: { main: string } }> = []
+    for (const childName of [`a`, `b`, `c`]) {
+      const childRes = await fetch(
+        `${baseUrl}/_electric/entities/${typeName}/child-${childName}-${ts}`,
+        {
+          method: `PUT`,
+          headers: { 'content-type': `application/json` },
+          body: JSON.stringify({ parent: parent.url }),
+        }
+      )
+      expect(childRes.status).toBe(201)
+      const child = (await childRes.json()) as {
+        url: string
+        streams: { main: string }
+      }
+      children.push(child)
+      await manager.wakeRegistry.register({
+        subscriberUrl: parent.url,
+        sourceUrl: child.url,
+        condition: `runFinished`,
+        oneShot: false,
+      })
+    }
+
+    await Promise.all(
+      children.map((child, index) =>
+        manager.evaluateWakes(child.url, {
+          type: `run`,
+          key: `run-${index}`,
+          value: { status: `completed`, result: `done-${index}` },
+          headers: { operation: `update` },
+        })
+      )
+    )
+
+    const wakeEvents = await waitForWakeEvents(parent.streams.main, 3)
+    expect(wakeEvents).toHaveLength(3)
+    expect(new Set(wakeEvents.map((event) => event.value?.source))).toEqual(
+      new Set(children.map((child) => child.url))
+    )
+  }, 15_000)
 
   it(`spawn with wake registers condition and delivers wake on child run completion`, async () => {
     const ts = Date.now()

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -97,6 +97,7 @@ describe(`Wake Registry`, () => {
     ;(registry as any).mode = `electric`
     ;(registry as any).allocateRuntimeId = async () => 42
     ;(registry as any).persistInsert = async () => undefined
+    ;(registry as any).waitForRegistrationVisible = async () => {}
 
     await registry.register({
       subscriberUrl: `/parent/p1`,

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -29,6 +29,14 @@ import {
 import type { Server } from 'node:http'
 import type { WakeEvalResult } from '../src/wake-registry'
 
+async function createLocalRegistry(
+  tenantId?: string | null
+): Promise<WakeRegistry> {
+  const registry = new WakeRegistry(createMockDb(), tenantId)
+  await registry.startLocalForTests()
+  return registry
+}
+
 let nextDbId = 1
 function createMockDb(): any {
   return {
@@ -62,8 +70,7 @@ function createMockDb(): any {
 
 describe(`Wake Registry`, () => {
   it(`evaluates registrations from local TanStack DB collection`, async () => {
-    const registry = new WakeRegistry(createMockDb())
-    await registry.startLocalForTests()
+    const registry = await createLocalRegistry()
 
     await registry.register({
       subscriberUrl: `/parent/p1`,
@@ -86,8 +93,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`timeout effect delivers timeout wake once and marks row consumed`, async () => {
-    const registry = new WakeRegistry(createMockDb())
-    await registry.startLocalForTests()
+    const registry = await createLocalRegistry()
     const delivered: Array<WakeEvalResult> = []
     registry.setTimeoutCallback((result) => delivered.push(result))
 
@@ -109,8 +115,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`local timeout effect does not consume timeout before callback is registered`, async () => {
-    const registry = new WakeRegistry(createMockDb())
-    await registry.startLocalForTests()
+    const registry = await createLocalRegistry()
     const delivered: Array<WakeEvalResult> = []
 
     await registry.register({
@@ -134,7 +139,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`keeps shared registrations scoped by tenant`, async () => {
-    const registry = new WakeRegistry(createMockDb(), null)
+    const registry = await createLocalRegistry(null)
     await registry.register({
       tenantId: `tenant-a`,
       subscriberUrl: `/tenant-a/parent`,
@@ -168,7 +173,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`dispatches shared timeout callbacks by tenant`, async () => {
-    const registry = new WakeRegistry(createMockDb(), null)
+    const registry = await createLocalRegistry(null)
     const tenantA: Array<WakeEvalResult> = []
     const tenantB: Array<WakeEvalResult> = []
     registry.setTimeoutCallback((result) => tenantA.push(result), `tenant-a`)
@@ -200,7 +205,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`does not consume shared timeout before tenant callback is registered`, async () => {
-    const registry = new WakeRegistry(createMockDb(), null)
+    const registry = await createLocalRegistry(null)
     const delivered: Array<WakeEvalResult> = []
 
     await registry.register({
@@ -227,7 +232,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`evaluates runFinished condition on completed run event`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/parent/p1`,
       sourceUrl: `/child/c1`,
@@ -253,7 +258,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`returns registrationDbId and sourceEventKey for immediate matches`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/watcher/w1`,
       sourceUrl: `/_cron/abc`,
@@ -274,7 +279,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`removes cached registrations from shape delete old_value ids`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/watcher/w1`,
       sourceUrl: `/_cron/abc`,
@@ -306,7 +311,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`keeps distinct registrations distinct for the same source event`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/watcher/w1`,
       sourceUrl: `/_cron/abc`,
@@ -335,7 +340,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`runFinished remains active for repeated child completions`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/parent/p1`,
       sourceUrl: `/child/c1`,
@@ -361,7 +366,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`evaluates collection change condition`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/watcher/w1`,
       sourceUrl: `/source/s1`,
@@ -382,7 +387,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`includes inbox message details in wake changes`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/agent/self`,
       sourceUrl: `/agent/self`,
@@ -419,7 +424,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`ignores events for non-matching collections`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/watcher/w1`,
       sourceUrl: `/source/s1`,
@@ -438,7 +443,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`filters collection wakes by operation kind when ops is provided`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/watcher/w1`,
       sourceUrl: `/source/s1`,
@@ -473,7 +478,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`maps pg-sync old_value from the event value into change.oldValue`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/watcher/w1`,
       sourceUrl: `/_electric/pg-sync/default/pg-source-1`,
@@ -507,8 +512,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`unregisterBySource removes all matching local collection rows`, async () => {
-    const registry = new WakeRegistry(createMockDb())
-    await registry.startLocalForTests()
+    const registry = await createLocalRegistry()
 
     await registry.register({
       subscriberUrl: `/parent/a`,
@@ -550,8 +554,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`oneShot match removes row before a second immediate evaluation`, async () => {
-    const registry = new WakeRegistry(createMockDb())
-    await registry.startLocalForTests()
+    const registry = await createLocalRegistry()
 
     await registry.register({
       subscriberUrl: `/parent/p1`,
@@ -572,7 +575,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`cleanup on subscriber deletion removes all registrations`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/parent/p1`,
       sourceUrl: `/child/c1`,
@@ -606,7 +609,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`surgical unregister removes only the targeted subscriber+source pair`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/parent/p1`,
       sourceUrl: `/child/c1`,
@@ -663,7 +666,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`rebuilds registry from register calls`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/parent/p1`,
       sourceUrl: `/child/c1`,
@@ -697,7 +700,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`evaluates shared-state wakes against the shared-state stream path`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/parent/p1`,
       sourceUrl: `/_electric/shared-state/board-1`,
@@ -717,7 +720,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`delivers timeout wake when timeoutMs expires`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     const delivered: Array<WakeEvalResult> = []
     registry.setTimeoutCallback((result) => {
       delivered.push(result)
@@ -742,7 +745,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`debounce coalesces rapid events into single wake`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     const debounced: Array<WakeEvalResult> = []
     registry.setDebounceCallback((result) => {
       debounced.push(result)
@@ -776,7 +779,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`keeps debounced registrations distinct for different conditions on the same source`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     const debounced: Array<WakeEvalResult> = []
     registry.setDebounceCallback((result) => {
       debounced.push(result)
@@ -831,7 +834,7 @@ describe(`Wake Registry`, () => {
     ).toBe(2)
   })
 
-  it(`reloads wake registrations and retries runFinished evaluation on cache miss`, async () => {
+  it(`awaits wake registration evaluation results`, async () => {
     const wakeResult = {
       tenantId: `default`,
       subscriberUrl: `/parent/p1`,
@@ -845,11 +848,7 @@ describe(`Wake Registry`, () => {
       runFinishedStatus: `completed`,
     }
     const wakeRegistry = {
-      evaluate: vi
-        .fn()
-        .mockReturnValueOnce([])
-        .mockReturnValueOnce([wakeResult]),
-      loadRegistrations: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue([wakeResult]),
     }
     const deliverWakeResult = vi.fn().mockResolvedValue(undefined)
     const manager = {
@@ -865,8 +864,7 @@ describe(`Wake Registry`, () => {
       headers: { operation: `update` },
     })
 
-    expect(wakeRegistry.loadRegistrations).toHaveBeenCalledTimes(1)
-    expect(wakeRegistry.evaluate).toHaveBeenCalledTimes(2)
+    expect(wakeRegistry.evaluate).toHaveBeenCalledTimes(1)
     expect(deliverWakeResult).toHaveBeenCalledWith(wakeResult)
   })
 
@@ -912,7 +910,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`passes includeResponse through evaluate result`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/parent/p1`,
       sourceUrl: `/child/c1`,
@@ -933,7 +931,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`includeResponse defaults to undefined when not set`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     await registry.register({
       subscriberUrl: `/parent/p1`,
       sourceUrl: `/child/c1`,
@@ -953,7 +951,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`debounced runFinished preserves runFinishedStatus and includeResponse`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     const delivered: Array<WakeEvalResult> = []
     registry.setDebounceCallback((result) => {
       delivered.push(result)
@@ -988,7 +986,7 @@ describe(`Wake Registry`, () => {
   })
 
   it(`debounced multi-run: status matches changes[0] run key`, async () => {
-    const registry = new WakeRegistry(createMockDb())
+    const registry = await createLocalRegistry()
     const delivered: Array<WakeEvalResult> = []
     registry.setDebounceCallback((result) => {
       delivered.push(result)

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -458,6 +458,71 @@ describe(`Wake Registry`, () => {
     })
   })
 
+  it(`unregisterBySource removes all matching local collection rows`, async () => {
+    const registry = new WakeRegistry(createMockDb())
+    await registry.startLocalForTests()
+
+    await registry.register({
+      subscriberUrl: `/parent/a`,
+      sourceUrl: `/source/1`,
+      condition: { on: `change` },
+      oneShot: false,
+    })
+    await registry.register({
+      subscriberUrl: `/parent/b`,
+      sourceUrl: `/source/1`,
+      condition: { on: `change` },
+      oneShot: false,
+    })
+    await registry.register({
+      subscriberUrl: `/parent/c`,
+      sourceUrl: `/source/2`,
+      condition: { on: `change` },
+      oneShot: false,
+    })
+
+    await registry.unregisterBySource(`/source/1`)
+
+    expect(
+      await registry.evaluate(`/source/1`, {
+        type: `texts`,
+        key: `t1`,
+        value: {},
+        headers: { operation: `insert` },
+      })
+    ).toHaveLength(0)
+    expect(
+      await registry.evaluate(`/source/2`, {
+        type: `texts`,
+        key: `t2`,
+        value: {},
+        headers: { operation: `insert` },
+      })
+    ).toHaveLength(1)
+  })
+
+  it(`oneShot match removes row before a second immediate evaluation`, async () => {
+    const registry = new WakeRegistry(createMockDb())
+    await registry.startLocalForTests()
+
+    await registry.register({
+      subscriberUrl: `/parent/p1`,
+      sourceUrl: `/child/c1`,
+      condition: `runFinished`,
+      oneShot: true,
+    })
+
+    const event = {
+      type: `run`,
+      key: `run-1`,
+      value: { status: `completed` },
+      headers: { operation: `update` },
+    }
+
+    expect(await registry.evaluate(`/child/c1`, event)).toHaveLength(1)
+    expect(await registry.evaluate(`/child/c1`, event)).toHaveLength(0)
+  })
+
   it(`cleanup on subscriber deletion removes all registrations`, async () => {
     const registry = new WakeRegistry(createMockDb())
     await registry.register({

--- a/packages/agents-server/test/wake-registry.test.ts
+++ b/packages/agents-server/test/wake-registry.test.ts
@@ -61,6 +61,30 @@ function createMockDb(): any {
 }
 
 describe(`Wake Registry`, () => {
+  it(`evaluates registrations from local TanStack DB collection`, async () => {
+    const registry = new WakeRegistry(createMockDb())
+    await registry.startLocalForTests()
+
+    await registry.register({
+      subscriberUrl: `/parent/p1`,
+      sourceUrl: `/child/c1`,
+      condition: `runFinished`,
+      oneShot: false,
+    })
+
+    const results = await registry.evaluate(`/child/c1`, {
+      type: `run`,
+      key: `run-1`,
+      value: { status: `completed` },
+      headers: { operation: `update` },
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0]!.subscriberUrl).toBe(`/parent/p1`)
+    expect(results[0]!.registrationDbId).toBe(1)
+    expect(results[0]!.sourceEventKey).toBe(`update:run-1`)
+  })
+
   it(`keeps shared registrations scoped by tenant`, async () => {
     const registry = new WakeRegistry(createMockDb(), null)
     await registry.register({
@@ -84,8 +108,8 @@ describe(`Wake Registry`, () => {
       value: {},
       headers: { operation: `insert` },
     }
-    const tenantA = registry.evaluate(`/source/shared`, event, `tenant-a`)
-    const tenantB = registry.evaluate(`/source/shared`, event, `tenant-b`)
+    const tenantA = await registry.evaluate(`/source/shared`, event, `tenant-a`)
+    const tenantB = await registry.evaluate(`/source/shared`, event, `tenant-b`)
 
     expect(tenantA).toHaveLength(1)
     expect(tenantA[0]!.tenantId).toBe(`tenant-a`)
@@ -163,7 +187,7 @@ describe(`Wake Registry`, () => {
       oneShot: false,
     })
 
-    const results = registry.evaluate(`/child/c1`, {
+    const results = await registry.evaluate(`/child/c1`, {
       type: `run`,
       key: `run-1`,
       value: { status: `completed` },
@@ -189,7 +213,7 @@ describe(`Wake Registry`, () => {
       oneShot: false,
     })
 
-    const results = registry.evaluate(`/_cron/abc`, {
+    const results = await registry.evaluate(`/_cron/abc`, {
       type: `cron_tick`,
       key: `tick-7`,
       value: {},
@@ -210,7 +234,7 @@ describe(`Wake Registry`, () => {
       oneShot: false,
     })
 
-    const before = registry.evaluate(`/_cron/abc`, {
+    const before = await registry.evaluate(`/_cron/abc`, {
       type: `cron_tick`,
       key: `tick-7`,
       value: {},
@@ -224,7 +248,7 @@ describe(`Wake Registry`, () => {
       headers: { operation: `delete` },
     })
 
-    const after = registry.evaluate(`/_cron/abc`, {
+    const after = await registry.evaluate(`/_cron/abc`, {
       type: `cron_tick`,
       key: `tick-8`,
       value: {},
@@ -248,7 +272,7 @@ describe(`Wake Registry`, () => {
       oneShot: false,
     })
 
-    const results = registry.evaluate(`/_cron/abc`, {
+    const results = await registry.evaluate(`/_cron/abc`, {
       type: `cron_tick`,
       key: `tick-7`,
       value: {},
@@ -271,7 +295,7 @@ describe(`Wake Registry`, () => {
       oneShot: false,
     })
 
-    const first = registry.evaluate(`/child/c1`, {
+    const first = await registry.evaluate(`/child/c1`, {
       type: `run`,
       key: `run-1`,
       value: { status: `completed` },
@@ -279,7 +303,7 @@ describe(`Wake Registry`, () => {
     })
     expect(first).toHaveLength(1)
 
-    const second = registry.evaluate(`/child/c1`, {
+    const second = await registry.evaluate(`/child/c1`, {
       type: `run`,
       key: `run-2`,
       value: { status: `completed` },
@@ -297,7 +321,7 @@ describe(`Wake Registry`, () => {
       oneShot: false,
     })
 
-    const results = registry.evaluate(`/source/s1`, {
+    const results = await registry.evaluate(`/source/s1`, {
       type: `texts`,
       key: `text-1`,
       value: { content: `hello` },
@@ -318,7 +342,7 @@ describe(`Wake Registry`, () => {
       oneShot: false,
     })
 
-    const results = registry.evaluate(`/agent/self`, {
+    const results = await registry.evaluate(`/agent/self`, {
       type: `inbox`,
       key: `msg-1`,
       value: {
@@ -355,7 +379,7 @@ describe(`Wake Registry`, () => {
       oneShot: false,
     })
 
-    const results = registry.evaluate(`/source/s1`, {
+    const results = await registry.evaluate(`/source/s1`, {
       type: `toolCalls`,
       key: `tc-1`,
       value: {},
@@ -378,13 +402,13 @@ describe(`Wake Registry`, () => {
       oneShot: false,
     })
 
-    const insertResults = registry.evaluate(`/source/s1`, {
+    const insertResults = await registry.evaluate(`/source/s1`, {
       type: `members`,
       key: `/task/a`,
       value: { url: `/task/a` },
       headers: { operation: `insert` },
     })
-    const deleteResults = registry.evaluate(`/source/s1`, {
+    const deleteResults = await registry.evaluate(`/source/s1`, {
       type: `members`,
       key: `/task/a`,
       old_value: { url: `/task/a` },
@@ -409,7 +433,7 @@ describe(`Wake Registry`, () => {
       oneShot: false,
     })
 
-    const results = registry.evaluate(
+    const results = await registry.evaluate(
       `/_electric/pg-sync/default/pg-source-1`,
       {
         type: `pg_sync_change`,
@@ -451,13 +475,13 @@ describe(`Wake Registry`, () => {
 
     await registry.unregisterBySubscriber(`/parent/p1`)
 
-    const r1 = registry.evaluate(`/child/c1`, {
+    const r1 = await registry.evaluate(`/child/c1`, {
       type: `run`,
       key: `run-1`,
       value: { status: `completed` },
       headers: { operation: `update` },
     })
-    const r2 = registry.evaluate(`/child/c2`, {
+    const r2 = await registry.evaluate(`/child/c2`, {
       type: `texts`,
       key: `t-1`,
       value: {},
@@ -485,13 +509,13 @@ describe(`Wake Registry`, () => {
 
     await registry.unregisterBySubscriberAndSource(`/parent/p1`, `/child/c1`)
 
-    const r1 = registry.evaluate(`/child/c1`, {
+    const r1 = await registry.evaluate(`/child/c1`, {
       type: `run`,
       key: `run-1`,
       value: { status: `completed` },
       headers: { operation: `update` },
     })
-    const r2 = registry.evaluate(`/child/c2`, {
+    const r2 = await registry.evaluate(`/child/c2`, {
       type: `texts`,
       key: `t-1`,
       value: {},
@@ -540,7 +564,7 @@ describe(`Wake Registry`, () => {
       oneShot: false,
     })
 
-    const runResults = registry.evaluate(`/child/c1`, {
+    const runResults = await registry.evaluate(`/child/c1`, {
       type: `run`,
       key: `run-1`,
       value: { status: `completed` },
@@ -549,7 +573,7 @@ describe(`Wake Registry`, () => {
     expect(runResults).toHaveLength(1)
     expect(runResults[0]!.subscriberUrl).toBe(`/parent/p1`)
 
-    const changeResults = registry.evaluate(`/source/s1`, {
+    const changeResults = await registry.evaluate(`/source/s1`, {
       type: `texts`,
       key: `t-1`,
       value: {},
@@ -568,7 +592,7 @@ describe(`Wake Registry`, () => {
       oneShot: false,
     })
 
-    const results = registry.evaluate(`/_electric/shared-state/board-1`, {
+    const results = await registry.evaluate(`/_electric/shared-state/board-1`, {
       type: `texts`,
       key: `t-1`,
       value: {},
@@ -620,7 +644,7 @@ describe(`Wake Registry`, () => {
     })
 
     for (let i = 0; i < 3; i++) {
-      const immediate = registry.evaluate(`/source/s1`, {
+      const immediate = await registry.evaluate(`/source/s1`, {
         type: `texts`,
         key: `text-${i}`,
         value: { content: `msg-${i}` },
@@ -661,7 +685,7 @@ describe(`Wake Registry`, () => {
     })
 
     expect(
-      registry.evaluate(`/source/s1`, {
+      await registry.evaluate(`/source/s1`, {
         type: `texts`,
         key: `text-1`,
         value: { content: `hello` },
@@ -670,7 +694,7 @@ describe(`Wake Registry`, () => {
     ).toHaveLength(0)
 
     expect(
-      registry.evaluate(`/source/s1`, {
+      await registry.evaluate(`/source/s1`, {
         type: `toolCalls`,
         key: `tool-1`,
         value: { name: `search` },
@@ -784,7 +808,7 @@ describe(`Wake Registry`, () => {
       includeResponse: false,
     })
 
-    const results = registry.evaluate(`/child/c1`, {
+    const results = await registry.evaluate(`/child/c1`, {
       type: `run`,
       key: `run-1`,
       value: { status: `completed` },
@@ -804,7 +828,7 @@ describe(`Wake Registry`, () => {
       oneShot: false,
     })
 
-    const results = registry.evaluate(`/child/c1`, {
+    const results = await registry.evaluate(`/child/c1`, {
       type: `run`,
       key: `run-1`,
       value: { status: `completed` },
@@ -832,7 +856,7 @@ describe(`Wake Registry`, () => {
     })
 
     // Immediate evaluate should return nothing (debounced)
-    const results = registry.evaluate(`/child/c1`, {
+    const results = await registry.evaluate(`/child/c1`, {
       type: `run`,
       key: `run-1`,
       value: { status: `completed` },
@@ -866,7 +890,7 @@ describe(`Wake Registry`, () => {
     })
 
     // run-1 completes
-    registry.evaluate(`/child/c1`, {
+    await registry.evaluate(`/child/c1`, {
       type: `run`,
       key: `run-1`,
       value: { status: `completed` },
@@ -874,7 +898,7 @@ describe(`Wake Registry`, () => {
     })
 
     // run-2 fails in the same debounce window
-    registry.evaluate(`/child/c1`, {
+    await registry.evaluate(`/child/c1`, {
       type: `run`,
       key: `run-2`,
       value: { status: `failed` },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1946,6 +1946,12 @@ importers:
       '@sinclair/typebox':
         specifier: ^0.34.48
         version: 0.34.49
+      '@tanstack/db':
+        specifier: ^0.6.7
+        version: 0.6.7(typescript@5.8.3)
+      '@tanstack/electric-db-collection':
+        specifier: ^0.3.5
+        version: 0.3.5(typescript@5.8.3)
       '@whatwg-node/server':
         specifier: ^0.10.18
         version: 0.10.18
@@ -4768,8 +4774,8 @@ packages:
   '@electric-sql/client@1.2.0':
     resolution: {integrity: sha512-K/MEjti3UF4aPKJJqO6Tp4f5noqc2/3icU1NPdpKfQaHwbzGtEX2aJmL2vxTEUJbfyrISkPKbOPnrz/lAvw1Vg==}
 
-  '@electric-sql/client@1.5.20':
-    resolution: {integrity: sha512-Ftf+ze/rZK9dBzvZqW7wrS74aQBToUlhQeUFm7KCTfOCkNJZ+7iZMm9JW/NjyIQjPOz4ApXg3VWOpeCbzsU3IQ==}
+  '@electric-sql/client@1.5.21':
+    resolution: {integrity: sha512-Aize0Aa2ZyTZySQMfMSTDPP/EJWcR1HfH7qE1DgMhI5f6dDxm1B74CN4o1fnIQeW/ZLg9TdbTgFYo1tsUg7mXg==}
     hasBin: true
 
   '@electric-sql/d2mini@0.1.8':
@@ -25333,7 +25339,7 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-darwin-arm64': 4.46.1
 
-  '@electric-sql/client@1.5.20':
+  '@electric-sql/client@1.5.21':
     dependencies:
       '@microsoft/fetch-event-source': 2.0.1(patch_hash=46f4e76dd960e002a542732bb4323817a24fce1673cb71e2f458fe09776fa188)
     optionalDependencies:
@@ -31426,9 +31432,20 @@ snapshots:
       - supports-color
       - typescript
 
+  '@tanstack/electric-db-collection@0.3.5(typescript@5.8.3)':
+    dependencies:
+      '@electric-sql/client': 1.5.21
+      '@standard-schema/spec': 1.1.0
+      '@tanstack/db': 0.6.7(typescript@5.8.3)
+      '@tanstack/store': 0.9.3
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@tanstack/electric-db-collection@0.3.5(typescript@5.9.3)':
     dependencies:
-      '@electric-sql/client': 1.5.20
+      '@electric-sql/client': 1.5.21
       '@standard-schema/spec': 1.1.0
       '@tanstack/db': 0.6.7(typescript@5.9.3)
       '@tanstack/store': 0.9.3


### PR DESCRIPTION
Refactor the agents-server wake registry onto TanStack DB/Electric collections and fix child wake delivery across the server and runtime. The user-visible impact is that parent agents reliably receive child completion wakes, cron wake setup is safer under concurrent tests, and wake-registry sync behavior is covered by isolated CI-stable integration tests.

## Root Cause

Child wake delivery had multiple loss and flake points across the end-to-end path.

On the runtime side, the pull-wake runner intentionally avoids claiming multiple wakes for the same stream concurrently. When another wake arrived while that stream already had an active claim or handler, it was deferred, but deferred wakes were stored as a single event per stream path:

```ts
Map<string, PullWakeEvent>
```

That meant later deferred wakes for the same parent stream overwrote earlier ones.

On the server side, the wake registry was a manual ShapeStream-backed cache. Registration mutations, Electric visibility, and cache lifecycle had to be coordinated by hand, which made terminal `runFinished` wake evaluation vulnerable to stale or missing in-memory state. Follow-up CI failures also exposed a test isolation problem: integration tests that reset the shared Postgres/Electric backend can delete schema/data while other concurrently running tests are polling Electric or evaluating wakes.

## Approach

The branch fixes both the runtime delivery issue and the server registry implementation.

- The runtime same-stream wake notification buffer is now a FIFO queue per stream path:

```ts
Map<string, Array<PullWakeEvent>>
```

Queued same-stream wake notifications are used to trigger serialized claim attempts after the active stream claim drains. The next successful claim is expected to drain the stream’s available pending wake rows together, while the queue prevents losing trigger notifications and avoids concurrent claims for the same stream.

- Heartbeat state now records the `AbortSignal` associated with the in-flight heartbeat. A stale heartbeat from an aborted runner cannot suppress heartbeat startup after restart.

- The server wake registry now uses TanStack DB collections and optimistic actions over the `wake_registrations` table, backed by Electric sync. This removes the custom ShapeStream cache and the stale-cache reload fallback.

- Agents server startup now requires an Electric URL for the wake-registry runtime instead of silently falling back to a non-syncing local load path.

- Cron stream creation now tolerates a concurrent `409` if another caller created the stream after the existence check.

- Sensitive integration tests now either avoid shared-backend resets or run on isolated Docker Compose backends/ports, preventing one test from dropping schema/data while another test is still using it.

## Key Invariants

- Server-side wake registrations are sourced from the synced `wake_registrations` collection.
- Terminal child run events must produce parent wake rows for every matching registration.
- Wakes for the same stream are never claimed concurrently.
- Multiple same-stream wake trigger notifications are preserved while an active claim/handler is already running, so the runner will attempt another claim after the active work drains.
- Queued same-stream wake trigger retries stop cleanly on runner shutdown.
- A stale heartbeat promise from a previous run cannot clear or block newer heartbeat state.
- Tests that reset Postgres/Electric state must own their backend or avoid racing with tests using the shared backend.

## Non-goals

- This does not change the persisted `wake_registrations` schema.
- This does not change durable-stream subscription claim semantics.
- This does not broaden runtime wake batching semantics beyond preserving queued same-stream wake notifications.
- This does not attempt to make shared-backend schema resets safe under arbitrary concurrent test execution; the reset-owning tests are isolated instead.

## Trade-offs

The main implementation choice was to replace the custom ShapeStream cache with TanStack DB rather than continue adding cache-reload fallbacks. TanStack DB adds explicit package dependencies to `@electric-ax/agents-server`, but it gives the registry a collection/effect model that better matches the rest of the agents stack and removes bespoke cache mutation logic.

For CI stabilization, isolating reset-heavy tests costs some additional Docker Compose setup and ports. That is preferable to serializing the whole package test suite or weakening assertions, because it keeps the tests representative while preventing cross-file data deletion races.

The runtime queue remains per stream path, matching the existing concurrency guard. This preserves the “one active claim per stream” behavior while fixing the trigger-notification loss from storing only one same-stream wake notification while a claim was active. It does not mean wake rows are handled one at a time; the next successful claim can still drain the stream’s available pending wake rows together.

## Relation to the previous child wake fix

The previous fix in #4613 addressed a later runtime acking bug: when multiple `wake` rows were already present in one pending handler window, `processWake` selected one wake but acknowledged the whole window, effectively consuming sibling wake rows. That fix batches coalesced wake rows into one `wake_batch` payload.

This PR fixes earlier loss points:

- Pull-wake delivery: preserve same-stream wake notifications while a parent stream already has an active claim/handler.
- Server registry sync: use a TanStack DB/Electric-backed collection for wake registrations instead of a manual ShapeStream cache.
- Test isolation: prevent reset-heavy integration tests from deleting data used by other tests under full-suite concurrency.

## Verification

Targeted runtime verification:

```sh
cd packages/agents-runtime
pnpm exec vitest run test/pull-wake-runner.test.ts --reporter=dot
```

Targeted agents-server verification run during the branch:

```sh
pnpm --filter @electric-ax/agents-server test test/wake-registry.test.ts -t "reloads wake registrations" --run
pnpm --filter @electric-ax/agents-server test test/wake-registry.test.ts -t "delivers concurrent runFinished" --run
pnpm exec vitest run test/wake-registry-sync.test.ts --reporter verbose
pnpm exec tsc --noEmit
```

Changeset validation:

```sh
GITHUB_BASE_REF=main node scripts/check-changeset.mjs
```

Result:

```txt
✅ Changesets cover all affected packages: @electric-ax/agents-runtime, @electric-ax/agents-server
```

CI status for the latest pushed commit is green for all active checks.

## Files changed

- `.changeset/fix-deferred-pull-wakes.md`
  - Adds patch changesets for `@electric-ax/agents-runtime` and `@electric-ax/agents-server`.

- `packages/agents-runtime/src/pull-wake-runner.ts`
  - Preserves same-stream wake notifications in a per-stream FIFO queue.
  - Uses queued same-stream wake notifications to trigger serialized claim attempts after the active stream claim drains.
  - Tracks the signal owning an in-flight heartbeat to avoid stale heartbeat suppression.

- `packages/agents-runtime/test/pull-wake-runner.test.ts`
  - Adds regression coverage for multiple deferred wake events on the same stream.

- `packages/agents-server/package.json` and `pnpm-lock.yaml`
  - Adds TanStack DB and Electric collection dependencies for the server wake registry.

- `packages/agents-server/src/wake-registry.ts`
  - Refactors wake registration storage/sync to TanStack DB collections and optimistic actions over `wake_registrations`.
  - Removes the manual ShapeStream-backed registration cache path.

- `packages/agents-server/src/entity-manager.ts`
  - Requires Electric-backed wake registry startup and tolerates concurrent cron stream creation.

- `packages/agents-server/src/host.ts`
  - Requires an Electric URL before starting the wake-registry runtime.

- `packages/agents-server/test/*.test.ts`
  - Updates wake-registry, host, server-start, pg-sync, Horton pull-wake, scheduler, and wake-registry-sync coverage for the TanStack DB registry and isolated-backend behavior.

- `docs/superpowers/plans/2026-06-19-wake-registry-tanstack-db.md`
  - Adds the implementation plan for the wake-registry TanStack DB refactor.

- `docs/superpowers/specs/2026-03-23-wake-registry-tanstack-db-design.md`
  - Adds the design/spec context for the wake-registry TanStack DB work.

---
Related: #4613


