### PR TITLE
fix(telemetry): reduce SystemMonitor heap growth

### DIFF
--- a/.changeset/fix-telemetry-system-monitor-memory.md
+++ b/.changeset/fix-telemetry-system-monitor-memory.md
@@ -1,0 +1,5 @@
+---
+"@core/electric-telemetry": patch
+---
+
+Reduce SystemMonitor heap growth by avoiding full process dictionary, memory, and binary metadata when classifying monitor events, and periodically garbage collect the monitor process.

--- a/packages/electric-telemetry/lib/electric/telemetry/processes.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/processes.ex
@@ -4,6 +4,16 @@ defmodule ElectricTelemetry.Processes do
 
   @default_count 5
   @default_limit {:count, @default_count}
+  @initial_call_key :"$initial_call"
+  @ancestors_key :"$ancestors"
+  @proc_type_info_items [
+    :label,
+    {:dictionary, @initial_call_key},
+    {:dictionary, @ancestors_key},
+    :initial_call,
+    :registered_name
+  ]
+  @expanded_info_items @proc_type_info_items ++ [:memory, :binary]
 
   # Minimum memory threshold for a process group when using :mem_percent mode.
   @min_group_memory 1024 * 1024
@@ -23,7 +33,7 @@ defmodule ElectricTelemetry.Processes do
   Derive a stable, low-cardinality `process_type` for a pid.
   """
   @spec proc_type(pid()) :: atom() | binary()
-  def proc_type(pid), do: proc_type(pid, info(pid))
+  def proc_type(pid), do: proc_type(pid, info(pid, false))
 
   def top_memory_by_type, do: top_by(:proc_mem)
   def top_memory_by_type(proc_list_or_limit), do: top_by(:proc_mem, proc_list_or_limit)
@@ -140,9 +150,8 @@ defmodule ElectricTelemetry.Processes do
     |> Map.put(:type, type)
   end
 
-  @doc false
-  def info(pid) do
-    Process.info(pid, [:dictionary, :initial_call, :label, :memory, :binary, :registered_name])
+  defp info(pid, expanded? \\ true) do
+    Process.info(pid, if(expanded?, do: @expanded_info_items, else: @proc_type_info_items))
   end
 
   defp proc_type(pid, info) do
@@ -177,7 +186,7 @@ defmodule ElectricTelemetry.Processes do
   end
 
   defp ancestor_name(info) do
-    case get_in(info, [:dictionary, :"$ancestors"]) do
+    case dictionary_value(info, @ancestors_key) do
       [name | _] when is_atom(name) and not is_nil(name) -> name
       _ -> nil
     end
@@ -187,7 +196,7 @@ defmodule ElectricTelemetry.Processes do
     # Prefer the dictionary-stored $initial_call (set by proc_lib for OTP processes),
     # falling back to the raw initial_call reported by the VM. Returns "Module.fun/arity".
     mfa =
-      case get_in(info, [:dictionary, :"$initial_call"]) do
+      case dictionary_value(info, @initial_call_key) do
         {m, f, a} -> {m, f, a}
         _ -> info[:initial_call]
       end
@@ -213,7 +222,7 @@ defmodule ElectricTelemetry.Processes do
   end
 
   defp initial_module_from_info(info) do
-    case get_in(info, [:dictionary, :"$initial_call"]) do
+    case initial_call_from_dictionary(info) do
       {module, _function, _arg_count} ->
         module
 
@@ -222,6 +231,22 @@ defmodule ElectricTelemetry.Processes do
           {module, _function, _arg_count} -> module
           nil -> nil
         end
+    end
+  end
+
+  defp initial_call_from_dictionary(info) do
+    dictionary_value(info, @initial_call_key)
+  end
+
+  defp dictionary_value(nil, _key), do: nil
+
+  defp dictionary_value(info, key) do
+    case List.keyfind(info, {:dictionary, key}, 0) do
+      {{:dictionary, ^key}, value} ->
+        value
+
+      nil ->
+        get_in(info, [:dictionary, key])
     end
   end
 

--- a/packages/electric-telemetry/lib/electric/telemetry/system_monitor.ex
+++ b/packages/electric-telemetry/lib/electric/telemetry/system_monitor.ex
@@ -19,6 +19,8 @@ defmodule ElectricTelemetry.SystemMonitor do
   @vm_monitor_long_gc [:vm, :monitor, :long_gc]
   @vm_monitor_long_schedule [:vm, :monitor, :long_schedule]
   @vm_monitor_long_message_queue [:vm, :monitor, :long_message_queue]
+  @garbage_collect_interval :timer.hours(1)
+  @garbage_collect_message :periodic_garbage_collect
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts.intervals_and_thresholds, name: __MODULE__)
@@ -32,7 +34,13 @@ defmodule ElectricTelemetry.SystemMonitor do
         {opts.long_message_queue_disable_threshold, opts.long_message_queue_enable_threshold}
     )
 
-    {:ok, %{long_message_queue_pids: MapSet.new(), long_message_queue_timer: nil}}
+    state = %{
+      long_message_queue_pids: MapSet.new(),
+      long_message_queue_timer: nil,
+      garbage_collect_timer: nil
+    }
+
+    {:ok, schedule_garbage_collect(state)}
   end
 
   def handle_info({:monitor, gc_pid, :long_gc, info}, state) do
@@ -128,6 +136,12 @@ defmodule ElectricTelemetry.SystemMonitor do
     end
   end
 
+  def handle_info(@garbage_collect_message, state) do
+    :erlang.garbage_collect()
+
+    {:noreply, %{state | garbage_collect_timer: nil} |> schedule_garbage_collect()}
+  end
+
   defp log_long_message_queue_event(pid, type) do
     with {:message_queue_len, queue_len} <- Process.info(pid, :message_queue_len) do
       :telemetry.execute(@vm_monitor_long_message_queue, %{length: queue_len}, %{
@@ -148,4 +162,14 @@ defmodule ElectricTelemetry.SystemMonitor do
   end
 
   defp maybe_start_long_message_queue_timer(state), do: state
+
+  defp schedule_garbage_collect(%{garbage_collect_timer: nil} = state) do
+    %{
+      state
+      | garbage_collect_timer:
+          Process.send_after(self(), @garbage_collect_message, @garbage_collect_interval)
+    }
+  end
+
+  defp schedule_garbage_collect(state), do: state
 end

--- a/packages/electric-telemetry/test/electric/telemetry/system_monitor_test.exs
+++ b/packages/electric-telemetry/test/electric/telemetry/system_monitor_test.exs
@@ -1,0 +1,30 @@
+defmodule ElectricTelemetry.SystemMonitorTest do
+  use ExUnit.Case, async: false
+
+  @opts %{
+    intervals_and_thresholds: %{
+      long_gc_threshold: 50,
+      long_schedule_threshold: 150,
+      long_message_queue_enable_threshold: 20,
+      long_message_queue_disable_threshold: 0
+    }
+  }
+
+  setup do
+    on_exit(fn -> :erlang.system_monitor(:undefined) end)
+  end
+
+  test "schedules periodic self garbage collection" do
+    {:ok, pid} = start_supervised({ElectricTelemetry.SystemMonitor, @opts})
+
+    %{garbage_collect_timer: first_timer} = :sys.get_state(pid)
+    assert is_reference(first_timer)
+
+    send(pid, :periodic_garbage_collect)
+    Process.sleep(50)
+
+    %{garbage_collect_timer: next_timer} = :sys.get_state(pid)
+    assert is_reference(next_timer)
+    assert next_timer != first_timer
+  end
+end


### PR DESCRIPTION
## Summary

This reduces avoidable heap growth in `ElectricTelemetry.SystemMonitor` when the VM monitor emits long GC, long schedule, or long message queue events.

- Classify monitor-event processes with a lightweight `Process.info/2` call that only requests the label, initial call, and the single `$initial_call` process dictionary entry.
- Keep memory aggregation behavior intact while avoiding full process dictionary copies there as well.
- Add an hourly self-GC timer to `SystemMonitor` so large transient terms copied while handling monitor events do not remain resident indefinitely.
- Add a patch changeset for `@core/electric-telemetry`.

## Motivation

In production, `ElectricTelemetry.SystemMonitor` could report more than 1GB of process memory while its GenServer state and message queue were tiny. Forcing `:erlang.garbage_collect(pid)` dropped the process memory back to a few KB, showing the memory was transient garbage retained on the process heap rather than live state.

The expensive path was process classification for monitor events. `proc_type/1` requested full process dictionary, memory, and binary metadata from arbitrary target processes even though monitor-event tagging only needs the process label and initial-call fallback. On nodes with many large request processes, those copied terms can inflate the SystemMonitor heap until a full collection happens.

## Decisions

The public `proc_type/1` path now uses the narrow metadata request. The top memory/bin-memory poller path still asks for memory and binary metadata because those metrics need it, but it now requests only the `$initial_call` dictionary entry instead of the full dictionary.

The SystemMonitor GC is periodic rather than per-event to avoid adding garbage-collection work to every monitor notification while still bounding retained transient heap growth.