### PR TITLE
fix(sync-service): Fix keepalive acks advancing past unflushed small transactions

### DIFF
--- a/.changeset/keepalive-ack-flush-tracker-bypass.md
+++ b/.changeset/keepalive-ack-flush-tracker-bypass.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix keepalives acknowledging WAL past small transactions whose storage flush hasn't been confirmed yet. A crash in that window could permanently lose the transaction for all affected shapes, since the replication slot had already advanced past it.

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -57,6 +57,7 @@ defmodule Electric.Postgres.ReplicationClient do
       pending_event: nil,
       received_wal: 0,
       flushed_wal: 0,
+      last_confirmed_flush_lsn: 0,
       last_seen_txn_lsn: Lsn.from_integer(0),
       last_seen_txn_timestamp: nil,
       flush_up_to_date?: true
@@ -83,6 +84,7 @@ defmodule Electric.Postgres.ReplicationClient do
             pending_event: {reference(), term(), non_neg_integer(), integer()} | nil,
             received_wal: non_neg_integer(),
             flushed_wal: non_neg_integer(),
+            last_confirmed_flush_lsn: non_neg_integer(),
             last_seen_txn_lsn: Lsn.t(),
             last_seen_txn_timestamp: integer(),
             flush_up_to_date?: boolean()
@@ -287,15 +289,18 @@ defmodule Electric.Postgres.ReplicationClient do
   @impl true
   def handle_info({:flush_boundary_updated, lsn}, state) do
     state =
-      if Lsn.from_integer(lsn) == state.last_seen_txn_lsn do
+      %{state | last_confirmed_flush_lsn: max(lsn, state.last_confirmed_flush_lsn)}
+      |> update_flush_up_to_date()
+
+    state =
+      if state.flush_up_to_date? do
         %{
           state
-          | flush_up_to_date?: true,
-            flushed_wal: state.received_wal,
+          | flushed_wal: state.received_wal,
             received_wal: max(lsn, state.received_wal)
         }
       else
-        %{state | flushed_wal: max(lsn, state.flushed_wal), received_wal: state.received_wal}
+        %{state | flushed_wal: max(lsn, state.flushed_wal)}
       end
 
     {:noreply, [encode_standby_status_update(state)], state}
@@ -362,8 +367,8 @@ defmodule Electric.Postgres.ReplicationClient do
       when is_reference(ref) do
     Process.demonitor(ref, [:flush])
     state = %{state | pending_event: nil}
-    state = maybe_update_flush_up_to_date(state)
     {acks, state} = acknowledge_transaction(event, state)
+    state = update_flush_up_to_date(state)
     {:noreply_and_resume, acks, state}
   end
 
@@ -515,9 +520,9 @@ defmodule Electric.Postgres.ReplicationClient do
   # responsive to handle_info messages (keepalive timer, flush_boundary_updated,
   # EXIT signals) while providing backpressure to the replication stream.
   #
-  # maybe_update_flush_up_to_date and acknowledge_transaction are intentionally
-  # deferred to apply_event's success path, preserving the original semantics
-  # where they only ran after handle_event succeeded.
+  # acknowledge_transaction and the flush_up_to_date? recompute are
+  # intentionally deferred to apply_event's success path, preserving the
+  # original semantics where they only ran after handle_event succeeded.
   defp dispatch_event(event, state) do
     send(self(), {:process_event, event, @max_event_retry_time})
     {:noreply_and_pause, [], state}
@@ -602,12 +607,21 @@ defmodule Electric.Postgres.ReplicationClient do
 
   defp acknowledge_transaction(%Relation{}, state), do: {[], state}
 
-  defp maybe_update_flush_up_to_date(state) do
-    if MessageConverter.in_transaction?(state.message_converter) do
-      %{state | flush_up_to_date?: false}
-    else
+  # flush_up_to_date? is derived state: the client is up to speed exactly when
+  # the flush tracker has confirmed the last seen transaction. Recomputed
+  # whenever either side moves — after acknowledge_transaction/2 advances
+  # last_seen_txn_lsn and when a :flush_boundary_updated notification advances
+  # last_confirmed_flush_lsn.
+  #
+  # Both call sites matter: for a transaction that affects no shapes, the tracker's
+  # confirmation is emitted during event processing and reaches this process before the
+  # handler's reply that updates last_seen_txn_lsn.
+  defp update_flush_up_to_date(state) do
+    %{
       state
-    end
+      | flush_up_to_date?:
+          Lsn.from_integer(state.last_confirmed_flush_lsn) == state.last_seen_txn_lsn
+    }
   end
 
   defp encode_standby_status_update(state) do

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -577,6 +577,58 @@ defmodule Electric.Postgres.ReplicationClientTest do
       assert Lsn.to_integer(get_confirmed_flush_lsn(conn, ctx.slot_name)) >=
                Lsn.to_integer(Lsn.increment(lsn2, 1))
     end
