### PR TITLE
docs(agents): explain Docker webhook networking (0.0.0.0 bind + loopback rewrite)

### DIFF
--- a/website/docs/agents/usage/app-setup.md
+++ b/website/docs/agents/usage/app-setup.md
@@ -115,6 +115,16 @@ server.listen(PORT, async () => {
 })
 ```
 
+::: warning Local Docker networking
+
+In local development the runtime server runs in a Docker container (started by the CLI) while your app runs on the host. Two things make webhook callbacks reach your app:
+
+1. **Your app must listen on all interfaces (`0.0.0.0`), not just loopback.** The container reaches your app across the Docker host boundary, so an app bound only to `127.0.0.1`/`localhost` is unreachable — the agent spawns but never responds, and **no error is surfaced**. Node's `http` server and `@hono/node-server` listen on all interfaces by default; some frameworks default to loopback only (e.g. Nuxt/Nitro, which needs `devServer.host: '0.0.0.0'`).
+
+2. **Loopback `serveEndpoint` URLs are rewritten automatically.** A `serveEndpoint` whose host is `localhost`, `127.0.0.1`, or `::1` is rewritten by the server to the Docker host (`host.docker.internal`) before it dispatches webhooks — which is why a configured `http://localhost:3000/webhook` shows up as `http://host.docker.internal:3000/webhook` in `electric-ax agents types`. This is controlled by `ELECTRIC_AGENTS_REWRITE_LOOPBACK_WEBHOOKS_TO`, which the CLI's docker-compose sets to `host.docker.internal`. If you run the runtime server **directly on the host** (not in Docker) the variable is unset, so loopback URLs are left as-is — leave it unset in that case, or on-host loopback callbacks will break.
+
+:::
+
 ## registerTypes
 
 Registers all entity types with the Electric Agents runtime server and creates webhook subscriptions. Uses upsert semantics — re-registering an existing type updates it rather than erroring.

--- a/website/docs/agents/walkthrough.md
+++ b/website/docs/agents/walkthrough.md
@@ -349,6 +349,15 @@ Then when you run the app you should see:
 INFO: [agent-runtime] Registered entity type: assistant
 ```
 
+::: warning How the container reaches your app
+
+The runtime server runs in Docker while your app runs on the host, so webhook callbacks cross the Docker host boundary. Two things make this work — and both are easy to trip over:
+
+- **Your app must listen on all interfaces (`0.0.0.0`), not just loopback.** The `@hono/node-server` `serve()` above already does this, so the walkthrough works as-is. But if you wire the runtime handler into a framework that binds to loopback only by default (e.g. Nuxt/Nitro), the container can't reach it — the agent spawns but never responds, with **no error**. Configure the framework to listen on `0.0.0.0` (for Nuxt: `devServer.host: '0.0.0.0'`).
+- **`localhost` in `serveEndpoint` is rewritten to `host.docker.internal` automatically.** That is why the `agents types` output below shows `http://host.docker.internal:3000/electric-agents` even though we configured `http://localhost:3000`. The rewrite is controlled by the `ELECTRIC_AGENTS_REWRITE_LOOPBACK_WEBHOOKS_TO` env var, which the CLI's docker-compose sets. If you run the runtime server directly on the host instead of in Docker, it is unset and loopback URLs are used as-is.
+
+:::
+
 Check the registered entities types on the command line:
 
 ```sh


### PR DESCRIPTION
## Problem

Following the agents docs on a local Docker setup, a custom app can spawn agents but they **never respond**, with **no error surfaced anywhere** — an unusually hard failure to diagnose that can push people off the platform. The runtime server runs in a Docker container (started by the CLI) while the app runs on the host, so webhook callbacks cross the Docker host boundary. Two behaviors are load-bearing here, and neither is documented:

1. **The app must listen on all interfaces (`0.0.0.0`), not just loopback.** An app bound only to `127.0.0.1`/`localhost` is unreachable from the container. Node's `http` server and `@hono/node-server` bind all interfaces by default, so the walkthrough's own example works — which quietly masks the requirement. Frameworks that default to loopback-only (e.g. Nuxt/Nitro) fail silently: the agent spawns, the webhook is never delivered, nothing is logged.

2. **Loopback `serveEndpoint` URLs are rewritten to `host.docker.internal`.** `rewriteLoopbackWebhookUrl` (`packages/agents-server/src/utils/webhook-url.ts`) rewrites a `serveEndpoint` host of `localhost`/`127.0.0.1`/`::1` to the Docker host before dispatching webhooks, gated by `ELECTRIC_AGENTS_REWRITE_LOOPBACK_WEBHOOKS_TO` (set to `host.docker.internal` by the CLI's docker-compose). This is why `electric-ax agents types` prints `http://host.docker.internal:3000/electric-agents` for a `serveEndpoint` configured as `http://localhost:3000/...` — currently unexplained, so readers can't tell how a container reaches a `localhost` URL, and can't reason about running the server on the host (where the variable is unset and the rewrite correctly does not apply).

## Change

Docs only. Adds a `::: warning` callout to:

- **`app-setup.md`** (the runtime-handler reference) — after the HTTP server section.
- **`walkthrough.md`** — right before the `agents types` output, so it explains the `host.docker.internal` line the reader is about to see.

Each callout covers the `0.0.0.0` bind requirement (and its silent-failure mode), the loopback rewrite and the env var that controls it, and the on-host caveat. No code or behavior changes.