### PR TITLE
Reconnect pull-wake stream after sleep

### DIFF
--- a/.changeset/reconnect-wake-stream-after-sleep.md
+++ b/.changeset/reconnect-wake-stream-after-sleep.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-runtime': patch
+---
+
+Reconnect pull-wake streams after the runner resumes from sleep or a long event-loop stall so desktop agents keep receiving wake notifications.

--- a/packages/agents-runtime/src/pull-wake-runner.ts
+++ b/packages/agents-runtime/src/pull-wake-runner.ts
@@ -29,6 +29,12 @@ export interface PullWakeRunnerConfig {
   wakeStreamPath?: string
   heartbeatIntervalMs?: number
   eventHeartbeatThrottleMs?: number
+  /**
+   * If the heartbeat timer fires after a wall-clock gap larger than this,
+   * assume the process resumed from sleep or a long event-loop stall and force
+   * the long-lived wake stream to reconnect. Defaults to the runner lease.
+   */
+  resumeGapResetMs?: number
   leaseMs?: number
   heartbeatPath?: string
   claimPath?: string
@@ -146,6 +152,8 @@ export function createPullWakeRunner(
     config.eventHeartbeatThrottleMs ?? DEFAULT_EVENT_HEARTBEAT_THROTTLE_MS
   )
   const leaseMs = config.leaseMs ?? heartbeatIntervalMs * 3
+  const resumeGapResetMs = config.resumeGapResetMs ?? leaseMs
+  let lastHeartbeatTickAt = Date.now()
   const heartbeatPath =
     config.heartbeatPath ??
     `/_electric/runners/${encodeURIComponent(config.runnerId)}/heartbeat`
@@ -296,8 +304,25 @@ export function createPullWakeRunner(
 
   const startHeartbeat = (signal: AbortSignal): void => {
     if (heartbeatIntervalMs <= 0) return
+    lastHeartbeatTickAt = Date.now()
     requestHeartbeat(signal)
     heartbeatTimer = setInterval(() => {
+      const now = Date.now()
+      const elapsedMs = now - lastHeartbeatTickAt
+      lastHeartbeatTickAt = now
+      if (
+        resumeGapResetMs > 0 &&
+        elapsedMs > resumeGapResetMs &&
+        isRunningState() &&
+        !signal.aborted
+      ) {
+        actor.send({
+          type: `STREAM_RESET`,
+          error: new Error(
+            `Pull-wake runner heartbeat timer resumed after ${elapsedMs}ms gap`
+          ),
+        })
+      }
       requestHeartbeat(signal)
     }, heartbeatIntervalMs)
   }

--- a/packages/agents-runtime/test/pull-wake-runner.test.ts
+++ b/packages/agents-runtime/test/pull-wake-runner.test.ts
@@ -899,6 +899,69 @@ describe(`createPullWakeRunner`, () => {
     await runner.stop()
   })
 
+  it(`forces the stream to reconnect when heartbeat timer observes a resume gap`, async () => {
+    vi.useFakeTimers()
+    const firstStreamOpened = deferred<void>()
+    const secondStreamOpened = deferred<void>()
+    const firstStreamClosed = deferred<void>()
+    const secondStreamClosed = deferred<void>()
+    const firstCancel = vi.fn(() => firstStreamClosed.resolve())
+    const streamFactory = vi.fn(async () => {
+      if (streamFactory.mock.calls.length === 1) {
+        firstStreamOpened.resolve()
+        return {
+          async *jsonStream() {
+            await firstStreamClosed.promise
+          },
+          cancel: firstCancel,
+          closed: firstStreamClosed.promise,
+        }
+      }
+      secondStreamOpened.resolve()
+      return {
+        async *jsonStream() {
+          await secondStreamClosed.promise
+        },
+        cancel: () => secondStreamClosed.resolve(),
+        closed: secondStreamClosed.promise,
+      }
+    })
+    vi.stubGlobal(
+      `fetch`,
+      vi.fn(async () => Response.json({}))
+    )
+
+    const runner = createPullWakeRunner({
+      baseUrl: `http://server`,
+      runnerId: `runner-1`,
+      runtime: runtime(),
+      heartbeatIntervalMs: 10,
+      resumeGapResetMs: 25,
+      eventHeartbeatThrottleMs: 0,
+      streamFactory,
+    })
+
+    runner.start()
+    await firstStreamOpened.promise
+
+    // Simulate the computer being asleep: wall-clock time jumps forward before
+    // the next heartbeat timer gets CPU again, while networking is healthy.
+    vi.setSystemTime(Date.now() + 60)
+    await vi.advanceTimersByTimeAsync(10)
+
+    await waitFor(() => {
+      expect(firstCancel).toHaveBeenCalledWith(expect.any(Error))
+    })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await secondStreamOpened.promise
+
+    expect(streamFactory).toHaveBeenCalledTimes(2)
+    expect(runner.getHealth().reconnect_count).toBe(1)
+
+    await runner.stop()
+  })
+
   it(`forces the stream to reconnect after repeated heartbeat failures`, async () => {
     vi.useFakeTimers()
     const firstStreamOpened = deferred<void>()


### PR DESCRIPTION
Detect long heartbeat timer gaps in the pull-wake runner and reconnect the wake stream after a computer resumes from sleep or a long event-loop stall. This keeps desktop agents listening for wake notifications instead of staying attached to a stale long-lived stream.

## Root Cause

The pull-wake runner already reconnects its wake stream after repeated heartbeat failures. After a laptop sleep/resume, though, the long-lived wake stream can become stale while new heartbeat requests succeed again. In that state the runner can continue reporting a connected stream but stop receiving wake notifications.

This PR is stacked on #4632, which preserves deferred same-stream wake delivery and fixes stale in-flight heartbeat ownership across runner restarts. This change handles a separate failure mode: the process was suspended long enough that the existing wake stream should be considered suspect even if the next heartbeat succeeds.

## Approach

Track wall-clock time between heartbeat timer ticks:

```ts
const elapsedMs = now - lastHeartbeatTickAt
```

If the elapsed gap is larger than `resumeGapResetMs`, the runner sends `STREAM_RESET` to the pull-wake lifecycle machine. The default threshold is the runner lease duration, so normal short event-loop delays do not reconnect the stream, while sleep/resume-sized gaps do.

The test simulates sleep by advancing wall-clock time before the heartbeat timer gets CPU again, then verifies that the current stream is cancelled and a new stream connection is opened.

## Key Invariants

- Heartbeat requests still run on their normal cadence.
- Normal short timer drift does not reset the stream.
- Sleep/resume or long event-loop stalls force a wake-stream reconnect.
- The existing #4632 guarantees around deferred same-stream wakes and heartbeat ownership remain intact.

## Non-goals

- This does not change durable-stream client retry behavior.
- This does not change server-side runner leases or wake claim semantics.
- This does not replace heartbeat-failure-based reconnects; it adds a separate resume-gap signal.

## Trade-offs

The runner may reconnect after any event-loop stall longer than the lease, not only literal OS sleep. That is intentional: after a lease-sized gap, the long-lived stream is cheap to re-establish and safer than assuming it is still delivering wake events.

## Verification

```sh
cd packages/agents-runtime
pnpm exec vitest run test/pull-wake-runner.test.ts --reporter=dot
pnpm run typecheck
```

Also run from the repository root for changeset coverage:

```sh
GITHUB_BASE_REF=main node scripts/check-changeset.mjs
```

Verified locally:

- `pull-wake-runner.test.ts`: 65 passed
- `@electric-ax/agents-runtime` typecheck: passed after building the fresh worktree dependency `@electric-ax/agents-mcp`
- Changeset check: passed

## Files changed

- `packages/agents-runtime/src/pull-wake-runner.ts`
  - Adds `resumeGapResetMs` configuration.
  - Tracks heartbeat timer wall-clock gaps.
  - Forces `STREAM_RESET` when the gap exceeds the configured threshold.
- `packages/agents-runtime/test/pull-wake-runner.test.ts`
  - Adds regression coverage for reconnecting after a simulated sleep/resume gap.
- `.changeset/reconnect-wake-stream-after-sleep.md`
  - Adds a patch changeset for `@electric-ax/agents-runtime`.

## Stacking

Stacked on #4632.
