### PR TITLE
fix(examples): drop trailing slash from /v1/shape URLs (fixes yjs demo)

### DIFF
--- a/examples/linearlite-read-only/src/shapes.ts
+++ b/examples/linearlite-read-only/src/shapes.ts
@@ -2,7 +2,7 @@ import { ShapeStreamOptions } from '@electric-sql/client'
 import { baseUrl, source_id, secret } from './electric'
 
 export const issueShape: ShapeStreamOptions = {
-  url: `${baseUrl}/v1/shape/`,
+  url: `${baseUrl}/v1/shape`,
   params: {
     table: `issue`,
     secret,

--- a/examples/yjs/src/server/server.ts
+++ b/examples/yjs/src/server/server.ts
@@ -92,7 +92,7 @@ app.put(`/api/update`, async (c: Context) => {
 app.get(`/shape-proxy/v1/shape`, async (c: Context) => {
   const url = new URL(c.req.url)
   const electricUrl = process.env.ELECTRIC_URL || `http://localhost:3000`
-  const originUrl = new URL(`${electricUrl}/v1/shape/`)
+  const originUrl = new URL(`${electricUrl}/v1/shape`)
 
   // Forward all query parameters
   url.searchParams.forEach((value, key) => {


### PR DESCRIPTION
## What

One-character fix in two examples: `${ELECTRIC_URL}/v1/shape/` → `${ELECTRIC_URL}/v1/shape`.

## Why

The Electric Cloud API returns `404 {"error":{"code":"ROUTE_NOT_FOUND"}}` for `/v1/shape/` with a trailing slash (without the slash it routes fine).

This is currently breaking the deployed **yjs demo** (linked from https://electric-sql.com/sync/demos/yjs): the shape proxy at `yjs-server.examples.electric-sql.com/shape-proxy/v1/shape` forwards to `https://api.electric-sql.cloud/v1/shape/` and passes the 404 through, so the editor loads but stays permanently `disconnected`, retrying in a loop.

Verified against the live API:

```
$ curl -s -o /dev/null -w '%{http_code}' 'https://api.electric-sql.cloud/v1/shape/?table=foo&offset=-1'
404   # ROUTE_NOT_FOUND
$ curl -s -o /dev/null -w '%{http_code}' 'https://api.electric-sql.cloud/v1/shape?table=foo&offset=-1'
400   # MISSING_SERVICE_ID — routed correctly, param validation as expected
```

The same latent pattern existed in `linearlite-read-only`'s client-side shape config, fixed here too.

## Deploy

The yjs demo needs a redeploy of the `yjs` example service after this merges for the fix to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)