### PR TITLE
fix(agents-runtime): carry message_type through inbox timeline so composer_input reaches the agent as text

### DIFF
--- a/.changeset/composer-input-message-type.md
+++ b/.changeset/composer-input-message-type.md
@@ -1,0 +1,5 @@
+---
+"@electric-ax/agents-runtime": patch
+---
+
+Fix `composer_input` messages reaching the agent as raw JSON. `buildInboxMessages` dropped the `message_type` field when materializing the entity timeline from the db, so `projectInboxPayload` could no longer recognize composer input and fell back to `JSON.stringify(payload)` — the model saw `{"source":"..."}` instead of the plain text the user typed. The field is now carried through.

--- a/packages/agents-runtime/src/entity-timeline.ts
+++ b/packages/agents-runtime/src/entity-timeline.ts
@@ -946,6 +946,7 @@ function buildInboxMessages(
     order: message.order,
     from: message.from ?? `unknown`,
     payload: message.payload,
+    message_type: message.message_type,
     timestamp: message.timestamp ?? new Date(0).toISOString(),
     mode: message.mode ?? `immediate`,
     status: message.status ?? `processed`,

--- a/packages/agents-runtime/test/timeline-context.test.ts
+++ b/packages/agents-runtime/test/timeline-context.test.ts
@@ -524,6 +524,41 @@ describe(`timeline context`, () => {
     ])
   })
 
+  it(`timelineToMessages projects composer_input rows read from the db as source text`, () => {
+    const db = {
+      collections: {
+        runs: { toArray: [] },
+        texts: { toArray: [] },
+        textDeltas: { toArray: [] },
+        toolCalls: { toArray: [] },
+        steps: { toArray: [] },
+        errors: { toArray: [] },
+        inbox: {
+          toArray: [
+            {
+              key: `msg-1`,
+              from: `user`,
+              message_type: `composer_input`,
+              payload: { source: `summarize the article` },
+              timestamp: `2026-03-28T00:00:00.000Z`,
+            },
+          ],
+          __electricRowOffsets: new Map([[`msg-1`, offset(1)]]),
+        },
+        wakes: { toArray: [], __electricRowOffsets: new Map() },
+        signals: { toArray: [], __electricRowOffsets: new Map() },
+        contextInserted: { toArray: [], __electricRowOffsets: new Map() },
+        contextRemoved: { toArray: [], __electricRowOffsets: new Map() },
+        manifests: { toArray: [], __electricRowOffsets: new Map() },
+        childStatus: { toArray: [], __electricRowOffsets: new Map() },
+      },
+    } as unknown as EntityStreamDB
+
+    expect(timelineToMessages(db)).toEqual([
+      { role: `user`, content: `summarize the article` },
+    ])
+  })
+
   it(`timelineToMessages handles an empty entity timeline`, () => {
     const db = {
       collections: {


### PR DESCRIPTION
## Problem

Messages typed in the composer arrive to the agent as raw JSON — e.g. the model receives `{"source":"summarize the article"}` instead of the plain text `summarize the article`. This makes the agent respond about JSON rather than the actual message.

## Root cause

`composer_input` inbox messages are projected to model text by `projectInboxPayload` ([`timeline-context.ts`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/src/timeline-context.ts)), which extracts `payload.source` (or `payload.text`) **only when** `item.message_type === COMPOSER_INPUT_MESSAGE_TYPE`. Otherwise it falls back to `JSON.stringify(payload)`.

When the entity timeline is materialized from the db, `buildInboxMessages` in [`entity-timeline.ts`](https://github.com/electric-sql/electric/blob/main/packages/agents-runtime/src/entity-timeline.ts) rebuilds each inbox row but **drops `message_type`**. So by the time `projectInboxPayload` runs, `message_type` is `undefined`, the `composer_input` branch is never taken, and the raw payload is stringified.

`message_type` is present on the underlying collection row (`MessageReceivedValue`) and is already permitted on `IncludesInboxMessage` (the `Omit` doesn't exclude it) — it was simply not copied through.

## Fix

Carry `message_type` through `buildInboxMessages`. One field; no type changes needed.

## Test

Added a regression test to `test/timeline-context.test.ts` that drives the **db read path** (`timelineToMessages`) with a `composer_input` row and asserts the source text is extracted. The existing composer_input test only exercised `buildTimelineMessages` with a hand-built timeline, so it bypassed `buildInboxMessages` and didn't catch this. Verified the new test fails before the fix and passes after.

## Notes

- Changeset included (`patch` for `@electric-ax/agents-runtime`).
- `pnpm --filter @electric-ax/agents-runtime test` passes for the timeline suite. Two unrelated failures exist in a fresh clone and are not touched by this change: `tool-providers.test.ts` (can't resolve the unbuilt `@electric-ax/agents-mcp` sibling package) and a flaky heartbeat-timing assertion in `pull-wake-runner.test.ts`.