### PR TITLE
Prevent caching handle-less 409 must-refetch responses

### DIFF
--- a/.changeset/handleless-409-no-store.md
+++ b/.changeset/handleless-409-no-store.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Prevent handle-less `409 must-refetch` responses from being stored by caches, while preserving cacheable redirects for `409` responses that include an `electric-handle`.

--- a/packages/sync-service/lib/electric/shapes/api/response.ex
+++ b/packages/sync-service/lib/electric/shapes/api/response.ex
@@ -256,18 +256,16 @@ defmodule Electric.Shapes.Api.Response do
     |> put_cache_header("cache-control", "no-cache", api)
   end
 
-  # Briefly cache 409s as they act as shape redirects, when the requested shape
-  # is either invalidated or does not match the requested definition, and thus
-  # can benefit from persisting this cache for a brief period of time to avoid
-  # surges of traffic hitting the server whenever a shape is invalidated
-  defp put_cache_headers(conn, %__MODULE__{status: status, api: api, handle: handle})
-       when status in [409] do
-    # if handle is not present, cache for a minimum time just to allow request coalescing,
-    # as 409s without handles are suboptimal redirects
-    age = if is_nil(handle), do: 1, else: 60
-
+  # Briefly cache 409s with handles as they act as shape redirects, when the
+  # requested shape is either invalidated or does not match the requested
+  # definition, and thus can benefit from persisting this cache for a brief
+  # period of time to avoid surges of traffic hitting the server whenever a
+  # shape is invalidated. Handle-less 409s fall through to the general 4xx
+  # no-store handling below.
+  defp put_cache_headers(conn, %__MODULE__{status: 409, api: api, handle: handle})
+       when not is_nil(handle) do
     conn
-    |> put_cache_header("cache-control", "public, max-age=#{age}, must-revalidate", api)
+    |> put_cache_header("cache-control", "public, max-age=60, must-revalidate", api)
   end
 
   # All other 4xx and 5xx responses should never be cached

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -720,6 +720,9 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       assert conn.status == 409
       assert [%{"headers" => %{"control" => "must-refetch"}}] = Jason.decode!(conn.resp_body)
+      assert get_resp_header(conn, "electric-handle") == []
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+      assert get_resp_header(conn, "surrogate-control") == ["no-store"]
     end
 
     test "sends an up-to-date response after a timeout if no changes are observed",


### PR DESCRIPTION
Handle-less `409 must-refetch` responses are no longer cacheable; only `409`s with an `electric-handle` keep the short-lived redirect cache behavior. This prevents shared caches from replaying a non-actionable `409` that gives clients no replacement handle to follow.

## Root Cause

`409 must-refetch` responses serve two subtly different roles:

- With an `electric-handle`, the response acts like a shape redirect and can safely be cached briefly to coalesce refetch storms.
- Without an `electric-handle`, the response only tells the client to renegotiate from scratch. Caching that response can replay a stale, non-actionable retry signal and keep clients from converging on a fresh shape handle.

The previous cache-header logic cached both cases, using `max-age=1` for handle-less `409`s.

## Approach

The sync service now only special-cases `409` responses when they include a handle:

```elixir
defp put_cache_headers(conn, %{status: 409, handle: handle}) when not is_nil(handle) do
  # cacheable redirect
end
```

Handle-less `409`s fall through to the existing generic `status >= 400` handling, which sets both `cache-control: no-store` and `surrogate-control: no-store`.

## Key Invariants

- `409` responses with `electric-handle` remain cacheable as redirect/coalescing responses.
- `409` responses without `electric-handle` are not stored by downstream or surrogate caches.
- The response body still carries the `must-refetch` control message in both cases.

## Non-goals

- No client retry behavior changes.
- No change to shape rotation semantics.
- No change to cache behavior for successful shape responses or other error statuses.

## Trade-offs

This gives up the previous 1-second cache coalescing for handle-less `409`s. That is preferable because a handle-less `409` is not a useful redirect target; caching it can amplify the stuck-loop failure mode described in the bug report.

## Verification

```sh
cd packages/sync-service
mix test test/electric/plug/serve_shape_plug_test.exs:680
mix test test/electric/plug/serve_shape_plug_test.exs
```

Also verified the changeset coverage:

```sh
GITHUB_BASE_REF=main node scripts/check-changeset.mjs
```

## Files changed

- `packages/sync-service/lib/electric/shapes/api/response.ex` — restrict cacheable `409` handling to responses with a shape handle, allowing handle-less `409`s to use the generic `no-store` error path.
- `packages/sync-service/test/electric/plug/serve_shape_plug_test.exs` — assert handle-less shape-rotation `409`s have no handle and are marked `no-store`.
- `.changeset/handleless-409-no-store.md` — add patch changeset for `@core/sync-service`.
