### PR TITLE
docs(website): add Resend and Plausible to subprocessor list

### DIFF
--- a/website/about/legal/subprocessors.md
+++ b/website/about/legal/subprocessors.md
@@ -8,7 +8,7 @@ outline: deep
 
 # Subprocessor List
 
-Last Updated: March 17, 2026
+Last Updated: July 23, 2026
 
 Electric DB Inc. ("Electric") uses the following third-party subprocessors to provide the Electric Services. This list is maintained in accordance with our [Data Processing Addendum](/about/legal/dpa).
 
@@ -60,6 +60,13 @@ If you have questions, contact us at [support@electric-sql.com](mailto:support@e
 | Subprocessor | Purpose | Data Processed | Location |
 | --- | --- | --- | --- |
 | PostHog, Inc. (PostHog Cloud — US) | Website and product analytics | User identifiers, device data, usage data, online identifiers (see [Cookie Policy](/about/legal/privacy#cookie-policy)) | United States |
+| Plausible Insights OÜ (Plausible Analytics) | Privacy-friendly website analytics (cookieless) | De-identified device and usage data | European Union |
+
+## Email delivery
+
+| Subprocessor | Purpose | Data Processed | Location |
+| --- | --- | --- | --- |
+| Resend, Inc. | Transactional email delivery | Recipient email addresses, email content (e.g. invitations and account notifications) | United States |
 
 ## Authentication
 


### PR DESCRIPTION
## What

Adds two service providers that were missing from the published subprocessor list at `website/about/legal/subprocessors.md`:

- **Resend, Inc.** — transactional email delivery (invitations, account notifications); processes recipient email addresses and email content. Added under a new *Email delivery* section.
- **Plausible Insights OÜ (Plausible Analytics)** — cookieless, privacy-friendly website analytics, EU-hosted. Added under *Analytics*.

Also bumps the *Last Updated* date to July 23, 2026.

## Why

Both services are in active use (Resend via the admin API's transactional email sending, Plausible on the website) but were not reflected in the published list. This brings the list in line with actual data flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)