### PR TITLE
fix(sync-service): stop flaky ShapeCache await-consumer test under CI load

### DIFF
--- a/.changeset/fix-flaky-shape-cache-await.md
+++ b/.changeset/fix-flaky-shape-cache-await.md
@@ -1,5 +1,0 @@
----
-"@core/sync-service": patch
----
-
-Stop the `ShapeCache` "should wait for consumer to come up" test flaking under CI load. The test asserts the snapshot *eventually* starts once the consumer comes up, but its ~5s `Task.await` bound occasionally tripped when the shared Postgres instance and BEAM scheduler were briefly saturated by concurrent async tests. The bound is now generous-but-bounded (15s), absorbing load spikes while still failing reasonably fast on a genuine hang.

--- a/.changeset/fix-flaky-shape-cache-await.md
+++ b/.changeset/fix-flaky-shape-cache-await.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Stop the `ShapeCache` "should wait for consumer to come up" test flaking under CI load. The test asserts the snapshot *eventually* starts once the consumer comes up, but its ~5s `Task.await` bound occasionally tripped when the shared Postgres instance and BEAM scheduler were briefly saturated by concurrent async tests. The bound is now generous-but-bounded (15s), absorbing load spikes while still failing reasonably fast on a genuine hang.

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1116,7 +1116,13 @@ defmodule Electric.ShapeCacheTest do
       # should delay in responding
       refute Task.yield(wait_task, 10)
       Task.await(creation_task)
-      assert :started = Task.await(wait_task, start_consumer_delay + 5_000)
+
+      # We're asserting that the snapshot *eventually* starts once the consumer comes up,
+      # not that it does so within a few seconds. This normally resolves in well under a
+      # second; the generous-but-bounded timeout absorbs CI scheduler/PG load spikes (which
+      # occasionally pushed the old 5.3s bound over the edge) while still failing reasonably
+      # fast on a genuine hang — see https://github.com/electric-sql/electric/issues/4712.
+      assert :started = Task.await(wait_task, 15_000)
     end
 
     test "should not loop forever waiting for consumer to come up", ctx do


### PR DESCRIPTION
## Summary

Widens the tight `Task.await` bound in the `Electric.ShapeCacheTest` "should wait for consumer to come up" test so it stops flaking under CI load.

Refs #4712

## Problem

This test races consumer/snapshot startup: it spawns `await_snapshot_start` **before** the consumer exists, then asserts it eventually returns `:started` once the consumer comes up. The final bound was `Task.await(wait_task, start_consumer_delay + 5_000)` ≈ 5.3s.

Under CI load — when the shared Postgres instance and the BEAM scheduler are briefly saturated by concurrent async tests — the real (mocked-snapshot) consumer startup occasionally takes longer than 5.3s of wall-clock, tripping the bound. It then passes on rerun with no code change, version-hopping across the PG matrix. Reported twice in #4712:

- `Task.await(..., 5300)` timeout on pg15, passed on rerun
- Same test/timeout on pg17 two commits later

The test is asserting *eventual* startup, not 5-second startup.

## Solution

The bound is now a **generous-but-bounded 15s** (normal run stays ~0.8s). This absorbs realistic CI scheduler/PG load spikes while still failing reasonably fast on a genuine hang — deliberately not a huge 45–50s value, which would slow the failure signal when there's a real regression.

Alternatives considered and rejected:
- **Deterministic rendezvous** (gate consumer startup on a test signal instead of `Process.sleep`) — fights the 500ms noproc retry budget in `await_snapshot_start` this test is inherently coupled to, risking a *different* flake.
- **Fully mocking startup** — would gut the test's purpose (exercising the real consumer-startup path).

### Scope note

#4712 lists three other flakes (slow-snapshot-query, `TraceContextPlug`, `FlushTracker`/`Repatch.cleanup`). Those are **not** tight-await problems — their root cause is shared-Postgres saturation / global-state races under concurrent async tests, which needs separate infra-level work (pool sizing / connection resilience) rather than a timeout tweak. This PR intentionally fixes only the one clean tight-await flake; the rest are left for a follow-up.

## Test Plan

- [x] `mix test test/electric/shape_cache_test.exs` — 41 passed
- [x] Target test passes in isolation (`--only line:1081`)

---
Generated with [Claude Code](https://claude.com/claude-code)