+
+    @tag with_empty_publication?: true
+    test "keepalives don't ack WAL past an unflushed txn on an already-streamed table",
+         %{db_conn: conn} = ctx do
+      Postgrex.query!(conn, "ALTER PUBLICATION #{ctx.slot_name} SET TABLE serial_ids", [])
+
+      pid = start_client(ctx)
+
+      # First insert into serial_ids in this walsender session. The txn carries
+      # a Relation message which is dispatched as a standalone mid-transaction
+      # event, so this txn incidentally clears flush_up_to_date?.
+      Postgrex.query!(conn, "INSERT INTO serial_ids (id) VALUES (1)", [])
+      assert {lsn1, %NewRecord{record: %{"id" => "1"}}} = receive_tx_change_with_lsn()
+
+      # Confirm txn1 as flushed: lsn1 is the last seen txn, so the client
+      # becomes fully caught up and flush_up_to_date? is re-armed.
+      send(pid, {:flush_boundary_updated, Lsn.to_integer(lsn1)})
+
+      # A second small insert into the now already-streamed table: no Relation
+      # message and fewer changes than max_batch_size, so the whole txn is
+      # decoded into a single commit-carrying fragment with no mid-transaction
+      # event dispatch. Its flush is never confirmed.
+      Postgrex.query!(conn, "INSERT INTO serial_ids (id) VALUES (2)", [])
+      assert {lsn2, %NewRecord{record: %{"id" => "2"}}} = receive_tx_change_with_lsn()
+
+      # Writes to a table outside the publication make the walsender skip
+      # transactions and send keepalives with an advancing wal_end.
+      for _ <- 1..10, do: insert_item(conn, "test value")
+
+      # Wait long enough for those keepalives to arrive (their timing is up to
+      # PG), then make the client report its ack state: re-notifying an
+      # already-confirmed boundary — as happens whenever any shape reports a
+      # flush — sends a standby status update carrying the current flushed_wal.
+      confirmed =
+        Enum.reduce_while(1..20, nil, fn _, _ ->
+          Process.sleep(50)
+          send(pid, {:flush_boundary_updated, Lsn.to_integer(lsn1)})
+
+          confirmed = get_confirmed_flush_lsn(conn, ctx.slot_name)
+
+          if Lsn.compare(confirmed, lsn2) == :gt do
+            {:halt, confirmed}
+          else
+            {:cont, confirmed}
+          end
+        end)
+
+      # The unconfirmed txn2 must hold the flush boundary back: acknowledging
+      # WAL past it means PG can drop WAL that no shape has durably stored.
+      assert Lsn.compare(confirmed, lsn2) != :gt,
+             "confirmed_flush_lsn #{confirmed} advanced past the unflushed txn at #{lsn2}"
+    end
   end
 
   defp get_confirmed_flush_lsn(conn, slot_name) do

--- a/packages/sync-service/test/electric/postgres/replication_client_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client_test.exs
@@ -629,6 +629,54 @@ defmodule Electric.Postgres.ReplicationClientTest do
       assert Lsn.compare(confirmed, lsn2) != :gt,
              "confirmed_flush_lsn #{confirmed} advanced past the unflushed txn at #{lsn2}"
     end
