### PR TITLE
fix(sync-service): bound memory pinned by serves to slow or stalled clients

### DIFF
--- a/.changeset/bound-stalled-serve-memory.md
+++ b/.changeset/bound-stalled-serve-memory.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Bound the memory pinned by a shape response served to a slow or stalled client. Two compounding issues let every stalled connection pin its entire in-flight log chunk (~10 MB by default) for as long as the serve lived: the log file was read eagerly as one whole-range binary whose entries were served as sub-binary slices (pinning the full chunk plus the full entry list), and the JSON encoder batched response elements by item count only, so a batch of large rows grew into a multi-megabyte unit held in full by the request process and the socket's driver queue. Accumulated stalled serves could exhaust node memory (observed in production: ~400 stalled serves pinning ~3.9 GB, immune to GC since the references are live). The log is now read lazily in 64 KiB blocks and encoder batches are additionally capped at 256 KiB, bounding the pinned memory per stalled connection to well under 1 MB regardless of chunk size.

--- a/packages/sync-service/lib/electric/shape_cache/pure_file_storage/log_file.ex
+++ b/packages/sync-service/lib/electric/shape_cache/pure_file_storage/log_file.ex
@@ -179,9 +179,8 @@ defmodule Electric.ShapeCache.PureFileStorage.LogFile do
   # Every emitted json is a sub-binary of the block it was read from, and the
   # response-streaming pipeline can hold an in-flight element (and everything
   # it references) for the whole lifetime of a serve — including one stalled
-  # on a slow client. An eager whole-range read pinned the entire ~10MB chunk
-  # (once as the read binary, again as the full list of entries) per stalled
-  # connection; bounding the read block bounds that to ~the block size.
+  # on a slow client. Bounding the read block bounds the memory each stalled
+  # connection can pin.
   @read_block_bytes 64 * 1024
 
   def stream_jsons(

--- a/packages/sync-service/lib/electric/shape_cache/pure_file_storage/log_file.ex
+++ b/packages/sync-service/lib/electric/shape_cache/pure_file_storage/log_file.ex
@@ -174,6 +174,16 @@ defmodule Electric.ShapeCache.PureFileStorage.LogFile do
     )
   end
 
+  # Read the log range lazily in bounded blocks rather than all at once.
+  #
+  # Every emitted json is a sub-binary of the block it was read from, and the
+  # response-streaming pipeline can hold an in-flight element (and everything
+  # it references) for the whole lifetime of a serve — including one stalled
+  # on a slow client. An eager whole-range read pinned the entire ~10MB chunk
+  # (once as the read binary, again as the full list of entries) per stalled
+  # connection; bounding the read block bounds that to ~the block size.
+  @read_block_bytes 64 * 1024
+
   def stream_jsons(
         %PFS{} = opts,
         log_file_path,
@@ -181,17 +191,36 @@ defmodule Electric.ShapeCache.PureFileStorage.LogFile do
         end_position,
         exclusive_min_offset
       ) do
