### PR TITLE
fix: handle non-English PostgreSQL error messages in create_publication_result

### DIFF
--- a/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/connection_setup.ex
@@ -151,7 +151,7 @@ defmodule Electric.Postgres.ReplicationClient.ConnectionSetup do
     Logger.debug("ReplicationClient step: create_publication_query")
     # We're creating an "empty" publication here because synced tables are added to it
     # elsewhere. See `Electric.Replication.PublicationManager`.
-    query = "CREATE PUBLICATION #{Utils.quote_name(state.publication_name)}"
+    query = "CREATE PUBLICATION IF NOT EXISTS #{Utils.quote_name(state.publication_name)}"
 
     query =
       if state.pg_version >= @pg18_version,


### PR DESCRIPTION
### Problem

When PostgreSQL is configured with a non-English locale (e.g. Russian), error messages
are returned in that locale. The `create_publication_result` function matches the error
message text with a pin operator (`^error_message`) expecting English:

`%{code: :duplicate_object, pg_code: "42710", message: ^error_message} ->`

If PostgreSQL returns the message in another language (e.g. "публикация \"...\" уже существует"),
the pattern does not match and falls through to _ -> raise error, causing Electric to
crash and enter an infinite retry loop.

### Fix
Use CREATE PUBLICATION IF NOT EXISTS instead of CREATE PUBLICATION, so the duplicate
publication error never occurs in the first place, making the message text matching irrelevant.

query = "CREATE PUBLICATION IF NOT EXISTS #{Utils.quote_name(state.publication_name)}"

### Reproduction
Configure PostgreSQL with a non-English locale (lc_messages set to anything other than en_*)
Start Electric when a publication with the same name already exists
Electric enters an infinite crash loop with the localized duplicate publication error

### Notes
This issue was discovered after migrating from PostgreSQL 14 to PostgreSQL 18,
where the existing publication was preserved during migration and Electric failed to start.