### PR TITLE
Fail started agent runs on handler errors

### DIFF
--- a/.changeset/fail-started-agent-runs.md
+++ b/.changeset/fail-started-agent-runs.md
@@ -1,0 +1,5 @@
+---
+'@electric-ax/agents-runtime': patch
+---
+
+Mark newly-started agent runs as failed when a wake handler errors before ending them, preventing chat UIs from showing "Thinking" indefinitely after runtime failures.

--- a/packages/agents-runtime/src/process-wake.ts
+++ b/packages/agents-runtime/src/process-wake.ts
@@ -179,12 +179,14 @@ function withRegisteredManifestEntry(
   }
 }
 
-async function latestNewRunKey(
+async function latestStartedNewRunKey(
   db: EntityStreamDBWithActions,
   existingRunKeys: ReadonlySet<string>
 ): Promise<string | undefined> {
   const runs = await queryOnce((q) => q.from({ runs: db.collections.runs }))
-  return runs.filter((run) => !existingRunKeys.has(run.key)).at(-1)?.key
+  return runs
+    .filter((run) => !existingRunKeys.has(run.key) && run.status === `started`)
+    .at(-1)?.key
 }
 
 async function resolveHeadersProvider(
@@ -551,7 +553,29 @@ export async function processWake(
       failBackgroundWake(error, `WRITE_FAILED`)
     },
   })
+  const producedRunStatuses = new Map<
+    string,
+    `started` | `completed` | `failed`
+  >()
+  const producedRunOrder: Array<string> = []
   const writeEvent = (event: ChangeEvent): void => {
+    if (
+      event.type === `run` &&
+      event.value &&
+      typeof event.value === `object`
+    ) {
+      const status = (event.value as { status?: unknown }).status
+      if (
+        status === `started` ||
+        status === `completed` ||
+        status === `failed`
+      ) {
+        if (!producedRunStatuses.has(event.key)) {
+          producedRunOrder.push(event.key)
+        }
+        producedRunStatuses.set(event.key, status)
+      }
+    }
     producer.append(JSON.stringify(event))
   }
 
