### PR TITLE
Reset replication metadata caches on new/temporary slot shape purge

### DIFF
--- a/.changeset/wipe-replication-metadata-on-slot-purge.md
+++ b/.changeset/wipe-replication-metadata-on-slot-purge.md
@@ -1,0 +1,12 @@
+---
+'@core/sync-service': patch
+---
+
+Reset replication metadata caches when shapes are purged on a new or temporary
+replication slot. Previously, when Electric purged all shapes after the
+replication slot was (re)created — e.g. a temporary slot recreated on restart
+with `CLEANUP_REPLICATION_SLOTS_ON_SHUTDOWN=true` — the persisted relation
+tracking (`tracked_relations`) and the inspector cache (`ets_inspector_state`)
+survived and were read back on startup, even though WAL continuity had been
+lost. These caches are now reset as part of the same purge, so no stale
+pre-restart metadata is reused.

--- a/packages/sync-service/lib/electric/connection/manager.ex
+++ b/packages/sync-service/lib/electric/connection/manager.ex
@@ -472,14 +472,21 @@ defmodule Electric.Connection.Manager do
       # The ShapeStatusOwner process lives independently of connection or replication
       # supervisor. Purge all shapes from it before starting the replication supervisor.
       Electric.ShapeCache.ShapeStatus.reset(state.stack_id)
-    end
 
-    if timeline_changed? do
+      # Whenever we purge shapes - whether due to a timeline change or because the
+      # replication slot was (re)created (e.g. a temporary slot after restart) - the WAL
+      # continuity that the persisted replication metadata describes is gone. Reset those
+      # caches so we don't read stale relation tracking / inspector state on startup; they
+      # get repopulated from the fresh replication stream and live Postgres.
       Electric.Replication.PersistentReplicationState.reset(
         stack_id: state.stack_id,
         persistent_kv: state.persistent_kv
       )
 
