### PR TITLE
fix(ci): install client packages in example deploy jobs (unblocks burn redeploy)

### DIFF
--- a/.github/workflows/deploy_all_examples.yml
+++ b/.github/workflows/deploy_all_examples.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ -f "${{ matrix.example.path }}/package.json" ]; then
-            pnpm --filter "$(jq -r .name "${{ matrix.example.path }}/package.json")..." --filter @electric-examples/shared install --frozen-lockfile
+            pnpm --filter "$(jq -r .name "${{ matrix.example.path }}/package.json")..." --filter @electric-examples/shared --filter @electric-sql/client --filter @electric-sql/experimental --filter @electric-sql/react install --frozen-lockfile
           else
             pnpm install --frozen-lockfile
           fi

--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ -f "${{ matrix.example.path }}/package.json" ]; then
-            pnpm --filter "$(jq -r .name "${{ matrix.example.path }}/package.json")..." --filter @electric-examples/shared install --frozen-lockfile
+            pnpm --filter "$(jq -r .name "${{ matrix.example.path }}/package.json")..." --filter @electric-examples/shared --filter @electric-sql/client --filter @electric-sql/experimental --filter @electric-sql/react install --frozen-lockfile
           else
             pnpm install --frozen-lockfile
           fi

--- a/examples/burn/README.md
+++ b/examples/burn/README.md
@@ -208,3 +208,11 @@ To learn more, see:
 ## Support
 
 Reach out on the [Electric Discord](https://discord.electric-sql.com) if you need help or have any questions.
+
+## Deployment
+
+The production demo runs on ECS via SST (`sst.config.ts`) and is deployed
+by the `Deploy Examples` workflow when changes under `examples/burn` land
+on `main`. It requires a valid `ANTHROPIC_KEY` (GitHub Actions secret) and
+uses `claude-haiku-4-5-20251001` — the only model alias resolvable in
+production (see `config/config.exs`).


### PR DESCRIPTION
## What

Adds `@electric-sql/client`, `@electric-sql/experimental` and `@electric-sql/react` to the pnpm install filters in `deploy_examples.yml` and `deploy_all_examples.yml`, and adds a short Deployment section to `examples/burn/README.md`.

## Why — burn is still down after #4725

The deploy job's Deploy step unconditionally builds the three client packages before `sst deploy`, but the Install step only installs the example's own dependency graph (`pnpm --filter "<example>..."`). Burn is an Elixir app with no workspace dependency on those packages, so their devDeps (`shx`, `tsup`) are missing and the build dies:

```
../../packages/typescript-client build: sh: 1: shx: not found
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @electric-sql/client@1.5.24 build
```

The job failure is masked by `continue-on-error: true` (run 29458958432 shows green with a failed `Deploy burn` job), so #4725 never actually redeployed burn — the ECS service is still on task definition revision 1, crash-looping on the revoked `ANTHROPIC_KEY`.

All other examples pass because they happen to depend on the client packages via the workspace, which pulls them into the install.

## Redeploy

The README change puts `examples/burn` in the `changed-deployable` matrix, so **merging this PR triggers the burn deploy** — now unblocked — which picks up the rotated `ANTHROPIC_KEY` and the Haiku model config from #4725.

🤖 Generated with [Claude Code](https://claude.com/claude-code)