### PR TITLE
Address review feedback from #4051

### DIFF
--- a/packages/sync-service/lib/electric/lsn_tracker.ex
+++ b/packages/sync-service/lib/electric/lsn_tracker.ex
@@ -84,10 +84,7 @@ defmodule Electric.LsnTracker do
   """
   @spec get_last_broadcast_lsn(stack_ref()) :: non_neg_integer()
   def get_last_broadcast_lsn(stack_ref) do
-    case :ets.lookup(table(stack_ref), :last_broadcast_lsn) do
-      [{:last_broadcast_lsn, lsn}] -> lsn
-      [] -> 0
-    end
+    :ets.lookup_element(table(stack_ref), :last_broadcast_lsn, 2)
   rescue
     ArgumentError -> 0
   end

--- a/packages/sync-service/lib/electric/lsn_tracker.ex
+++ b/packages/sync-service/lib/electric/lsn_tracker.ex
@@ -89,6 +89,14 @@ defmodule Electric.LsnTracker do
     ArgumentError -> 0
   end
 
+  @doc """
+  Subscribe the calling process to global LSN updates.
+
+  On success, if an LSN has already been broadcast, a `{:global_last_seen_lsn, lsn}`
+  message is sent to the calling process (`self()`) before returning. Callers are
+  expected to handle that message in their `handle_info/2` just like subsequent
+  broadcasts.
+  """
   @spec subscribe_to_global_lsn_updates(stack_ref(), term()) :: {:ok, pid()} | {:error, term()}
   def subscribe_to_global_lsn_updates(stack_ref, value \\ []) do
     with {:ok, _} <-

--- a/packages/sync-service/lib/electric/replication/eval/decomposer.ex
+++ b/packages/sync-service/lib/electric/replication/eval/decomposer.ex
@@ -95,8 +95,8 @@ defmodule Electric.Replication.Eval.Decomposer do
 
   @type subexpression :: %{
           ast: Parser.tree_part(),
-          is_subquery: boolean(),
-          negated: boolean()
+          subquery?: boolean(),
+          negated?: boolean()
         }
 
   @type decomposition :: %{
@@ -268,7 +268,7 @@ defmodule Electric.Replication.Eval.Decomposer do
       term = Enum.find_value(expanded, fn row -> Enum.at(row, pos) end)
       {ref, negated} = ref_and_polarity(term)
       ast = Map.fetch!(ref_subexpressions, ref)
-      {pos, %{ast: ast, is_subquery: is_subquery?(ast), negated: negated}}
+      {pos, %{ast: ast, subquery?: is_subquery?(ast), negated?: negated}}
     end)
   end
 

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -32,7 +32,14 @@ defmodule Electric.ShapeCache.Storage do
            Querying.json_iodata()}
   @type log :: Enumerable.t(Querying.json_iodata())
 
-  @type row :: list()
+  @typedoc """
+  A move-in snapshot row, represented as a 3-element list `[key, tags, json]`:
+
+    * `key` – the row's key
+    * `tags` – the row's tag list
+    * `json` – the encoded log item body
+  """
+  @type row :: [String.t() | [String.t()] | Querying.json_iodata()]
 
   @doc "Validate and initialise storage base configuration from application configuration"
   @callback shared_opts(term()) :: compiled_opts()

--- a/packages/sync-service/lib/electric/shapes/consumer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer.ex
@@ -155,32 +155,6 @@ defmodule Electric.Shapes.Consumer do
   end
 
   @impl GenServer
-  def handle_continue({:init_consumer, config}, state) do
-    %{
-      stack_id: stack_id,
-      shape_handle: shape_handle
-    } = state
-
-    {:ok, shape} = ShapeCache.ShapeStatus.fetch_shape_by_handle(stack_id, shape_handle)
-
-    state = State.initialize_shape(state, shape, config)
-
-    stack_storage = ShapeCache.Storage.for_stack(stack_id)
-    storage = ShapeCache.Storage.for_shape(shape_handle, stack_storage)
-
-    # TODO: Remove. Only needed for InMemoryStorage
-    case ShapeCache.Storage.start_link(storage) do
-      {:ok, _pid} -> :ok
-      :ignore -> :ok
-    end
-
-    writer = ShapeCache.Storage.init_writer!(storage, shape)
-
-    state = State.initialize(state, storage, writer)
-
-    finish_initialization(state, config.action, config.otel_ctx)
-  end
-
   def handle_continue(:stop_and_clean, state) do
     stop_and_clean(state)
   end

--- a/packages/sync-service/lib/electric/shapes/consumer/transaction_converter.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/transaction_converter.ex
@@ -47,16 +47,23 @@ defmodule Electric.Shapes.Consumer.TransactionConverter do
           {:halt, {:error, {:truncate, txn.xid}}}
 
         _ ->
+          # Accumulate in reverse, flattening each conversion as we go so the head
+          # of the accumulator is always the last emitted change.
           converted = Shape.convert_change(shape, change, opts)
-          {:cont, [converted | acc]}
+          {:cont, Enum.reduce(converted, acc, &[&1 | &2])}
       end
     end)
     |> case do
       {:error, {:truncate, _xid}} = error ->
         error
 
-      converted ->
-        {:ok, converted |> Enum.reverse() |> List.flatten() |> mark_last_change()}
+      # Mark the last change before reversing, avoiding a separate pass to find
+      # and rebuild the tail.
+      [] ->
+        {:ok, []}
+
+      [last | rest] ->
+        {:ok, Enum.reverse([%{last | last?: true} | rest])}
     end
   end
 
@@ -64,12 +71,5 @@ defmodule Electric.Shapes.Consumer.TransactionConverter do
 
   defp append_effects(xid, changes) do
     [%Effects.AppendChanges{changes: changes, xid: xid}]
-  end
-
-  defp mark_last_change([]), do: []
-
-  defp mark_last_change(changes) do
-    {last, rest} = List.pop_at(changes, -1)
-    rest ++ [%{last | last?: true}]
   end
 end

--- a/packages/sync-service/lib/electric/shapes/dnf_plan.ex
+++ b/packages/sync-service/lib/electric/shapes/dnf_plan.ex
@@ -28,8 +28,8 @@ defmodule Electric.Shapes.DnfPlan do
   @type position_info :: %{
           ast: term(),
           sql: String.t(),
-          is_subquery: boolean(),
-          negated: boolean(),
+          subquery?: boolean(),
+          negated?: boolean(),
           dependency_index: non_neg_integer() | nil,
           subquery_ref: [String.t()] | nil,
           tag_columns: tag_columns() | nil
@@ -87,7 +87,7 @@ defmodule Electric.Shapes.DnfPlan do
   defp enrich_positions(subexpressions, shape) do
     Map.new(subexpressions, fn {pos, subexpr} ->
       {dep_index, subquery_ref, tag_columns} =
-        if subexpr.is_subquery do
+        if subexpr.subquery? do
           extract_subquery_info(subexpr.ast)
         else
           {nil, nil, nil}
@@ -96,9 +96,9 @@ defmodule Electric.Shapes.DnfPlan do
       {pos,
        %{
          ast: subexpr.ast,
-         sql: position_sql(subexpr.ast, subexpr.is_subquery, shape),
-         is_subquery: subexpr.is_subquery,
-         negated: subexpr.negated,
+         sql: position_sql(subexpr.ast, subexpr.subquery?, shape),
+         subquery?: subexpr.subquery?,
+         negated?: subexpr.negated?,
          dependency_index: dep_index,
          subquery_ref: subquery_ref,
          tag_columns: tag_columns
@@ -126,7 +126,7 @@ defmodule Electric.Shapes.DnfPlan do
 
   defp build_dependency_positions(positions) do
     positions
-    |> Enum.filter(fn {_pos, info} -> info.is_subquery end)
+    |> Enum.filter(fn {_pos, info} -> info.subquery? end)
     |> Enum.group_by(fn {_pos, info} -> info.dependency_index end, fn {pos, _} -> pos end)
     |> Map.new(fn {idx, poses} -> {idx, Enum.sort(poses)} end)
   end
@@ -137,7 +137,7 @@ defmodule Electric.Shapes.DnfPlan do
     |> Enum.reduce(%{}, fn {conj, disjunct_idx}, acc ->
       Enum.reduce(conj, acc, fn {pos, _polarity}, acc ->
         case Map.get(positions, pos) do
-          %{is_subquery: true, dependency_index: idx} when not is_nil(idx) ->
+          %{subquery?: true, dependency_index: idx} when not is_nil(idx) ->
             Map.update(acc, idx, MapSet.new([disjunct_idx]), &MapSet.put(&1, disjunct_idx))
 
           _ ->
@@ -150,10 +150,10 @@ defmodule Electric.Shapes.DnfPlan do
 
   defp build_dependency_polarities(positions) do
     positions
-    |> Enum.filter(fn {_pos, info} -> info.is_subquery end)
+    |> Enum.filter(fn {_pos, info} -> info.subquery? end)
     |> Enum.group_by(
       fn {_pos, info} -> info.dependency_index end,
-      fn {_pos, info} -> info.negated end
+      fn {_pos, info} -> info.negated? end
     )
     |> Enum.reduce_while({:ok, %{}}, fn {dep_index, negated_flags}, {:ok, acc} ->
       case Enum.uniq(negated_flags) do

--- a/packages/sync-service/lib/electric/shapes/filter/indexes/subquery_index.ex
+++ b/packages/sync-service/lib/electric/shapes/filter/indexes/subquery_index.ex
@@ -77,9 +77,9 @@ defmodule Electric.Shapes.Filter.Indexes.SubqueryIndex do
 
     polarities =
       plan.positions
-      |> Enum.filter(fn {_pos, info} -> info.is_subquery end)
+      |> Enum.filter(fn {_pos, info} -> info.subquery? end)
       |> Map.new(fn {_pos, info} ->
-        {info.dependency_index, if(info.negated, do: :negated, else: :positive)}
+        {info.dependency_index, if(info.negated?, do: :negated, else: :positive)}
       end)
 
     for {dep_index, polarity} <- polarities do

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -395,7 +395,7 @@ defmodule Electric.Shapes.Querying do
       info = plan.positions[pos]
       base_sql = info.sql
 
-      if info.negated do
+      if info.negated? do
         "(NOT COALESCE((#{base_sql})::boolean, false))::boolean"
       else
         "COALESCE((#{base_sql})::boolean, false)"
@@ -414,7 +414,7 @@ defmodule Electric.Shapes.Querying do
           position_to_sql(info, views, used_refs, param_idx)
 
         sql =
-          if info.negated do
+          if info.negated? do
             "(NOT COALESCE((#{base_sql})::boolean, false))::boolean"
           else
             "COALESCE((#{base_sql})::boolean, false)"
@@ -491,12 +491,12 @@ defmodule Electric.Shapes.Querying do
     {sql, params, next_pi}
   end
 
-  defp position_to_sql(%{is_subquery: false} = info, _, _, pidx) do
+  defp position_to_sql(%{subquery?: false} = info, _, _, pidx) do
     {info.sql, [], pidx}
   end
 
   defp position_to_sql(
-         %{is_subquery: true} = info,
+         %{subquery?: true} = info,
          views,
          used_refs,
          pidx
@@ -547,14 +547,14 @@ defmodule Electric.Shapes.Querying do
     SqlGenerator.to_sql(testexpr)
   end
 
-  defp tag_slot_sql(%{is_subquery: true, tag_columns: [col]}, stack_id, shape_handle) do
+  defp tag_slot_sql(%{subquery?: true, tag_columns: [col]}, stack_id, shape_handle) do
     col_sql = pg_cast_column_to_text(col)
     namespaced = pg_namespace_value_sql(col_sql)
     ~s[md5('#{stack_id}#{shape_handle}' || #{namespaced})]
   end
 
   defp tag_slot_sql(
-         %{is_subquery: true, tag_columns: {:hash_together, cols}},
+         %{subquery?: true, tag_columns: {:hash_together, cols}},
          stack_id,
          shape_handle
        ) do
@@ -567,7 +567,7 @@ defmodule Electric.Shapes.Querying do
     ~s[md5('#{stack_id}#{shape_handle}' || #{Enum.join(column_parts, " || ")})]
   end
 
-  defp tag_slot_sql(%{is_subquery: false}, _stack_id, _shape_handle) do
+  defp tag_slot_sql(%{subquery?: false}, _stack_id, _shape_handle) do
     "'1'"
   end
 

--- a/packages/sync-service/lib/electric/shapes/shape.ex
+++ b/packages/sync-service/lib/electric/shapes/shape.ex
@@ -901,7 +901,7 @@ defmodule Electric.Shapes.Shape do
           _ -> false
         end
 
-      if info.negated, do: not base_result, else: base_result
+      if info.negated?, do: not base_result, else: base_result
     end)
   end
 
@@ -920,12 +920,12 @@ defmodule Electric.Shapes.Shape do
     end)
   end
 
-  defp compute_tag_slot(%{is_subquery: true, tag_columns: [col]}, record, stack_id, shape_handle) do
+  defp compute_tag_slot(%{subquery?: true, tag_columns: [col]}, record, stack_id, shape_handle) do
     SubqueryTags.make_value_hash(stack_id, shape_handle, Map.get(record, col))
   end
 
   defp compute_tag_slot(
-         %{is_subquery: true, tag_columns: {:hash_together, cols}},
+         %{subquery?: true, tag_columns: {:hash_together, cols}},
          record,
          stack_id,
          shape_handle
@@ -938,7 +938,7 @@ defmodule Electric.Shapes.Shape do
     SubqueryTags.make_value_hash_raw(stack_id, shape_handle, Enum.join(parts))
   end
 
-  defp compute_tag_slot(%{is_subquery: false}, _record, _stack_id, _shape_handle) do
+  defp compute_tag_slot(%{subquery?: false}, _record, _stack_id, _shape_handle) do
     "1"
   end
 

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -2590,8 +2590,7 @@ defmodule Electric.Plug.RouterTest do
       assert {req, 200, [data, snapshot_end]} = shape_req(req, opts)
 
       tag =
-        :crypto.hash(:md5, stack_id <> req.handle <> "v:1")
-        |> Base.encode16(case: :lower)
+        value_tag(stack_id, req.handle, "v:1")
 
       assert %{"id" => "1", "inner_id" => "1", "value" => "10"} = data["value"]
       assert %{"operation" => "insert", "tags" => [^tag]} = data["headers"]
@@ -2608,8 +2607,7 @@ defmodule Electric.Plug.RouterTest do
         )
 
       tag2 =
-        :crypto.hash(:md5, stack_id <> req.handle <> "v:2")
-        |> Base.encode16(case: :lower)
+        value_tag(stack_id, req.handle, "v:2")
 
       assert {_, 200,
               [
@@ -2658,8 +2656,7 @@ defmodule Electric.Plug.RouterTest do
       task = live_shape_req(req, opts)
 
       tag =
-        :crypto.hash(:md5, stack_id <> req.handle <> "v:1")
-        |> Base.encode16(case: :lower)
+        value_tag(stack_id, req.handle, "v:1")
 
       # Now set inner row 1 to excluded = true.
       # This moves it into the subquery result and forces outer row 1 out.
@@ -2698,8 +2695,7 @@ defmodule Electric.Plug.RouterTest do
       Postgrex.query!(db_conn, "UPDATE inner_table SET excluded = false WHERE id = 1", [])
 
       tag =
-        :crypto.hash(:md5, stack_id <> req.handle <> "v:1")
-        |> Base.encode16(case: :lower)
+        value_tag(stack_id, req.handle, "v:1")
 
       assert {_req, 200,
               [
@@ -2858,8 +2854,7 @@ defmodule Electric.Plug.RouterTest do
       assert length(response) == 2
 
       tag =
-        :crypto.hash(:md5, opts[:stack_id] <> req.handle <> "v:1")
-        |> Base.encode16(case: :lower)
+        value_tag(opts[:stack_id], req.handle, "v:1")
 
       assert %{
                "value" => %{"id" => "1"},
@@ -2907,8 +2902,7 @@ defmodule Electric.Plug.RouterTest do
       assert length(response) == 2
 
       tag =
-        :crypto.hash(:md5, opts[:stack_id] <> req.handle <> "v:1")
-        |> Base.encode16(case: :lower)
+        value_tag(opts[:stack_id], req.handle, "v:1")
 
       assert %{
                "value" => %{"id" => "1"},
@@ -3021,8 +3015,7 @@ defmodule Electric.Plug.RouterTest do
       Postgrex.query!(ctx.db_conn, "INSERT INTO members (user_id, team_id) VALUES (1, 2)")
 
       tag =
-        :crypto.hash(:md5, ctx.stack_id <> req.handle <> "v:2")
-        |> Base.encode16(case: :lower)
+        value_tag(ctx.stack_id, req.handle, "v:2")
 
       assert {req, 200,
               [
@@ -3099,8 +3092,7 @@ defmodule Electric.Plug.RouterTest do
       )
 
       tag =
-        :crypto.hash(:md5, ctx.stack_id <> req.handle <> "user_id:v:2" <> "team_id:v:2")
-        |> Base.encode16(case: :lower)
+        value_tag(ctx.stack_id, req.handle, "user_id:v:2" <> "team_id:v:2")
 
       assert {req, 200,
               [
@@ -3171,8 +3163,7 @@ defmodule Electric.Plug.RouterTest do
       Postgrex.query!(ctx.db_conn, "UPDATE parent SET other_value = 10 WHERE id = 2")
 
       tag_hash =
-        :crypto.hash(:md5, ctx.stack_id <> req.handle <> "v:20")
-        |> Base.encode16(case: :lower)
+        value_tag(ctx.stack_id, req.handle, "v:20")
 
       # DNF tags: "subquery_hash/row_predicate_slot"
       tag = "#{tag_hash}/1"
@@ -3206,7 +3197,7 @@ defmodule Electric.Plug.RouterTest do
       assert length(response) == 2
 
       tag_hash =
-        :crypto.hash(:md5, ctx.stack_id <> req.handle <> "v:1") |> Base.encode16(case: :lower)
+        value_tag(ctx.stack_id, req.handle, "v:1")
 
       # DNF tags: "subquery_hash/row_predicate_slot"
       tag = "#{tag_hash}/1"
@@ -3323,10 +3314,10 @@ defmodule Electric.Plug.RouterTest do
       Process.sleep(1000)
 
       tag2 =
-        :crypto.hash(:md5, ctx.stack_id <> req.handle <> "v:2") |> Base.encode16(case: :lower)
+        value_tag(ctx.stack_id, req.handle, "v:2")
 
       tag3 =
-        :crypto.hash(:md5, ctx.stack_id <> req.handle <> "v:3") |> Base.encode16(case: :lower)
+        value_tag(ctx.stack_id, req.handle, "v:3")
 
       # The reduced move queue keeps the first move-in/move-out pair for
       # dependency row 2, then drops the later move-in/move-out oscillation
@@ -4001,6 +3992,15 @@ defmodule Electric.Plug.RouterTest do
     opts
     |> Map.new()
     |> Map.put(:table, table)
+  end
+
+  # Independently computes the expected subquery row tag (mirrors
+  # Electric.Shapes.SubqueryTags.make_value_hash_raw/3) so assertions document the
+  # wire format rather than reusing the code under test. `namespaced_value` is the
+  # already-prefixed tag value, e.g. "v:1".
+  defp value_tag(stack_id, handle, namespaced_value) do
+    :crypto.hash(:md5, stack_id <> handle <> namespaced_value)
+    |> Base.encode16(case: :lower)
   end
 
   defp shape_req(orig_base, router_opts, opts \\ []) do

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -2507,14 +2507,24 @@ defmodule Electric.Plug.RouterTest do
     test "return 400 if same subquery is used with both positive and negative polarity", %{
       opts: opts
     } do
-      assert %{status: 400} =
-               conn("GET", "/v1/shape", %{
-                 table: "outer_table",
-                 offset: "-1",
-                 where:
-                   "inner_id IN (SELECT id FROM inner_table) OR NOT inner_id IN (SELECT id FROM inner_table)"
-               })
-               |> Router.call(opts)
+      conn =
+        conn("GET", "/v1/shape", %{
+          table: "outer_table",
+          offset: "-1",
+          where:
+            "inner_id IN (SELECT id FROM inner_table) OR NOT inner_id IN (SELECT id FROM inner_table)"
+        })
+        |> Router.call(opts)
+
+      assert %{status: 400} = conn
+
+      assert %{
+               "errors" => %{
+                 "where" => [
+                   "a subquery dependency cannot be used with both positive and negative polarity in the same filter"
+                 ]
+               }
+             } = Jason.decode!(conn.resp_body)
     end
 
     @tag with_sql: [

--- a/packages/sync-service/test/electric/replication/eval/decomposer_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/decomposer_test.exs
@@ -370,7 +370,7 @@ defmodule Electric.Replication.Eval.DecomposerTest do
         |> Enum.filter(fn {_pos, subexpr} -> deparse(subexpr.ast) == ~s|"a" = 1| end)
 
       assert length(a_eq_1_entries) == 2
-      polarities = a_eq_1_entries |> Enum.map(fn {_, s} -> s.negated end) |> Enum.sort()
+      polarities = a_eq_1_entries |> Enum.map(fn {_, s} -> s.negated? end) |> Enum.sort()
       assert polarities == [false, true]
     end
 

--- a/packages/sync-service/test/electric/shapes/dnf_plan_test.exs
+++ b/packages/sync-service/test/electric/shapes/dnf_plan_test.exs
@@ -42,8 +42,8 @@ defmodule Electric.Shapes.DnfPlanTest do
       # Single position, which is a subquery
       assert map_size(plan.positions) == 1
       pos0 = plan.positions[0]
-      assert pos0.is_subquery == true
-      assert pos0.negated == false
+      assert pos0.subquery? == true
+      assert pos0.negated? == false
       assert pos0.dependency_index == 0
       assert pos0.subquery_ref == ["$sublink", "0"]
       assert pos0.tag_columns == ["x"]
@@ -70,13 +70,13 @@ defmodule Electric.Shapes.DnfPlanTest do
 
       # Position 0: x IN sq1
       pos0 = plan.positions[0]
-      assert pos0.is_subquery == true
+      assert pos0.subquery? == true
       assert pos0.dependency_index == 0
       assert pos0.tag_columns == ["x"]
 
       # Position 1: y IN sq2
       pos1 = plan.positions[1]
-      assert pos1.is_subquery == true
+      assert pos1.subquery? == true
       assert pos1.dependency_index == 1
       assert pos1.tag_columns == ["y"]
 
@@ -102,7 +102,7 @@ defmodule Electric.Shapes.DnfPlanTest do
       # Find the subquery positions
       subquery_positions =
         plan.positions
-        |> Enum.filter(fn {_pos, info} -> info.is_subquery end)
+        |> Enum.filter(fn {_pos, info} -> info.subquery? end)
         |> Enum.sort_by(fn {_pos, info} -> info.dependency_index end)
 
       assert length(subquery_positions) == 2
@@ -116,11 +116,11 @@ defmodule Electric.Shapes.DnfPlanTest do
       # Find the row predicate position
       row_positions =
         plan.positions
-        |> Enum.filter(fn {_pos, info} -> not info.is_subquery end)
+        |> Enum.filter(fn {_pos, info} -> not info.subquery? end)
 
       assert [{row_pos, row_info}] = row_positions
       assert row_info.sql =~ "status"
-      assert row_info.is_subquery == false
+      assert row_info.subquery? == false
       assert row_info.dependency_index == nil
 
       # Disjunct 0 should contain sq1 + row predicate, disjunct 1 should contain sq2
@@ -176,7 +176,7 @@ defmodule Electric.Shapes.DnfPlanTest do
 
       assert plan.position_count == 1
       pos0 = plan.positions[0]
-      assert pos0.is_subquery == true
+      assert pos0.subquery? == true
       assert pos0.tag_columns == {:hash_together, ["x", "y"]}
     end
   end
@@ -190,8 +190,8 @@ defmodule Electric.Shapes.DnfPlanTest do
       assert {:ok, plan} = DnfPlan.compile(shape)
 
       pos0 = plan.positions[0]
-      assert pos0.is_subquery == true
-      assert pos0.negated == true
+      assert pos0.subquery? == true
+      assert pos0.negated? == true
       assert plan.dependency_polarities == %{0 => :negated}
     end
 

--- a/packages/sync-service/test/electric/shapes/filter/subquery_index_test.exs
+++ b/packages/sync-service/test/electric/shapes/filter/subquery_index_test.exs
@@ -226,8 +226,8 @@ defmodule Electric.Shapes.Filter.Indexes.SubqueryIndexTest do
         0 => %{
           ast: ast,
           sql: "fake",
-          is_subquery: true,
-          negated: polarity == :negated,
+          subquery?: true,
+          negated?: polarity == :negated,
           dependency_index: dep_index,
           subquery_ref: subquery_ref,
           tag_columns: [field]

--- a/packages/sync-service/test/electric/shapes/filter/subquery_node_test.exs
+++ b/packages/sync-service/test/electric/shapes/filter/subquery_node_test.exs
@@ -220,8 +220,8 @@ defmodule Electric.Shapes.Filter.Indexes.SubqueryIndexNodeTest do
         0 => %{
           ast: ast,
           sql: "fake",
-          is_subquery: true,
-          negated: polarity == :negated,
+          subquery?: true,
+          negated?: polarity == :negated,
           dependency_index: dep_index,
           subquery_ref: subquery_ref,
           tag_columns: [field]

--- a/packages/sync-service/test/electric/shapes/shape_test.exs
+++ b/packages/sync-service/test/electric/shapes/shape_test.exs
@@ -1405,7 +1405,7 @@ defmodule Electric.Shapes.ShapeTest do
 
       row_pred_pos =
         plan.positions
-        |> Enum.find(fn {_pos, info} -> not info.is_subquery end)
+        |> Enum.find(fn {_pos, info} -> not info.subquery? end)
         |> elem(0)
 
       refute Enum.at(active_conditions, row_pred_pos)
@@ -1471,7 +1471,7 @@ defmodule Electric.Shapes.ShapeTest do
 
       row_pred_pos =
         plan.positions
-        |> Enum.find(fn {_pos, info} -> not info.is_subquery end)
+        |> Enum.find(fn {_pos, info} -> not info.subquery? end)
         |> elem(0)
 
       assert Enum.at(slots, row_pred_pos) == "1"
@@ -1502,7 +1502,7 @@ defmodule Electric.Shapes.ShapeTest do
 
       row_pred_pos =
         plan.positions
-        |> Enum.find(fn {_pos, info} -> not info.is_subquery end)
+        |> Enum.find(fn {_pos, info} -> not info.subquery? end)
         |> elem(0)
 
       assert Enum.at(old_ac, row_pred_pos) == true


### PR DESCRIPTION
## Summary

Follow-up to the merged subqueries PR #4051, addressing reviewer (@alco) feedback that came in after merge. Each commit maps 1:1 to a review comment so they can be reviewed independently.

## Changes

| Commit | Review comment |
| --- | --- |
| `8827e20` Make storage `row()` type reflect actual value type | [r3130325864](https://github.com/electric-sql/electric/pull/4051#discussion_r3130325864) |
| `fd7748e` Rename `position_info` boolean fields to `subquery?`/`negated?` | [r3130956496](https://github.com/electric-sql/electric/pull/4051#discussion_r3130956496) |
| `91f8f17` Use `:ets.lookup_element/3` in `get_last_broadcast_lsn` | [r3130990531](https://github.com/electric-sql/electric/pull/4051#discussion_r3130990531) |
| `dd8cb5c` Document `self()` message sent by `subscribe_to_global_lsn_updates` | [r3130996392](https://github.com/electric-sql/electric/pull/4051#discussion_r3130996392) |
| `82ecbc2` Remove dead `:init_consumer` `handle_continue` clause | [r3131087003](https://github.com/electric-sql/electric/pull/4051#discussion_r3131087003) |
| `1545bb3` Assert mixed-polarity subquery error message in router test | [r3131001659](https://github.com/electric-sql/electric/pull/4051#discussion_r3131001659) |
| `6aa7581` Mark last converted change before reversing | [r3131488531](https://github.com/electric-sql/electric/pull/4051#discussion_r3131488531) |
| `2a7fff5` Extract `value_tag/3` helper in router test | [r3131013153](https://github.com/electric-sql/electric/pull/4051#discussion_r3131013153) |

These are internal-only changes (type docs, field renames, a dead-code removal, an ETS lookup simplification, test assertions/helpers, and a list-building cleanup) with no user-facing behavior change, so no changeset is included.

A few comments were discussed and intentionally left unchanged: the `Stream.concat` suggestion ([r3131472813](https://github.com/electric-sql/electric/pull/4051#discussion_r3131472813), the accumulated lists are tiny and `reverse |> flatten` is clearer) and the `BETWEEN` question ([r3131209403](https://github.com/electric-sql/electric/pull/4051#discussion_r3131209403), confirmed as an intentional latent-bug fix required by this PR's `name`-based DNF decomposition / SQL generation).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