@@ -2285,7 +2309,22 @@ export async function processWake(
             ? setupErr.code
             : `HANDLER_FAILED`
         log.error(`handler failed for ${entityUrl}:`, errMsg)
-        const failedRunKey = await latestNewRunKey(db, existingRunKeys)
+        const failedRunKey =
+          (await latestStartedNewRunKey(db, existingRunKeys)) ??
+          [...producedRunOrder]
+            .reverse()
+            .find((key) => producedRunStatuses.get(key) === `started`)
+        if (failedRunKey) {
+          writeEvent(
+            entityStateSchema.runs.update({
+              key: failedRunKey,
+              value: {
+                status: `failed`,
+                finish_reason: `error`,
+              } as never,
+            }) as ChangeEvent
+          )
+        }
         writeEvent(
           entityStateSchema.errors.insert({
             key: `error-${epoch}-${crypto.randomUUID()}`,

--- a/packages/agents-runtime/test/process-wake.test.ts
+++ b/packages/agents-runtime/test/process-wake.test.ts
@@ -208,7 +208,9 @@ vi.mock(`../src/entity-stream-db`, () => ({
               ? errors
               : event.type === `signal`
                 ? signals
-                : undefined
+                : event.type === `run`
+                  ? runs
+                  : undefined
         if (!collection) {
           return
         }
@@ -503,6 +505,72 @@ describe(`processWake`, () => {
   afterEach(() => {
     vi.useRealTimers()
     fetchMock.mockRestore()
+  })
+
+  it(`marks a newly-started run failed when the handler throws before ending it`, async () => {
+    defineEntity(`test-agent`, {
+      handler: (ctx) => {
+        ctx.recordRun()
+        throw new Error(`boom after run start`)
+      },
+    })
+
+    await expect(processWake(makeNotification(), BASE_CONFIG)).rejects.toThrow(
+      `boom after run start`
+    )
+
+    const events = mockProducerAppend.mock.calls.map(([body]) =>
+      JSON.parse(String(body))
+    ) as Array<ChangeEvent>
+    const startedRun = events.find(
+      (event) =>
+        event.type === `run` &&
+        event.headers.operation === `insert` &&
+        (event.value as { status?: string }).status === `started`
+    )
+
+    expect(startedRun).toBeDefined()
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: `run`,
+        key: startedRun!.key,
+        headers: expect.objectContaining({ operation: `update` }),
+        value: expect.objectContaining({
+          status: `failed`,
+          finish_reason: `error`,
+        }),
+      })
+    )
+  })
+
+  it(`does not mark a completed run failed when later handler cleanup throws`, async () => {
+    defineEntity(`test-agent`, {
+      handler: (ctx) => {
+        ctx.db.collections.runs.insert({
+          key: `externally-visible-run`,
+          status: `completed`,
+          finish_reason: `stop`,
+        })
+        throw new Error(`boom after completed run`)
+      },
+    })
+
+    await expect(processWake(makeNotification(), BASE_CONFIG)).rejects.toThrow(
+      `boom after completed run`
+    )
+
+    const events = mockProducerAppend.mock.calls.map(([body]) =>
+      JSON.parse(String(body))
+    ) as Array<ChangeEvent>
+
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        type: `run`,
+        key: `externally-visible-run`,
+        headers: expect.objectContaining({ operation: `update` }),
+        value: expect.objectContaining({ status: `failed` }),
+      })
+    )
   })
 
   it(`returns null without acking for unknown entity types`, async () => {


### PR DESCRIPTION
## Executive Summary

Mark newly-started agent runs as failed when a wake handler errors before ending them. This prevents the chat UI from showing "Thinking" indefinitely for runtime failure paths where the run start was persisted but no terminal run status was written.

## Root Cause

The UI treats the latest run with `status: started` as actively streaming. When a handler created a run and then threw before calling the run's end path, `processWake` wrote an error event but did not also update that newly-started run to a terminal status. If the run was not yet visible through the local run collection, the existing failure association logic could not find it either.

## Approach

- Track run status events emitted through `processWake` during the current wake.
- On handler failure, find the latest new run that is still `started`:
  - prefer DB-visible new started runs, and
  - fall back to produced run events that have not yet materialized in the local collection.
- Write a terminal run update before the error event:

```ts
status: 'failed'
finish_reason: 'error'
```

The failure path deliberately checks that DB-visible runs are still `started`, so a run that already completed successfully is not regressed to failed if later cleanup throws.

## Key Invariants

- Every run started during a handler that then errors should become terminal if the runtime is still alive to handle the error.
- A completed or already-failed run must not be overwritten by generic handler cleanup failure handling.
- Error events should remain associated with the run that actually failed when such a run exists.

## Non-goals

- This does not implement abandoned-run recovery for hard process death, laptop sleep, or restart cases where no in-process catch/finally can run. That second layer is tracked in #4633.
- This does not change the UI's streaming detection logic.

## Trade-offs

The runtime keeps small per-wake bookkeeping of run status events in addition to querying the local collection. This is intentionally narrow: it only covers events emitted in the current wake and avoids broader persisted lease/heartbeat semantics, which need a separate design for crash recovery.

## Verification

```sh
pnpm --dir packages/agents-runtime test process-wake.test.ts --run --reporter=dot
```

## Files changed

- `packages/agents-runtime/src/process-wake.ts`: fail the latest new still-started run when handler errors escape, with produced-event fallback for unmaterialized local writes.
- `packages/agents-runtime/test/process-wake.test.ts`: add regression coverage for failing newly-started runs and for not regressing completed runs to failed.
- `.changeset/fail-started-agent-runs.md`: patch changeset for `@electric-ax/agents-runtime`.

---

Refs #4633
