### PR TITLE
fix(agents-chat-starter): spawn entities via /_electric/entities

### DIFF
--- a/examples/agents-chat-starter/AGENTS.md
+++ b/examples/agents-chat-starter/AGENTS.md
@@ -76,7 +76,7 @@ Without the top-level `key`, the StreamDB won't materialize the event into the c
 Entities need an `initialMessage` when spawned — the runtime skips the handler if there's no fresh input on first wake:
 
 ```typescript
-await fetch(`${AGENTS_URL}/${type}/${id}`, {
+await fetch(`${AGENTS_URL}/_electric/entities/${type}/${id}`, {
   method: 'PUT',
   body: JSON.stringify({
     args: { chatroomId: roomId },
@@ -84,6 +84,8 @@ await fetch(`${AGENTS_URL}/${type}/${id}`, {
   }),
 })
 ```
+
+Spawn through `/_electric/entities/:type/:id`. A bare `PUT /:type/:id` falls through to the durable-streams proxy: it returns `201` and creates a raw stream, but no entity is registered and the agent never wakes.
 
 ### Preventing Agent Loops
 

--- a/examples/agents-chat-starter/src/server/index.ts
+++ b/examples/agents-chat-starter/src/server/index.ts
@@ -103,7 +103,9 @@ async function spawnAgent(room: Room, type: string): Promise<string> {
   const agentId = `${room.id}-${type}-${room.agents.length + 1}`
   const entityUrl = `/${type}/${agentId}`
 
-  const putRes = await fetch(`${AGENTS_URL}${entityUrl}`, {
+  // Spawn via the entity API — a bare PUT /:type/:id falls through to the
+  // durable-streams proxy, which creates a raw stream instead of an entity
+  const putRes = await fetch(`${AGENTS_URL}/_electric/entities${entityUrl}`, {
     method: `PUT`,
     headers: { 'Content-Type': `application/json` },
     body: JSON.stringify({


### PR DESCRIPTION
Spawning an agent in the chat starter PUTs to `${AGENTS_URL}/${type}/${id}`. Since the routing refactor in #4307, that path falls through to the durable-streams proxy on the agents-server. The proxy creates a raw stream and returns `201`, so the starter's `putRes.ok` check passes, but no entity is created and the agent never wakes. The visible result is that rooms are created and no philosopher ever replies, with no error anywhere. Full analysis in #4687.

This changes the spawn fetch to the entity API at `/_electric/entities/${type}/${id}`, the same path `ctx.spawn` (`runtime-server-client.ts`), the `electric-ax` CLI (`entity-api.ts`), and the conformance DSL use. It also fixes the same snippet in the starter's `AGENTS.md`.

The `entityUrl` stored on the room and shown in the UI stays `/${type}/${id}`. Only the fetch URL changes.

Tested against `@electric-ax/agents-server` 0.6.3 with embedded streams. Before the change, the spawn PUT returns `201` and `/_electric/entities` stays empty. After it, the entity is created, the dispatch webhook is registered, and the first wake runs the handler.

No changeset, since the change only touches the example. #4217 is the precedent.

Fixes #4687
