### PR TITLE
fix(client): handle stream start rejection in subscribe

### DIFF
--- a/.changeset/handle-shape-stream-start-errors.md
+++ b/.changeset/handle-shape-stream-start-errors.md
@@ -1,0 +1,6 @@
+---
+"@electric-sql/client": patch
+---
+
+Prevent subscription startup failures from also surfacing as unhandled promise
+rejections after they are delivered to the subscriber error callback.

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -1825,7 +1825,12 @@ export class ShapeStream<T extends Row<unknown> = Row>
     const subscriptionId = {}
 
     this.#subscribers.set(subscriptionId, [callback, onError])
-    if (!this.#started) this.#start()
+    if (!this.#started) {
+      this.#start().catch(() => {
+        // Errors from #start are handled internally via onError.
+        // This catch prevents unhandled promise rejection in Node/Bun.
+      })
+    }
 
     return () => {
       this.#subscribers.delete(subscriptionId)

--- a/packages/typescript-client/test/stream.test.ts
+++ b/packages/typescript-client/test/stream.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   ShapeStream,
+  FetchError,
   isChangeMessage,
   isControlMessage,
   Message,
@@ -24,6 +25,36 @@ describe(`ShapeStream`, () => {
   })
 
   afterEach(() => aborter.abort())
+
+  it(`does not create an unhandled rejection when a subscriber handles an error`, async () => {
+    const unhandledRejections: unknown[] = []
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason)
+    }
+    process.on(`unhandledRejection`, onUnhandledRejection)
+
+    try {
+      const stream = new ShapeStream({
+        url: shapeUrl,
+        params: { table: `test` },
+        signal: aborter.signal,
+        fetchClient: async () =>
+          new Response(undefined, {
+            status: 401,
+          }),
+      })
+
+      const subscriberError = new Promise<Error>((resolve) => {
+        stream.subscribe(() => {}, resolve)
+      })
+
+      await expect(subscriberError).resolves.toBeInstanceOf(FetchError)
+      await resolveInMacrotask(undefined)
+      expect(unhandledRejections).toEqual([])
+    } finally {
+      process.off(`unhandledRejection`, onUnhandledRejection)
+    }
+  })
 
   it(`requestSnapshot waits for snapshot messages to be published to subscribers before resolving`, async () => {
     const snapshotRow = {


### PR DESCRIPTION
## Summary

- handle the fire-and-forget start promise created by ShapeStream.subscribe
- keep fatal errors delivered through the subscriber error callback without also producing a process-level unhandled rejection
- add a regression test for the Node/Bun failure path
- include the required patch changeset for @electric-sql/client

Fixes #4736

## Validation

- 35 ShapeStream unit tests passed
- TypeScript client typecheck passed
- TypeScript client build passed
- TypeScript client stylecheck passed
- required package changeset check passed
- Prettier and lint-staged passed