### PR TITLE
perf(wal): fix the high-stream-cardinality write cliff (1M streams → 1.11M ops/s @ 16 vCPU)

### DIFF
--- a/.changeset/wal-1m-cardinality.md
+++ b/.changeset/wal-1m-cardinality.md
@@ -1,0 +1,9 @@
+---
+"@electric-ax/durable-streams-server-rust": patch
+---
+
+perf: fix the high-stream-cardinality (200k–1M streams) write cliff — O(1) WAL
+checkpoint drain, checkpoint fully off the async runtime with concurrent shards
+and a resident tails map, meta sidecar flush moved from per-append to the
+checkpoint, single registry lookup per append. 1M streams now sustains 1.11M
+ops/s on 16 vCPU (was 862k, with 405 ms worst-case latency now 150 ms).

--- a/packages/durable-streams-rust/CARDINALITY_1M.md
+++ b/packages/durable-streams-rust/CARDINALITY_1M.md
@@ -1,0 +1,54 @@
+# 1M-stream cardinality fixes — findings + results (2026-07-02)
+
+Follow-up to `WRITE_BOTTLENECKS_1M.md` (bottleneck #2: stream cardinality) and
+`CONTENTION_INVESTIGATION.md`. Server commit: `662b0c845` on
+`perf/combined-t1a-t1c-t2a`. **Outcome: 1M streams reaches 1,114,644 ops/s on a
+16 vCPU `c4d-standard-16-lssd` (ladder unsaturated), and the 500k→1M degradation at
+equal load is −17% (was a cliff).**
+
+## Root causes (evidence-first, local Linux repro at 20k→400k streams)
+
+The key mechanism: **at high cardinality, ops/stream/checkpoint-interval drops below
+1, so every "amortized once-per-stream-per-interval" cost becomes a per-op cost.**
+
+| #   | cost                                                                                                                                                                                                                                  | evidence                                                                                                           | fix                                                                                                                                                                                                                                                  |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Checkpoint drain did O(touched) capture (`shared.read()` + Arc clone per stream) **while holding the shard `dirty` mutex** — the same mutex every append's epoch-transition takes; at 400k streams every append is a transition       | `WAL_CKPT drain_us` 25–140 ms/tick; `dirty_wait_load` 0.01→0.30 cores as streams 20k→400k; p99 ≈ max drain         | O(1) critical section: take Vec + bump epoch under the lock, capture after release                                                                                                                                                                   |
+| 2   | Checkpoint capture / cumulative tails-file re-read+re-sort+rewrite / recycle ran **on async runtime threads**, serially across shards                                                                                                 | `WAL_CKPT` capture 31 ms + tails 24 ms per tick per shard on runtime threads                                       | whole checkpoint body in one `spawn_blocking`; tails map memory-resident; shards checkpoint concurrently (`JoinSet`)                                                                                                                                 |
+| 3   | **Per-append meta sidecar flush**: with inter-append gap > the 100 ms debounce (always, at high cardinality) every producer append did JSON + `File::create(.meta.tmp)` + `rename` → all workers spin on the **data-dir inode rwsem** | perf: `osq_lock`+`rwsem_spin_on_owner` under `write_meta_sync` = **38–46% of ALL server CPU at every cardinality** | WAL-staged appends only mark `meta_dirty`; checkpoint writes sidecars for drained streams after recycle (memory-mode keeps the debounced flush). Producer/access staleness bound: 100 ms debounce → checkpoint cadence (contract already allows lag) |
+| 4   | Two registry lookups per append (`handle_append` metric label + `_inner`) — 2× SipHash + cold DashMap walk at 1M keys                                                                                                                 | code inspection                                                                                                    | `_inner` returns `is_json`                                                                                                                                                                                                                           |
+
+## Local A/B (contention-repro-linux.sh, 6 srv cores, conn=256, shards=6)
+
+| streams | before        | after      | p99          |
+| ------- | ------------- | ---------- | ------------ |
+| 20k     | ~43–46k ops/s | **80.4k**  | 41 → 7.7 ms  |
+| 200k    | 32.3k         | **50.6k**  | 53 → 17.9 ms |
+| 400k    | 16.0k         | **36–44k** | 144 → ~28 ms |
+
+Correctness: 95 crate tests + 326 conformance tests pass. New telemetry: `WAL_CKPT`
+per-shard checkpoint phase line (`--wal-stats`), and the repro script grew
+`--tmpfs` / `--wal-stats` knobs + WAL_CKPT summarizing.
+
+## Remote validation (GKE, 16 vCPU, pool client, 256 B, batch 1)
+
+Suite `ds-bench/suites/run-durable-cpu16-1m-card.json`, image
+`durable-streams:combined-card@sha256:d74840bd…`; full detail + caveats in
+`ds-bench/results/run-durable-cpu16-1m-card/FINDINGS.md`.
+
+| streams | pods | ops/s         | p50 / p99 / max                                              |
+| ------- | ---- | ------------- | ------------------------------------------------------------ |
+| 1M      | 32   | 898,582       | 3.5 / 30.5 / **149.6 ms** (baseline 862k, 3.3 / 32 / 405 ms) |
+| 1M      | 64   | **1,114,644** | 3.4 / 60.3 / 211 ms — still climbing (+21%/+16 pods)         |
+| 500k    | 48   | 1,110,268     | 3.1 / 42.7 / 145 ms                                          |
+
+## Open follow-ups
+
+1. True 16 vCPU ceiling at 1M (ladder past 64 pods) and a 32 vCPU 1M run.
+2. **Per-shard producer-state journal**: sidecar writes/s ≈ ops/s at full cardinality
+   (off the hot path now, but it stretches checkpoint cadence — locally ~1.6 s/shard
+   meta phase at 400k — and bounds producer-state staleness). One cumulative
+   per-shard file per tick, recovery overlays producers by max(epoch, seq).
+3. Read+write mix at 1M streams (everything here is write-only).
+4. `--wal-stats` cell on NVMe (`run-durable-cpu16-1m-card-stats.json`, never ran) to
+   confirm checkpoint fsync/meta phase behavior at 1M on real disks.

--- a/packages/durable-streams-rust/scripts/contention-repro-linux.sh
+++ b/packages/durable-streams-rust/scripts/contention-repro-linux.sh
@@ -16,6 +16,7 @@
 #   scripts/contention-repro-linux.sh [--shards N] [--connections C]
 #       [--streams S] [--duration D] [--warmup W] [--payload P] [--batch B]
 #       [--srv-cpus 0-5] [--cli-cpus 6-9] [--label NAME] [--no-build]
+#       [--tmpfs SIZE] [--wal-stats 0|1]
 set -euo pipefail
 
 SHARDS=1
@@ -29,6 +30,8 @@ SRV_CPUS="0-5"
 CLI_CPUS="6-9"
 LABEL=""
 DO_BUILD=1
+TMPFS_SIZE=2g   # at high stream cardinality each non-empty file pins >=1 page: size ~ streams*4k + data
+WAL_STATS=1
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CRATE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -56,6 +59,8 @@ while [ $# -gt 0 ]; do
     --cli-cpus) CLI_CPUS="$2"; shift 2;;
     --label) LABEL="$2"; shift 2;;
     --no-build) DO_BUILD=0; shift;;