+      Electric.Postgres.Inspector.reset(state.inspector)
+    end
+
+    if timeline_changed? do
       dispatch_stack_event(
         {:warning,
          %{

--- a/packages/sync-service/lib/electric/postgres/inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector.ex
@@ -56,6 +56,8 @@ defmodule Electric.Postgres.Inspector do
   @callback list_relations_with_stale_cache(opts :: term()) ::
               {:ok, [Electric.oid_relation()]} | :error
 
+  @callback reset(opts :: term()) :: :ok
+
   @type inspector :: {module(), opts :: term()}
 
   def for_stack(stack_id) do
@@ -162,6 +164,14 @@ defmodule Electric.Postgres.Inspector do
           {:ok, [Electric.oid_relation()]} | :error
   def list_relations_with_stale_cache({module, opts}) do
     module.list_relations_with_stale_cache(opts)
+  end
+
+  @doc """
+  Drop the entire inspector cache. Inspectors without a cache are a no-op.
+  """
+  @spec reset(inspector()) :: :ok
+  def reset({module, opts}) do
+    module.reset(opts)
   end
 
   defp as_atom(type) when is_binary(type), do: String.to_atom(type)

--- a/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
@@ -260,4 +260,7 @@ defmodule Electric.Postgres.Inspector.DirectInspector do
 
   @impl Electric.Postgres.Inspector
   def clean(_, _), do: :ok
+
+  @impl Electric.Postgres.Inspector
+  def reset(_), do: :ok
 end

--- a/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
@@ -87,6 +87,12 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
     GenServer.call(opts[:server], :list_relations_with_stale_cache, :infinity)
   end
 
+  @impl Inspector
+  @spec reset(opts :: term()) :: :ok
+  def reset(opts) do
+    GenServer.call(opts[:server], :reset, :infinity)
+  end
+
   ## Internal API
 
   @impl GenServer
@@ -169,6 +175,13 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
 
   def handle_call({:clean, oid}, _from, state) do
     {:reply, :ok, delete_relation_info(state, oid)}
+  end
+
+  def handle_call(:reset, _from, state) do
+    :ets.delete_all_objects(inspector_table(state))
+    # Re-persist so the cleared cache survives a restart instead of restoring stale data.
+    persist_data(state)
+    {:reply, :ok, state}
   end
 
   def handle_call(:list_relations_with_stale_cache, _from, state) do

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -6,8 +6,11 @@ defmodule Electric.Connection.ConnectionManagerTest do
   import Support.DbSetup
 
   alias Electric.Replication.ShapeLogCollector
+  alias Electric.Replication.PersistentReplicationState
   alias Electric.Connection
   alias Electric.StatusMonitor
+  alias Electric.Postgres.Inspector.EtsInspector
+  alias Electric.Timeline
 
   @moduletag :tmp_dir
 
@@ -310,6 +313,32 @@ defmodule Electric.Connection.ConnectionManagerTest do
       Process.exit(shape_cache_pid, {:error, :reason})
 
       refute_receive {:DOWN, ^ref, :process, ^manager_pid, _reason}, 300
+    end
+  end
+
+  describe "purging replication metadata on shape purge" do
+    # Pre-seed replication metadata caches and a non-matching timeline so that the
+    # connection manager purges all shapes on startup (here via a timeline change; the
+    # new-slot / temporary-slot path purges through the same shared block in
+    # Connection.Manager). Both the persisted relation tracking and the inspector cache
+    # must be reset as part of that purge, otherwise stale pre-restart metadata would be
+    # read back even though WAL continuity was lost.
+    setup [:seed_stale_replication_metadata, :start_connection_manager]
+
+    test "resets tracked relations and the inspector cache", %{
+      stack_id: stack_id,
+      persistent_kv: persistent_kv,
+      pg_inspector_table: pg_inspector_table
+    } do
+      wait_until_active(stack_id)
+
+      assert :ets.tab2list(pg_inspector_table) == []
+
+      assert %{table_to_id: %{}, id_to_table_info: %{}} =
+               PersistentReplicationState.get_tracked_relations(
+                 stack_id: stack_id,
+                 persistent_kv: persistent_kv
+               )
     end
   end
 
@@ -716,6 +745,30 @@ defmodule Electric.Connection.ConnectionManagerTest do
       # so the lock breaker should not terminate any backends
       refute log =~ "Terminated a stuck backend"
     end
+  end
+
+  defp seed_stale_replication_metadata(%{
+         stack_id: stack_id,
+         persistent_kv: persistent_kv,
+         inspector: {EtsInspector, inspector_opts},
+         pg_inspector_table: pg_inspector_table
+       }) do
+    # Populate the inspector cache (supported features needs no table) ...
+    assert {:ok, _features} = EtsInspector.load_supported_features(inspector_opts)
+    refute :ets.tab2list(pg_inspector_table) == []
+
+    # ... and the persisted relation tracking.
+    PersistentReplicationState.set_tracked_relations(
+      %{table_to_id: %{{"public", "items"} => 1}, id_to_table_info: %{}},
+      stack_id: stack_id,
+      persistent_kv: persistent_kv
+    )
+
+    # Store a timeline with a Postgres ID that cannot match the real one, forcing a
+    # timeline change (and therefore a full shape purge) on the next connection.
+    Timeline.store_timeline({0, 1}, stack_id: stack_id, persistent_kv: persistent_kv)
+
+    :ok
   end
 
   defp wait_until_active(stack_id) do

--- a/packages/sync-service/test/electric/connection/manager_test.exs
+++ b/packages/sync-service/test/electric/connection/manager_test.exs
@@ -316,29 +316,32 @@ defmodule Electric.Connection.ConnectionManagerTest do
     end
   end
 
-  describe "purging replication metadata on shape purge" do
-    # Pre-seed replication metadata caches and a non-matching timeline so that the
-    # connection manager purges all shapes on startup (here via a timeline change; the
-    # new-slot / temporary-slot path purges through the same shared block in
-    # Connection.Manager). Both the persisted relation tracking and the inspector cache
-    # must be reset as part of that purge, otherwise stale pre-restart metadata would be
-    # read back even though WAL continuity was lost.
-    setup [:seed_stale_replication_metadata, :start_connection_manager]
+  # Both the persisted relation tracking and the inspector cache must be reset whenever
+  # shapes are purged, otherwise stale pre-restart metadata would be read back even though
+  # WAL continuity was lost. The purge runs through a single shared block in
+  # Connection.Manager regardless of trigger, so we cover both triggers.
+  describe "purging replication metadata on timeline change" do
+    # A non-matching stored timeline forces a timeline change (and therefore a purge) on
+    # the next connection.
+    setup [
+      :seed_stale_replication_metadata,
+      :store_mismatched_timeline,
+      :start_connection_manager
+    ]
 
-    test "resets tracked relations and the inspector cache", %{
-      stack_id: stack_id,
-      persistent_kv: persistent_kv,
-      pg_inspector_table: pg_inspector_table
-    } do
-      wait_until_active(stack_id)
+    test "resets tracked relations and the inspector cache", ctx do
+      assert_metadata_reset_after_active(ctx)
+    end
+  end
 
-      assert :ets.tab2list(pg_inspector_table) == []
+  describe "purging replication metadata on new/temporary replication slot" do
+    # The motivating path: the timeline is unchanged but the (temporary) replication slot
+    # was created fresh, setting purge_all_shapes?. We stub the timeline check to report an
+    # unchanged, non-initializing timeline so the purge is driven solely by slot creation.
+    setup [:seed_stale_replication_metadata, :force_unchanged_timeline, :start_connection_manager]
 
-      assert %{table_to_id: %{}, id_to_table_info: %{}} =
-               PersistentReplicationState.get_tracked_relations(
-                 stack_id: stack_id,
-                 persistent_kv: persistent_kv
-               )
+    test "resets tracked relations and the inspector cache", ctx do
+      assert_metadata_reset_after_active(ctx)
     end
   end
 
@@ -764,11 +767,58 @@ defmodule Electric.Connection.ConnectionManagerTest do
       persistent_kv: persistent_kv
     )
 
-    # Store a timeline with a Postgres ID that cannot match the real one, forcing a
-    # timeline change (and therefore a full shape purge) on the next connection.
-    Timeline.store_timeline({0, 1}, stack_id: stack_id, persistent_kv: persistent_kv)
-
     :ok
+  end
+
+  # Store a timeline with a Postgres ID that cannot match the real one, forcing a timeline
+  # change (and therefore a full shape purge) on the next connection.
+  defp store_mismatched_timeline(%{stack_id: stack_id, persistent_kv: persistent_kv}) do
+    Timeline.store_timeline({0, 1}, stack_id: stack_id, persistent_kv: persistent_kv)
+    :ok
+  end
+
+  # Make the timeline check report an unchanged, non-initializing timeline so that the only
+  # thing that can drive a purge is the freshly-created (temporary) replication slot setting
+  # purge_all_shapes?.
+  defp force_unchanged_timeline(%{stack_id: stack_id}) do
+    parent = self()
+    Repatch.patch(Timeline, :check, [mode: :shared], fn _pg_timeline, _opts -> :ok end)
+    allow_patches_in_manager(stack_id, parent)
+    :ok
+  end
+
+  # Process allowance doesn't follow the supervision tree, so allow the manager process to
+  # see the shared patch as soon as it has started.
+  defp allow_patches_in_manager(stack_id, parent) do
+    spawn_link(fn ->
+      Stream.repeatedly(fn -> 0 end)
+      |> Enum.reduce_while(0, fn _, _ ->
+        case GenServer.whereis(Connection.Manager.name(stack_id)) do
+          nil ->
+            {:cont, 0}
+
+          pid ->
+            Repatch.allow(parent, pid)
+            {:halt, 0}
+        end
+      end)
+    end)
+  end
+
+  defp assert_metadata_reset_after_active(%{
+         stack_id: stack_id,
+         persistent_kv: persistent_kv,
+         pg_inspector_table: pg_inspector_table
+       }) do
+    wait_until_active(stack_id)
+
+    assert :ets.tab2list(pg_inspector_table) == []
+
+    assert %{table_to_id: %{}, id_to_table_info: %{}} =
+             PersistentReplicationState.get_tracked_relations(
+               stack_id: stack_id,
+               persistent_kv: persistent_kv
+             )
   end
 
   defp wait_until_active(stack_id) do

--- a/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
+++ b/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
@@ -209,6 +209,41 @@ defmodule Electric.Postgres.Inspector.EtsInspectorTest do
     end
   end
 
+  describe "reset/1" do
+    setup :with_shared_db
+    setup :in_transaction
+    setup :with_stack_id_from_test
+    setup [:with_persistent_kv, :with_inspector, :with_basic_tables, :with_sql_execute]
+    setup %{inspector: {EtsInspector, opts}}, do: %{opts: opts}
+    setup :with_items_oid
+
+    test "drops the entire ETS cache", %{
+      opts: opts,
+      pg_inspector_table: pg_inspector_table
+    } do
+      assert {:ok, {_oid, _}} = EtsInspector.load_relation_oid({"public", "items"}, opts)
+      refute :ets.tab2list(pg_inspector_table) == []
+
+      assert :ok = EtsInspector.reset(opts)
+      assert :ets.tab2list(pg_inspector_table) == []
+    end
+
+    test "does not restore the cleared cache on a restart", %{opts: opts, db_conn: conn} = ctx do
+      assert {:ok, {_oid, _}} = EtsInspector.load_relation_oid({"public", "items"}, opts)
+      assert :ok = EtsInspector.reset(opts)
+
+      stop_supervised!(EtsInspector)
+
+      # Drop the table so that, if a stale cache were restored, the lookup would
+      # succeed from cache rather than report the table as missing.
+      Postgrex.query!(conn, "DROP TABLE items", [])
+
+      %{inspector: {EtsInspector, opts}} = with_inspector(ctx)
+
+      assert :table_not_found = EtsInspector.load_relation_oid({"public", "items"}, opts)
+    end
+  end
+
   describe "load_column_info/2" do
     setup :with_shared_db
     setup :in_transaction

--- a/packages/sync-service/test/support/stub_inspector.ex
+++ b/packages/sync-service/test/support/stub_inspector.ex
@@ -124,4 +124,7 @@ defmodule Support.StubInspector do
 
   @impl true
   def clean(_, _), do: :ok
+
+  @impl true
+  def reset(_), do: :ok
 end


### PR DESCRIPTION
## Summary

When Electric purges all shapes because the replication slot was (re)created — e.g. a **temporary** slot recreated on restart with `CLEANUP_REPLICATION_SLOTS_ON_SHUTDOWN=true` — or because the timeline changed, it now also resets the two replication-metadata caches that previously survived and were read back on startup.

## Problem

With a temporary slot, every restart drops the old slot and creates a new one, which triggers a full shape purge (storage `cleanup_all!` + `ShapeStatus.reset`). But two persistent caches were left untouched and **read on startup**, so they could be inconsistent with the freshly-created slot (WAL continuity was intentionally discarded):

- `<stack_id>:tracked_relations` — read by `ShapeLogCollector` on init via `PersistentReplicationState.get_tracked_relations/1`. It was only reset on a **timeline change**, not on the new-slot purge path.
- `<stack_id>:ets_inspector_state` — restored by `EtsInspector` on init. Never reset on either path.

## Changes

- `connection/manager.ex` — move `PersistentReplicationState.reset/1` (tracked_relations) out of the timeline-only block into the **shared purge block**, so it also runs on the new-slot / temporary-slot path; add `Electric.Postgres.Inspector.reset(state.inspector)` to clear the inspector cache in the same block.
- `postgres/inspector/ets_inspector.ex` — new public `reset/1` + `handle_call(:reset, …)` that empties the in-memory ETS table and re-persists empty state so the cleared cache survives a restart.
- `postgres/inspector.ex` — new `reset/1` behaviour callback + `{module, opts}` dispatch wrapper (mirrors `clean/2`).
- `postgres/inspector/direct_inspector.ex` + `test/support/stub_inspector.ex` — no-op `reset/1` (no cache).

On a new slot, pgoutput resends `Relation` messages before any DML, so clearing `tracked_relations` is safe (it repopulates); the inspector is a write-through cache reconciled against Postgres, so clearing is conservative.

## Test Plan

- [x] `ets_inspector_test.exs` — `reset/1` drops the entire ETS cache, and a restart does not restore the cleared cache.
- [x] `connection/manager_test.exs` — seeds the inspector cache + non-empty tracked_relations + a non-matching timeline, then asserts both are reset once the manager comes up (exercises the shared purge block the new-slot path uses).
- [x] Affected suites green: manager, inspector, shape_log_collector (104 tests).

---
Generated with [Claude Code](https://claude.com/claude-code)