-    # We can read ahead entire chunk into memory since chunk sizes are expected to be ~10MB by default,
-    case safely_open_file!(opts, log_file_path, [:read, :raw]) do
-      {:halt, :data_removed} ->
-        []
+    Stream.resource(
+      fn ->
+        case safely_open_file!(opts, log_file_path, [:read, :raw]) do
+          {:ok, file} -> {file, start_position, ""}
+          {:halt, :data_removed} -> :halt
+        end
+      end,
+      fn
+        :halt ->
+          {:halt, []}
 
-      {:ok, file} ->
-        try do
-          with {:ok, data} <- :file.pread(file, start_position, end_position - start_position) do
-            {jsons, _} = extract_jsons_from_binary(data, exclusive_min_offset, nil)
-            jsons
+        {file, position, binary_rest} when position >= end_position ->
+          if binary_rest == "" do
+            {:halt, {file, position, binary_rest}}
           else
+            # A partial entry at the end of the range means the file is
+            # shorter than the chunk index says it should be.
+            raise "unexpected end of file"
+          end
+
+        {file, position, binary_rest} ->
+          read_size = min(@read_block_bytes, end_position - position)
+
+          case :file.pread(file, position, read_size) do
+            {:ok, data} ->
+              {jsons, rest} =
+                extract_jsons_from_binary(binary_rest <> data, exclusive_min_offset, nil)
+
+              {jsons, {file, position + byte_size(data), rest}}
+
             :eof ->
               raise "unexpected end of file"
 
@@ -199,12 +228,14 @@ defmodule Electric.ShapeCache.PureFileStorage.LogFile do
               raise File.Error,
                 path: log_file_path,
                 reason: reason,
-                action: "pread(#{start_position}, #{end_position - start_position})"
+                action: "pread(#{position}, #{read_size})"
           end
-        after
-          File.close(file)
-        end
-    end
+      end,
+      fn
+        [] -> :ok
+        {file, _position, _rest} -> File.close(file)
+      end
+    )
   end
 
   def stream_jsons_until_offset(

--- a/packages/sync-service/lib/electric/shapes/api/encoder.ex
+++ b/packages/sync-service/lib/electric/shapes/api/encoder.ex
@@ -67,12 +67,10 @@ defmodule Electric.Shapes.Api.Encoder.JSON do
   @json_item_separator ","
 
   # Batch stream items into iodata units bounded by BOTH item count and byte
-  # size. Batching by count alone let a batch of large rows grow into a
-  # multi-megabyte unit; each response body element is held in full by the
-  # request process and by the socket's driver queue while it is being written,
-  # so a serve to a slow or stalled client pins the whole unit for as long as
-  # the serve lives. Bounding the unit size bounds the memory pinned per
-  # stalled connection.
+  # size. Each response body element is held in full by the request process
+  # and by the socket's driver queue while it is being written, so a serve to
+  # a slow or stalled client pins the whole unit for as long as the serve
+  # lives. Bounding the unit size bounds the memory pinned per connection.
   @max_batch_items 500
   @max_batch_bytes 256 * 1024
 

--- a/packages/sync-service/lib/electric/shapes/api/encoder.ex
+++ b/packages/sync-service/lib/electric/shapes/api/encoder.ex
@@ -66,13 +66,46 @@ defmodule Electric.Shapes.Api.Encoder.JSON do
   @json_list_end "]"
   @json_item_separator ","
 
+  # Batch stream items into iodata units bounded by BOTH item count and byte
+  # size. Batching by count alone let a batch of large rows grow into a
+  # multi-megabyte unit; each response body element is held in full by the
+  # request process and by the socket's driver queue while it is being written,
+  # so a serve to a slow or stalled client pins the whole unit for as long as
+  # the serve lives. Bounding the unit size bounds the memory pinned per
+  # stalled connection.
+  @max_batch_items 500
+  @max_batch_bytes 256 * 1024
+
   defp to_json_stream(items) do
     Stream.concat([
       [@json_list_start],
       Stream.intersperse(items, @json_item_separator),
       [@json_list_end]
     ])
-    |> Stream.chunk_every(500)
+    |> chunk_by_count_and_bytes(@max_batch_items, @max_batch_bytes)
+  end
+
+  defp chunk_by_count_and_bytes(stream, max_items, max_bytes) do
+    Stream.transform(
+      stream,
+      fn -> {[], 0, 0} end,
+      fn item, {acc, count, bytes} ->
+        acc = [item | acc]
+        count = count + 1
+        bytes = bytes + IO.iodata_length(item)
+
+        if count >= max_items or bytes >= max_bytes do
+          {[Enum.reverse(acc)], {[], 0, 0}}
+        else
+          {[], {acc, count, bytes}}
+        end
+      end,
+      fn
+        {[], _count, _bytes} -> {[], nil}
+        {acc, _count, _bytes} -> {[Enum.reverse(acc)], nil}
+      end,
+      fn _acc -> :ok end
+    )
   end
 end
 

--- a/packages/sync-service/test/integration/stalled_serve_memory_test.exs
+++ b/packages/sync-service/test/integration/stalled_serve_memory_test.exs
@@ -1,0 +1,155 @@
+defmodule Electric.Integration.StalledServeMemoryTest do
+  @moduledoc """
+  A shape response served to a client that stops reading must not pin a full
+  log chunk (~`chunk_bytes_threshold`, 10 MB by default) per connection for an
+  unbounded time.
+
+  Reproduces a production OOM (2026-07-01): a bulk write woke a fleet of live
+  long-pollers into multi-chunk catch-up serves; connections whose clients
+  stalled kept their entire in-flight chunk pinned — once in the handler
+  process and once in the socket's driver queue — with nothing to reap them.
+  ~400 such serves × ~10 MB ≈ 3.9 GB of reference-counted binary and the node
+  ran out of memory. The pinned data is live-referenced, so no GC tuning can
+  reclaim it; the server must either bound the in-flight write unit or reap
+  serves that stop making progress.
+
+  Full stack: real Postgres, real replication, real Bandit server, raw TCP
+  clients that request a live shape and then never read the response.
+  """
+  use ExUnit.Case, async: false
+
+  import Support.ComponentSetup
+  import Support.DbSetup
+  import Support.DbStructureSetup
+  import Support.IntegrationSetup
+
+  alias Electric.Plug.Router
+
+  @moduletag :tmp_dir
+
+  # Stalled connections and the per-connection pinned-memory budget the server
+  # must stay within regardless of chunk size. Today each stalled serve pins
+  # ~2x the 10 MB chunk (handler + socket driver queue), so the budget is
+  # exceeded ~10x over.
+  @stalled_clients 10
+  @per_connection_budget 2 * 1024 * 1024
+
+  describe "stalled live clients" do
+    setup [:with_unique_db, :with_basic_tables, :with_sql_execute]
+    setup :with_complete_stack
+    setup :with_electric_client
+
+    @tag timeout: 120_000
+    test "a stalled serve does not pin the full in-flight chunk indefinitely", ctx do
+      %{stack_id: stack_id, db_conn: db_conn, port: port, server_pid: server_pid} = ctx
+      opts = Router.init(build_router_opts(ctx))
+      registry = Electric.StackSupervisor.registry_name(stack_id)
+
+      # Create the shape and learn its handle.
+      snapshot = Plug.Test.conn(:get, "/v1/shape?table=items&offset=-1") |> Router.call(opts)
+      assert snapshot.status == 200
+      [handle] = Plug.Conn.get_resp_header(snapshot, "electric-handle")
+
+      # Park live long-pollers over raw sockets that will never be read from.
+      socks =
+        for _ <- 1..@stalled_clients do
+          {:ok, s} =
+            :gen_tcp.connect({127, 0, 0, 1}, port, [
+              :binary,
+              active: false,
+              recbuf: 2048,
+              buffer: 2048
+            ])
+
+          :ok =
+            :gen_tcp.send(
+              s,
+              "GET /v1/shape?table=items&handle=#{handle}&offset=0_0&live=true HTTP/1.1\r\n" <>
+                "Host: localhost\r\n\r\n"
+            )
+
+          s
+        end
+
+      on_exit(fn -> Enum.each(socks, &:gen_tcp.close/1) end)
+
+      wait_for_subscribers(registry, handle, @stalled_clients)
+      {:ok, handlers} = ThousandIsland.connection_pids(server_pid)
+      assert length(handlers) == @stalled_clients
+
+      # The trigger: one bulk transaction (~50 MB) that all parked waiters wake
+      # to serve. Every response dwarfs the client's socket buffers, so every
+      # serve stalls.
+      Postgrex.query!(
+        db_conn,
+        "INSERT INTO items SELECT gen_random_uuid(), repeat('x', 50000) FROM generate_series(1, 1000)",
+        []
+      )
+
+      # Give every handler ample time to wake, load its chunk, and wedge — and
+      # the server ample time to notice serves that make no progress.
+      Process.sleep(25_000)
+
+      pinned = Enum.map(handlers, &pinned_bytes/1)
+      total_pinned = Enum.sum(pinned)
+      worst = Enum.max(pinned)
+      alive = Enum.count(handlers, &Process.alive?/1)
+
+      assert total_pinned <= @stalled_clients * @per_connection_budget,
+             """
+             #{alive}/#{@stalled_clients} stalled serves still alive, pinning \
+             #{mb(total_pinned)} of response data (worst connection: #{mb(worst)}, \
+             budget: #{mb(@per_connection_budget)}/connection).
+             Each stalled connection pins its entire in-flight log chunk (handler \
+             heap + socket driver queue) with nothing to bound or reap it — the \
+             unbounded growth that OOMed production.
+             """
+    end
+  end
+
+  # Response bytes pinned by one stalled connection: refc binaries referenced
+  # by the handler process (deduplicated by binary id) plus bytes queued in the
+  # socket ports it owns. A dead (reaped) handler pins nothing.
+  defp pinned_bytes(handler) do
+    heap_bytes =
+      case Process.info(handler, :binary) do
+        {:binary, list} ->
+          list
+          |> Enum.reduce(%{}, fn {id, size, _refc}, acc -> Map.put(acc, id, size) end)
+          |> Map.values()
+          |> Enum.sum()
+
+        nil ->
+          0
+      end
+
+    port_bytes =
+      case Process.info(handler, :links) do
+        {:links, links} ->
+          for p <- links, is_port(p), reduce: 0 do
+            acc ->
+              case :erlang.port_info(p, :queue_size) do
+                {:queue_size, n} -> acc + n
+                _ -> acc
+              end
+          end
+
+        nil ->
+          0
+      end
+
+    heap_bytes + port_bytes
+  end
+
+  defp wait_for_subscribers(registry, handle, n, tries \\ 400) do
+    found = length(Registry.lookup(registry, handle))
+
+    cond do
+      found >= n -> :ok
+      tries > 0 -> Process.sleep(25) && wait_for_subscribers(registry, handle, n, tries - 1)
+      true -> flunk("only #{found}/#{n} live requests subscribed")
+    end
+  end
+
+  defp mb(bytes), do: "#{Float.round(bytes / 1_048_576, 1)}MB"
+end

--- a/packages/sync-service/test/integration/stalled_serve_memory_test.exs
+++ b/packages/sync-service/test/integration/stalled_serve_memory_test.exs
@@ -28,9 +28,7 @@ defmodule Electric.Integration.StalledServeMemoryTest do
   @moduletag :tmp_dir
 
   # Stalled connections and the per-connection pinned-memory budget the server
-  # must stay within regardless of chunk size. Today each stalled serve pins
-  # ~2x the 10 MB chunk (handler + socket driver queue), so the budget is
-  # exceeded ~10x over.
+  # must stay within regardless of the configured chunk size.
   @stalled_clients 10
   @per_connection_budget 2 * 1024 * 1024
 


### PR DESCRIPTION
## Summary

Bounds the server-side memory pinned by a shape response being served to a client that stops (or slows) reading. Previously every such serve pinned its entire in-flight log chunk (~10 MB by default) — twice — for as long as the serve lived, with nothing to bound or reap it. Accumulated stalled serves exhausted a production node.

## The production incident (2026-07-01)

A customer's primary Electric node (1.7.0) OOM'd after `vm.memory(:binary)` grew 0 → **3.9 GB** in ~65 minutes. Root-caused from their telemetry plus reproduction on both 1.7.0 and current main:

- A bulk write (~12:36 UTC) woke a fleet of parked live long-pollers into large multi-chunk catch-up serves.
- Serves whose clients stalled never complete — and **emit no telemetry** (spans and request counters are completion-based), so the node looked near-idle while dying. The stalled population was visible only as a ~+400 rise in BEAM process count tracking the memory curve.
- Each stalled serve pinned **~19.6 MB**: the whole ~10 MB chunk held by the handler process, plus the same chunk's iodata queued in the socket's driver queue (`port_command` enqueues the entire iodata; busy-port only gates the *next* write — driver queues are invisible to per-process memory attribution).
- The references are **live**, so no GC tuning helps: a forced global GC in the reproduction reclaims ~0.3 MB of hundreds pinned.
- Measured linear scaling: 5 stalled clients ≈ 150 MB, 50 ≈ 602 MB. ~400 × ~10 MB ≈ the 3.9 GB observed.

The stalled clients themselves were streams hung mid-body in `@electric-sql/client` before #4674. **#4674 (client-side watchdog, `@electric-sql/client` ≥ 1.5.23) prevents this accumulation at its source** — a hung fetch is aborted and reconnected, which also frees the server side. But the server must not depend on well-behaved clients: any client that opens a shape request and stops reading (buggy consumer, drip-feeding proxy, hostile actor) could pin ~2× chunk-size per connection indefinitely. This PR adds the server-side guard.

## Why each stalled serve pinned ~2× the chunk

1. **`LogFile.stream_jsons` read eagerly**: one whole-range `pread` (~the full 10 MB chunk as a single binary), returning an eager *list* of entries sliced from it as sub-binaries — pinning the chunk once as the read binary and again via the entry list, for the lifetime of the response.
2. **`Encoder.JSON` batched by item count only** (`chunk_every(500)`): with large rows a single body element grew to multi-MB, held in full by the request process and, once written, by the socket driver queue.

## Solution

1. `stream_jsons` is now a lazy `Stream.resource` reading **64 KiB blocks** (mirroring the existing `stream_jsons_until_offset`, reusing `extract_jsons_from_binary`'s partial-input handling). Each emitted entry pins at most its read block.
2. Encoder batches are additionally capped at **256 KiB** (count cap unchanged).

Per stalled connection: **19.6 MB → well under 1 MB**, regardless of `chunk_bytes_threshold`.

Trade-off for review: a 10 MB chunk is now ~160 `pread`s instead of 1 (the old comment chose the eager read deliberately). This is noise relative to JSON encoding and socket writes; `@read_block_bytes` is a module attribute if tuning is wanted.

## Test plan

- [x] New integration test (`stalled_serve_memory_test.exs`): 10 live long-pollers on never-read sockets, one ~50 MB transaction, 25s grace; asserts per-connection pinned response memory (deduplicated handler-held refc binary + owned port queue bytes) ≤ 2 MB/connection. RED on main (19.6 MB/conn), GREEN with this fix. The assertion is implementation-agnostic: bounding the write unit or reaping stalled serves both satisfy it.
- [x] No regressions: `pure_file_storage` + storage suites, `router_test`, `low_privilege_router_test`, `api_test`, all of `test/integration/` — 361 tests passing.
- [x] `mix compile --warnings-as-errors` clean.

## Follow-up (not in this PR)

A progress deadline for serves (reap connections making no forward progress) — defense-in-depth so even sub-MB pinning can't accumulate without bound across pathological connection counts.

---
Generated with [Claude Code](https://claude.com/claude-code)