+    --tmpfs) TMPFS_SIZE="$2"; shift 2;;
+    --wal-stats) WAL_STATS="$2"; shift 2;;
     *) echo "unknown arg: $1" >&2; exit 2;;
   esac
 done
@@ -92,11 +97,11 @@ docker rm -f "$SRV" >/dev/null 2>&1 || true
 docker run -d --name "$SRV" --network "$NET" \
   --cpuset-cpus="$SRV_CPUS" \
   -v "$TARGET_VOL":/target:ro \
-  --tmpfs /data:rw,size=2g \
+  --tmpfs /data:rw,size="$TMPFS_SIZE" \
   debian:bookworm-slim \
   /target/release/durable-streams-server \
     --host 0.0.0.0 --port 4437 --data-dir /data \
-    --durability wal --wal-shards "$SHARDS" --wal-stats 1 >/dev/null
+    --durability wal --wal-shards "$SHARDS" --wal-stats "$WAL_STATS" >/dev/null
 
 for _ in $(seq 1 100); do
   docker logs "$SRV" 2>&1 | grep -q "listening on" && break
@@ -144,4 +149,11 @@ print(f"  fsync_per_s        = {avg('fsync/s'):,.0f}   batch_avg = {avg('batch_a
 print(f"  inner_wait_us      = {avg('inner_wait_us'):.2f}   inner_wait_load = {avg('inner_wait_load'):.2f} cores")
 print(f"  dirty_wait_us      = {avg('dirty_wait_us'):.2f}   dirty_wait_load = {avg('dirty_wait_load'):.2f} cores")
 print(f"  waiters_woken_avg  = {avg('waiters_woken_avg'):.1f}")
+ck=[{k:float(v) for k,v in pat.findall(l)} for l in open(srv_log,errors="ignore") if "WAL_CKPT" in l]
+if ck:
+    n=len(ck)
+    m=lambda k:max(r.get(k,0.0) for r in ck)
+    a=lambda k:sum(r.get(k,0.0) for r in ck)/n
+    print(f"  ckpt (n={n}) touched avg/max      = {a('touched'):,.0f} / {m('touched'):,.0f}   tails_entries max = {m('tails_entries'):,.0f}   meta avg = {a('meta'):,.0f}")
+    print(f"  ckpt us avg/max: capture={a('capture_us'):,.0f}/{m('capture_us'):,.0f} fsync={a('fsync_us'):,.0f}/{m('fsync_us'):,.0f} tails={a('tails_us'):,.0f}/{m('tails_us'):,.0f} rest={a('rest_us'):,.0f}/{m('rest_us'):,.0f} meta={a('meta_us'):,.0f}/{m('meta_us'):,.0f} total={a('total_us'):,.0f}/{m('total_us'):,.0f}")
 PY

--- a/packages/durable-streams-rust/src/handlers.rs
+++ b/packages/durable-streams-rust/src/handlers.rs
@@ -886,25 +886,26 @@ impl AppendOutcome {
 
 async fn handle_append(store: Arc<Store>, req: Req, path: String) -> Resp {
     let t0 = crate::telemetry::Timer::start();
-    // is_json is needed for the metric label even on the not-found path, where we
-    // don't have a stream; default to false there.
-    let is_json = store.get(&path).map(|s| s.is_json).unwrap_or(false);
-    let (resp, outcome) = handle_append_inner(store, req, path).await;
+    // is_json comes back from the inner handler (false on the not-found path) so
+    // the metric label doesn't cost a SECOND registry lookup per append — at high
+    // stream cardinality each lookup is a cold walk of a million-key map.
+    let (resp, outcome, is_json) = handle_append_inner(store, req, path).await;
     crate::telemetry::record_append(t0.elapsed_secs(), outcome.label(), is_json);
     resp
 }
 
-async fn handle_append_inner(store: Arc<Store>, req: Req, path: String) -> (Resp, AppendOutcome) {
+async fn handle_append_inner(store: Arc<Store>, req: Req, path: String) -> (Resp, AppendOutcome, bool) {
     use AppendOutcome::*;
-    macro_rules! ret {
-        ($resp:expr, $oc:expr) => {
-            return ($resp, $oc)
-        };
-    }
     let st = match store.get(&path) {
         Some(s) => s,
-        None => ret!(text_response(404, "stream not found"), Conflict),
+        None => return (text_response(404, "stream not found"), Conflict, false),
     };
+    let is_json = st.is_json;
+    macro_rules! ret {
+        ($resp:expr, $oc:expr) => {
+            return ($resp, $oc, is_json)
+        };
+    }
     if st.shared.read().unwrap().soft_deleted {
         ret!(gone(), Conflict);
     }
@@ -1156,7 +1157,18 @@ async fn handle_append_inner(store: Arc<Store>, req: Req, path: String) -> (Resp
         st.tail_tx.send_replace(Tail { bytes: tail, closed: true });
         #[cfg(target_os = "linux")]
         crate::sse_reactor::wake_stream(&st);
+    } else if staged_lsn.is_some() {
+        // WAL mode: the stream is in its shard's dirty set (register_dirty ran
+        // during staging), so the ~3 s checkpoint will write the sidecar for us —
+        // just mark it. This keeps the meta `File::create`+`rename` (and its
+        // parent-directory rwsem, measured at ~40% of server CPU under write
+        // saturation) plus a timer task OFF the per-append path. Producer/access
+        // updates are already documented as a non-durable, lagging flush; the lag
+        // bound moves from the 100 ms debounce to the checkpoint cadence.
+        st.meta_dirty.store(true, std::sync::atomic::Ordering::Release);
     } else {
+        // No WAL record staged (memory durability): no checkpoint will flush the
+        // sidecar — keep the debounced flush.
         st.schedule_meta_flush();
     }
     if !wire.is_empty() {
@@ -1178,7 +1190,7 @@ async fn handle_append_inner(store: Arc<Store>, req: Req, path: String) -> (Resp
     if tail.closed {
         b = b.hs(H_CLOSED, "true");
     }
-    (b.body(empty()), Accept)
+    (b.body(empty()), Accept, is_json)
 }
 
 fn closed_conflict(tail: u64) -> Resp {

--- a/packages/durable-streams-rust/src/main.rs
+++ b/packages/durable-streams-rust/src/main.rs
@@ -433,11 +433,22 @@ fn spawn_checkpoint_ticker(walset: Arc<wal::walset::WalSet>) {
         ticker.tick().await;
         loop {
             ticker.tick().await;
+            // All shards checkpoint CONCURRENTLY. Each checkpoint is one
+            // spawn_blocking task (capture + per-stream fdatasyncs + tails/ckpt
+            // persist + recycle), so a serial walk makes every per-stream fsync
+            // across the whole server queue behind a single shard's — at high
+            // stream cardinality that serialization is what stretches the
+            // checkpoint wave (and on real disks wastes the device's parallelism).
+            let mut wave = tokio::task::JoinSet::new();
             for shard in walset.shards() {
-                if let Err(e) = shard.checkpoint().await {
-                    eprintln!("WAL checkpoint failed for shard {:?}: {e}", shard.dir());
-                }
+                let shard = Arc::clone(shard);
+                wave.spawn(async move {
+                    if let Err(e) = shard.checkpoint().await {
+                        eprintln!("WAL checkpoint failed for shard {:?}: {e}", shard.dir());
+                    }
+                });
             }
+            while wave.join_next().await.is_some() {}
         }
     });
 }

--- a/packages/durable-streams-rust/src/wal/shard.rs
+++ b/packages/durable-streams-rust/src/wal/shard.rs
@@ -345,6 +345,13 @@ pub struct Shard {
     /// racing the drain sees a stale stream epoch and re-registers into the next
     /// interval's collection — no touched stream is ever dropped.
     dirty_epoch: AtomicU64,
+    /// Resident copy of the CUMULATIVE per-stream durable-tail map persisted at
+    /// `<shard_dir>/tails` (task 11b). `None` until the first checkpoint needs it
+    /// (then seeded from disk once); afterwards `persist_durable_tails` merges and
+    /// serializes from memory instead of re-reading + re-parsing the whole file
+    /// every ~3 s (O(total streams per shard) — ~20 ms/tick at 400k streams).
+    /// Only the (serialized, per-shard) checkpoint path locks it.
+    tails_cache: Mutex<Option<HashMap<u64, u64>>>,
     /// Per-shard batch-size + durability counters (spec §11). Updated once per
     /// successful committer `fdatasync` (`record_batch`) — cheap relaxed atomics,
     /// no lock/alloc/syscall on the commit path. Read off-path by the 1 Hz
@@ -441,6 +448,7 @@ impl Shard {
             // Epoch starts at 1; StreamStates start at dirty_epoch 0, so the first
             // append on every stream registers it (0 != 1).
             dirty_epoch: AtomicU64::new(1),
+            tails_cache: Mutex::new(None),
             stats: ShardStats::default(),
             #[cfg(test)]
             on_stage: Mutex::new(None),
@@ -724,7 +732,7 @@ impl Shard {
     /// re-registering a stream is never lost (it lands in the *next* checkpoint).
     ///
     /// Returns the `checkpoint_lsn` persisted.
-    pub async fn checkpoint(&self) -> io::Result<u64> {
+    pub async fn checkpoint(self: &Arc<Self>) -> io::Result<u64> {
         // 1. Snapshot the recycle floor = the highest durably-acked lsn.
         let checkpoint_lsn = self.durable_lsn.load(Ordering::Acquire);
 
@@ -747,58 +755,115 @@ impl Shard {
         //    observes the bumped epoch necessarily pushes AFTER we release this
         //    lock, landing in the fresh post-take Vec for the next checkpoint. So no
         //    touched stream is ever both drained here AND silently skipped next time.
-        let touched: Vec<(u64, u64, Arc<std::fs::File>)> = {
+        //    The critical section is O(1) — take the Vec and bump the epoch, nothing
+        //    else. The per-stream tail/file capture below runs AFTER the lock is
+        //    released: at high stream cardinality nearly every append is its
+        //    stream's first touch of the interval (the transition path), so any
+        //    O(touched) work under this lock stalls every appender on the shard
+        //    for the whole drain (measured 25–140 ms per tick at 400k streams).
+        let drained: Vec<Arc<StreamState>> = {
             let mut g = self.dirty.lock().unwrap();
             self.dirty_epoch.fetch_add(1, Ordering::AcqRel);
             std::mem::take(&mut *g)
-                .into_iter()
+        };
+
+        // Everything below is file IO + O(touched)/O(total-streams) CPU — run it
+        // in ONE blocking task so none of it ever stalls an async worker thread
+        // (at 400k streams the capture+fsync+tails phases are tens of ms per tick
+        // each; on a real disk the fsync fan-out can be far worse). Ordering
+        // inside the closure is exactly the required hard ordering: capture tails
+        // → fdatasync per-stream files → persist tails map → persist
+        // checkpoint_lsn → recycle. Acks never gate on any of this.
+        let this = Arc::clone(self);
+        tokio::task::spawn_blocking(move || -> io::Result<u64> {
+            // Phase timing for the `WAL_CKPT` line (`--wal-stats`). One clock
+            // read per phase, once per ~3 s per shard — nowhere near the hot path.
+            let t_start = std::time::Instant::now();
+            // Capture each touched stream's current logical tail and live file.
+            // The tail is read BEFORE the fsync; the fdatasync flushes every page
+            // already in the file's cache, so the file is durable up to AT LEAST
+            // this tail afterwards (a later concurrent append only extends past
+            // it and lands in the next checkpoint). Conservative-safe.
+            let touched: Vec<(u64, u64, Arc<std::fs::File>)> = drained
+                .iter()
                 .map(|st| {
                     let s = st.shared.read().unwrap();
                     (st.id, s.tail, Arc::clone(&s.file))
                 })
-                .collect()
-        };
-        // Run the (potentially blocking) fdatasyncs off the async runtime so a
-        // slow disk can't stall this task's executor thread. Ordering preserved:
-        // we await all per-stream fsyncs before touching the WAL. We move only the
-        // files into the blocking task; the (stream_id, durable_tail) pairs stay
-        // here to merge into the persisted tail map after the fsyncs succeed.
-        let tails: Vec<(u64, u64)> = touched.iter().map(|(id, tail, _)| (*id, *tail)).collect();
-        let to_sync: Vec<Arc<std::fs::File>> =
-            touched.into_iter().map(|(_, _, f)| f).collect();
-        tokio::task::spawn_blocking(move || -> io::Result<()> {
-            for f in &to_sync {
+                .collect();
+            let n_touched = touched.len();
+            let t_capture = t_start.elapsed();
+
+            // 2. fdatasync each touched per-stream file.
+            for (_, _, f) in &touched {
                 crate::store::barrier_fsync(f)?;
             }
-            Ok(())
+            let t_fsync = t_start.elapsed();
+
+            // 3a. Persist the CUMULATIVE per-stream durable-tail map (task 11b)
+            //     AFTER the per-stream files are fsync'd, and BEFORE recycle —
+            //     same hard ordering as `checkpoint_lsn`. Merge this checkpoint's
+            //     touched tails into the resident map so a stream touched in an
+            //     earlier checkpoint (but not this one) keeps its last durable
+            //     tail. `tmp` + rename + fsync makes the map itself crash-durable,
+            //     so when recycle deletes the WAL records below the floor,
+            //     recovery can still truncate a recycled stream's torn
+            //     per-stream-file tail to its durable tail.
+            let tails: Vec<(u64, u64)> =
+                touched.iter().map(|(id, tail, _)| (*id, *tail)).collect();
+            let n_tails = this.persist_durable_tails(&tails)?;
+            let t_tails = t_start.elapsed();
+
+            // 3b. Persist checkpoint_lsn (durably) AFTER the per-stream files are
+            //     fsync'd, so the recorded floor only ever covers bytes already on
+            //     disk in their own files.
+            let ckpt_path = this.dir.join(CHECKPOINT_FILE);
+            let tmp = this.dir.join(format!("{CHECKPOINT_FILE}.tmp"));
+            std::fs::write(&tmp, checkpoint_lsn.to_string())?;
+            std::fs::rename(&tmp, &ckpt_path)?;
+
+            // 4. Recycle: unlink WAL segments fully below checkpoint_lsn. This is
+            //    the LAST step — strictly after the per-stream fsyncs AND the
+            //    durable-tail map persist above.
+            this.recycle_below(checkpoint_lsn)?;
+            let t_rest = t_start.elapsed();
+
+            // 5. Flush the meta sidecar of every touched stream whose append
+            //    path marked it dirty (WAL mode defers the per-append debounced
+            //    flush to here — see handle_append_inner). Strictly AFTER the
+            //    WAL-critical sequence above: sidecar producer/access state is
+            //    non-durable by contract and plays no part in WAL replay, so it
+            //    must never delay the recycle floor. Errors are ignored exactly
+            //    like the debounced flush ignored them.
+            let mut n_meta = 0u64;
+            for st in &drained {
+                if st.meta_dirty.swap(false, Ordering::AcqRel) {
+                    let _ = crate::store::write_meta_sync(st, false);
+                    n_meta += 1;
+                }
+            }
+
+            if super::telemetry::stats_enabled() {
+                let t_total = t_start.elapsed();
+                eprintln!(
+                    "WAL_CKPT shard={} touched={} tails_entries={} meta={} capture_us={} fsync_us={} tails_us={} rest_us={} meta_us={} total_us={}",
+                    this.dir.file_name().and_then(|s| s.to_str()).unwrap_or("?"),
+                    n_touched,
+                    n_tails,
+                    n_meta,
+                    t_capture.as_micros(),
+                    (t_fsync - t_capture).as_micros(),
+                    (t_tails - t_fsync).as_micros(),
+                    (t_rest - t_tails).as_micros(),
+                    (t_total - t_rest).as_micros(),
+                    t_total.as_micros(),
+                );
+            }
+
+            Ok(checkpoint_lsn)
         })
         .await
-        .expect("checkpoint fdatasync task panicked")?;
-
-        // 3a. Persist the CUMULATIVE per-stream durable-tail map (task 11b) AFTER
-        //     the per-stream files are fsync'd, and BEFORE recycle — same hard
-        //     ordering as `checkpoint_lsn`. Merge this checkpoint's touched tails
-        //     into the previously-persisted map so a stream touched in an earlier
-        //     checkpoint (but not this one) keeps its last durable tail. `tmp` +
-        //     rename + fsync makes the map itself crash-durable, so when recycle
-        //     deletes the WAL records below the floor, recovery can still truncate
-        //     a recycled stream's torn per-stream-file tail to its durable tail.
-        self.persist_durable_tails(&tails)?;
-
-        // 3b. Persist checkpoint_lsn (durably) AFTER the per-stream files are
-        //     fsync'd, so the recorded floor only ever covers bytes already on
-        //     disk in their own files.
-        let ckpt_path = self.dir.join(CHECKPOINT_FILE);
-        let tmp = self.dir.join(format!("{CHECKPOINT_FILE}.tmp"));
-        std::fs::write(&tmp, checkpoint_lsn.to_string())?;
-        std::fs::rename(&tmp, &ckpt_path)?;
-
-        // 4. Recycle: unlink WAL segments fully below checkpoint_lsn. This is the
-        //    LAST step — strictly after the per-stream fsyncs AND the durable-tail
-        //    map persist above.
-        self.recycle_below(checkpoint_lsn)?;
-
-        Ok(checkpoint_lsn)
+        .expect("checkpoint task panicked")
     }
 
     /// Merge `touched` `(stream_id, durable_tail)` pairs into the persisted
@@ -808,28 +873,40 @@ impl Shard {
     /// the WAL is recycled, so a torn per-stream-file tail can always be truncated
     /// to its durable tail even after its WAL records are gone (task 11b).
     ///
-    /// Cumulative-merge: read the existing map, overwrite each touched stream's
-    /// entry with its newest durable tail (`max`, so a re-checkpointed earlier tail
-    /// can never regress the recorded value), keep every untouched stream's last
-    /// recorded tail.
-    fn persist_durable_tails(&self, touched: &[(u64, u64)]) -> io::Result<()> {
+    /// Cumulative-merge: merge into the RESIDENT map (`tails_cache`, seeded from
+    /// disk once on first use), overwrite each touched stream's entry with its
+    /// newest durable tail (`max`, so a re-checkpointed earlier tail can never
+    /// regress the recorded value), keep every untouched stream's last recorded
+    /// tail. Serializing from memory avoids re-reading + re-parsing the whole
+    /// file every checkpoint (O(total streams per shard) each ~3 s).
+    /// Returns the number of entries in the persisted map (for `WAL_CKPT`).
+    fn persist_durable_tails(&self, touched: &[(u64, u64)]) -> io::Result<usize> {
         if touched.is_empty() && !self.dir.join(TAILS_FILE).exists() {
             // Nothing touched and no prior map: nothing to persist.
-            return Ok(());
+            return Ok(0);
         }
-        let mut map = Self::read_durable_tails_at(&self.dir);
+        let mut cache = self.tails_cache.lock().unwrap();
+        let map = cache.get_or_insert_with(|| Self::read_durable_tails_at(&self.dir));
         for &(id, tail) in touched {
             let slot = map.entry(id).or_insert(0);
             *slot = (*slot).max(tail);
         }
         // Serialize as `stream_id durable_tail` lines (sorted for a deterministic,
         // diff-friendly file). Plain decimal text, matching the `checkpoint` file.
-        let mut entries: Vec<(u64, u64)> = map.into_iter().collect();
+        let mut entries: Vec<(u64, u64)> = map.iter().map(|(&k, &v)| (k, v)).collect();
         entries.sort_unstable();
+        let n = entries.len();
         let mut body = String::with_capacity(entries.len() * 16);
-        for (id, tail) in entries {
-            body.push_str(&format!("{id} {tail}\n"));
+        {
+            use std::fmt::Write as _;
+            for (id, tail) in entries {
+                let _ = writeln!(body, "{id} {tail}");
+            }
         }
+        // The resident map is fully merged and serialized; release it before the
+        // file IO below (nothing else contends today, but don't hold a lock over
+        // a write+fsync+rename gratuitously).
+        drop(cache);
         let path = self.dir.join(TAILS_FILE);
         let tmp = self.dir.join(format!("{TAILS_FILE}.tmp"));
         std::fs::write(&tmp, &body)?;
@@ -837,7 +914,7 @@ impl Shard {
         // crash-durable BEFORE recycle (the whole point of 11b).
         std::fs::File::open(&tmp)?.sync_all()?;
         std::fs::rename(&tmp, &path)?;
-        Ok(())
+        Ok(n)
     }
 
     /// Read the persisted per-shard durable-tail map from `<dir>/tails`. Returns


### PR DESCRIPTION
> Stacked on #4675 (`perf/combined-t1a-t1c-t2a`) — this diff contains only the cardinality work.

## Summary

At high stream cardinality (200k–1M streams) write throughput fell off a cliff even after #4675's coordination fixes — at a fixed local load, going 20k→400k streams cost **−65% throughput** while server CPU *dropped*. This PR removes the four costs behind that cliff. Local repro at 400k streams: **16.0k → ~44k ops/s, p99 144 → 27 ms**; on GKE at 16 vCPU, 1M streams goes **862k → 1,114,644 ops/s** (ladder still unsaturated at 64 pods) and worst-case latency at the baseline rung drops **405 ms → 150 ms**. The 500k→1M degradation at equal load is now **−17%** (was a cliff).

## Root cause — why cardinality broke the amortization

The write path amortizes several costs to "once per stream per ~3 s checkpoint interval". **At high cardinality, ops/stream/interval < 1, so every such cost silently becomes a per-op cost** — and some of them ran under locks the hot path needs. Concretely (each confirmed with `WAL_CKPT` phase telemetry added here, plus `perf`):

1. **Checkpoint drain held the shard `dirty` mutex during O(touched) work** (`shard.rs`). The drain captured each touched stream's tail/file (`shared.read()` + Arc clone, ~8–20k streams/shard/tick) *inside* the mutex — 25–140 ms holds. Meanwhile the Tier-1a "lock-free" fast path is dead at high cardinality: nearly every append is its stream's first touch of the epoch, so **every append takes the transition path through that same mutex**. Measured: `dirty_wait_load` 0.01 → 0.30 cores as streams went 20k → 400k; client p99 (144 ms) ≈ max drain hold (140 ms).
2. **Checkpoint phases ran on async runtime threads, serially across shards.** Only the per-stream fsyncs were `spawn_blocking`; the capture, the cumulative tails-file rewrite (re-read + re-parse + re-sort + re-format of *every stream ever touched*, every 3 s), and recycle all stalled runtime workers.
3. **Per-append meta sidecar flush — the biggest, flattest tax.** Every producer append debounce-scheduled `write_meta_sync` (JSON + `File::create(.meta.tmp)` + `rename`). The 100 ms debounce only coalesces when a stream is re-appended within 100 ms — never, at high cardinality — so the server did one create+rename in the shared data directory *per append*, and all workers spun on that directory's inode rwsem. `perf`: **`osq_lock` + `rwsem_spin_on_owner` under `write_meta_sync` = 38–46% of all server CPU, at every cardinality.**
4. **Two registry lookups per append**: `handle_append` did a `store.get(&path)` just for the `is_json` metric label, then `handle_append_inner` did the real one — 2× SipHash + cold DashMap walk per op at 1M keys.

## What unlocked the performance

- **O(1) dirty-drain critical section**: take the Vec + bump the epoch under the lock, nothing else; the O(touched) capture runs after release. The Tier-1a safety argument is preserved — the epoch bump and take still happen in the same critical section `register_dirty`'s push uses, and the recycle invariant was never anchored on capture position (it's protected by snapshotting `checkpoint_lsn` *before* the drain).
- **Whole checkpoint body in one `spawn_blocking`** (capture → per-stream fdatasyncs → tails persist → checkpoint_lsn persist → recycle, same hard ordering), with **shards checkpointing concurrently** (`JoinSet`) instead of serially.
- **Resident tails map**: seeded from disk once, merged + serialized from memory each tick — no more O(total-streams) file re-read/re-parse/re-sort every 3 s.
- **Meta sidecar flush moved to the checkpoint**: WAL-staged appends just set `meta_dirty` (one atomic store — also drops a `tokio::spawn`ed debounce timer per append); the checkpoint writes sidecars for drained streams *after* recycle, off the hot path. Memory-mode appends keep the debounced flush (no checkpoint exists to pick them up).
- **Single registry lookup**: `handle_append_inner` returns `is_json` for the metric label.
- **`WAL_CKPT` telemetry** (`--wal-stats`): per-shard checkpoint line with touched/tails/meta counts and capture/fsync/tails/rest/meta phase timings — this is what attributed the cliff, and it's what a future run reads to decide the next fix.

## Key invariants (unchanged)

- **Recycle safety**: per-stream file fsyncs and the durable-tails persist still strictly precede WAL segment recycling; `checkpoint_lsn` is snapshotted before the drain, so any record durable at snapshot time is in the drained set (its `register_dirty` happened-before the commit that made it durable).
- **Close durability**: stream closes still write the sidecar synchronously + fsynced before readers observe EOF.
- **Producer-state contract**: sidecar producer/access flushes were already documented as non-durable and lagging (producers bump epoch on restart). The lag bound moves from the 100 ms debounce to the checkpoint cadence.

## Non-goals / follow-ups

- **Per-shard producer-state journal**: sidecar writes/s still ≈ ops/s at full cardinality — now off the hot path, but it stretches checkpoint cadence and staleness. The structural fix (one cumulative per-shard file per tick, recovery overlays producers by max(epoch, seq)) touches recovery and is deliberately not in this PR.
- Read-path work, T1b/T3 from the original investigation, and the true 16 vCPU ceiling (ladder was still climbing at 64 pods) are out of scope. Details in `packages/durable-streams-rust/CARDINALITY_1M.md`.

## Verification

- `cargo test --release` — 95 unit/e2e tests pass (incl. WAL recovery + checkpoint ordering tests).
- `pnpm run test:conformance` — 326 conformance tests pass.
- Local A/B: `scripts/contention-repro-linux.sh --shards 6 --connections 256 --streams 400000 --tmpfs 4g` before/after (16.0k → ~44k ops/s; p99 144 → 27 ms; 20k-stream rung also ~2× from the meta-flush fix alone).
- Remote: `ds-bench` suite `run-durable-cpu16-1m-card` (results + provenance + caveats in `ds-bench/results/run-durable-cpu16-1m-card/FINDINGS.md`): 1M streams 899k @ 32 pods (max 150 ms) → **1.115M @ 64 pods, unsaturated**; 500k @ 48 pods 1.110M.

## Files

- `src/wal/shard.rs` — O(1) drain; checkpoint body in one blocking task; resident tails map; checkpoint-time meta flush; `WAL_CKPT` timings.
- `src/main.rs` — concurrent per-shard checkpoint ticker.
- `src/handlers.rs` — mark-`meta_dirty` instead of per-append flush (WAL mode); single registry lookup.
- `scripts/contention-repro-linux.sh` — `--tmpfs`/`--wal-stats` knobs + `WAL_CKPT` summary.
- `CARDINALITY_1M.md` — investigation + results write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzV7avRUMhPqmm1SgU4z1J