+
+    @tag with_empty_publication?: true
+    @tag database_settings: ["wal_sender_timeout='3s'"]
+    test "keepalives keep advancing acks past txns that are confirmed during processing",
+         %{db_conn: conn} = ctx do
+      Postgrex.query!(conn, "ALTER PUBLICATION #{ctx.slot_name} SET TABLE serial_ids", [])
+
+      # The confirming handler notifies the flush boundary from within event
+      # processing, before the reply — like the ShapeLogCollector does for a
+      # transaction that affects no shapes. Such transactions must not stall
+      # the keepalive-driven slot advance. No further notifications arrive
+      # after the reply, so the up-to-date state must be recomputed once the
+      # transaction is acknowledged; the acks reach PG via the client's
+      # periodic status updates (wal_sender_timeout/3, hence the 3s setting).
+      replication_opts =
+        Keyword.put(
+          ctx.replication_opts,
+          :handle_event,
+          {__MODULE__, :test_handle_event_confirming_async, [self()]}
+        )
+
+      start_client(ctx, replication_opts: replication_opts)
+
+      Postgrex.query!(conn, "INSERT INTO serial_ids (id) VALUES (1)", [])
+      assert {lsn1, %NewRecord{record: %{"id" => "1"}}} = receive_tx_change_with_lsn()
+
+      # WAL produced outside the publication arrives as keepalives and must
+      # keep being acknowledged past the already-confirmed transaction.
+      for _ <- 1..10, do: insert_item(conn, "test value")
+
+      confirmed =
+        Enum.reduce_while(1..40, nil, fn _, _ ->
+          Process.sleep(100)
+
+          confirmed = get_confirmed_flush_lsn(conn, ctx.slot_name)
+
+          if Lsn.to_integer(confirmed) > Lsn.to_integer(lsn1) + 1 do
+            {:halt, confirmed}
+          else
+            {:cont, confirmed}
+          end
+        end)
+
+      # If the up-to-date state were only recomputed when the notification
+      # arrives, the ack would stall at exactly lsn1 + 1.
+      assert Lsn.to_integer(confirmed) > Lsn.to_integer(lsn1) + 1,
+             "confirmed_flush_lsn #{confirmed} stalled at the confirmed txn at #{lsn1}"
+    end
   end
 
   defp get_confirmed_flush_lsn(conn, slot_name) do
@@ -884,6 +932,23 @@ defmodule Electric.Postgres.ReplicationClientTest do
   # Async variant for the $gen_call-based apply_event. Runs the handler inline
   # (in the gen_statem process) and queues the result as a {ref, result} message.
   # Since these test handlers are fast (no delay), this doesn't block keepalives.
+  # Like test_handle_event_async, but confirms a committed transaction's flush
+  # boundary from within event processing, before replying — mirroring the
+  # ShapeLogCollector's behaviour for a transaction that affects no shapes.
+  # Runs inside the replication client process, so send(self(), ...) puts the
+  # notification in the client's mailbox ahead of the handler's reply.
+  def test_handle_event_confirming_async(
+        %TransactionFragment{commit: commit, lsn: lsn} = event,
+        test_pid
+      )
+      when not is_nil(commit) do
+    send(self(), {:flush_boundary_updated, Lsn.to_integer(lsn)})
+    test_handle_event_async(event, test_pid)
+  end
+
+  def test_handle_event_confirming_async(event, test_pid),
+    do: test_handle_event_async(event, test_pid)
+
   def test_handle_event_async(event, test_pid) do
     ref = make_ref()
 


### PR DESCRIPTION
Keepalives could acknowledge WAL past a transaction whose storage flush hadn't been confirmed yet: `flush_up_to_date?` was only cleared while the decoder was mid-transaction, which never happens for a transaction that fits into a single commit-carrying fragment (fewer changes than `max_batch_size`, no `Relation` message). A crash in the window between such a transaction's commit and its async storage flush loses it permanently — the slot's `confirmed_flush_lsn` is already past it. It also means a stuck flush pipeline gets acked past instead of retaining WAL under small-transaction-only traffic.

Introduced by the operation batching refactor in #3483 (`33fbc857f`, first shipped in `@core/sync-service@1.2.7`): before it, the flag was cleared on every transaction's first protocol message; the refactor's buffering path skips the flag update, leaving dispatch-at-commit as the only touchpoint — when the decoder is already out of the transaction.

The fix makes the flag derived state: the client is up to speed exactly when the flush tracker has confirmed the last seen transaction, recomputed whenever either LSN moves. The first commit adds a regression test that fails on `main`; the second commit fixes it and adds a test for the confirmation-during-processing ordering that keeps no-shape transactions from stalling the keepalive-driven slot advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
