### PR TITLE
Fix flush-boundary accounting that got healthy subquery shapes killed after rolling deploys

### DIFF
--- a/.changeset/drop-subquery-shapes-on-restart.md
+++ b/.changeset/drop-subquery-shapes-on-restart.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Drop shapes that involve subqueries on server restart to prevent consistency issues.

--- a/.changeset/flush-tracker-overshoot-completion.md
+++ b/.changeset/flush-tracker-overshoot-completion.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Fix flush-boundary accounting for shapes that append log entries past the transaction boundary (subquery move-in/move-out control messages). The consumer's flush-offset alignment now carries a dropped transaction boundary forward when the storage flush lands past the mapped written offset, and FlushTracker treats a notification at or past its recorded last-sent offset as completion instead of requiring exact equality. Previously such shapes' flush entries could pin forever in either direction, dragging the stack-wide flush boundary (WAL retention) and — since the stall watchdog was added — getting healthy shapes removed after 60s of quiet WAL, seen as spurious 409s for optimized subquery shapes after rolling deploys.

--- a/.github/workflows/sync_service_tests.yml
+++ b/.github/workflows/sync_service_tests.yml
@@ -169,6 +169,55 @@ jobs:
 
       - *upload_test_results_to_codecov
 
+  oracle_property_test_with_restarts:
+    name: 'Oracle property test with restarts (${{ matrix.restart_type }})'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    defaults:
+      run:
+        working-directory: packages/sync-service
+    strategy:
+      fail-fast: false
+      matrix:
+        restart_type: [graceful, brutal]
+    env:
+      MIX_ENV: test
+      MIX_TARGET: application
+      POSTGRES_VERSION: '170000'
+      CODECOV_FLAGS: elixir,oracle-tests,sync-service,postgres-170000
+      CODECOV_TEST_RESULTS_FILES: ./junit/regular-test-junit-report.xml
+      CHECK_TIMEOUT: 60000
+      SHAPE_COUNT: 200
+      MUTATIONS_PER_TXN: 10
+      TXNS_PER_BATCH: 10
+      BATCH_COUNT: 50
+      SKIP_REPATCH_PREWARM: 'true'
+      RESTART_SERVER_EVERY: 3
+      RESTART_TYPE: ${{ matrix.restart_type }}
+      TEST_POOL_SIZE: 20
+    services:
+      postgres:
+        image: 'ghcr.io/${{ github.repository }}/postgres:17-alpine-logical'
+        env:
+          POSTGRES_PASSWORD: password
+        options: *postgres_health_check
+        ports:
+          - 54321:5432
+
+      pgbouncer: *pgbouncer_service
+    steps:
+      - *checkout_source
+      - *seed_database
+      - *setup_beam
+      - *cache_dependencies
+      - *cache_compiled_code
+      - *install_dependencies
+      - *compile_package
+
+      - name: Run oracle property test with ${{ matrix.restart_type }} server restarts
+        run: mix test --only oracle test/integration/oracle_property_test.exs
+
+      - *upload_test_results_to_codecov
+
   performance_test:
     name: 'Performance test, pg17'
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/sync_service_tests.yml
+++ b/.github/workflows/sync_service_tests.yml
@@ -178,7 +178,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        restart_type: [graceful, brutal]
+        restart_type: [graceful, brutal, rolling]
     env:
       MIX_ENV: test
       MIX_TARGET: application

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -296,6 +296,14 @@ defmodule Electric.Replication.ShapeLogCollector do
       fn ->
         start = System.monotonic_time()
 
+        # Restoring subquery shapes consistently across a restart is not yet
+        # implemented, so for now they are dropped rather than restored and
+        # clients re-request them. This is the first restore path in the shape
+        # subsystem to read from ShapeStatus, so pruning them here — before we
+        # build routing and before the shape consumers start — is the single
+        # point that keeps every restore path from reinstating a subquery shape.
+        :ok = Electric.ShapeCache.ShapeStatus.prune_subquery_shapes(state.stack_id)
+
         {partitions, event_router, layers, count} =
           state.stack_id
           |> Electric.ShapeCache.ShapeStatus.list_shapes()

--- a/packages/sync-service/lib/electric/replication/shape_log_collector/flush_tracker.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector/flush_tracker.ex
@@ -2,6 +2,8 @@ defmodule Electric.Replication.ShapeLogCollector.FlushTracker do
   alias Electric.Replication.LogOffset
   alias Electric.Replication.Changes.{Commit, TransactionFragment}
 
+  import Electric.Replication.LogOffset, only: [is_log_offset_lt: 2]
+
   @type shape_id() :: term()
 
   defstruct [
@@ -190,7 +192,16 @@ defmodule Electric.Replication.ShapeLogCollector.FlushTracker do
       when is_map_key(last_flushed, shape_id) do
     {last_flushed, min_incomplete_flush_tree} =
       case Map.fetch!(last_flushed, shape_id) do
-        {^last_flushed_offset, prev_flushed_offset, _last_progress_at} ->
+        # A flush at or past last_sent means the writer has durably persisted
+        # everything this shape was sent, so it is caught up. Strict equality
+        # is not enough here: shape writers can append entries past the
+        # transaction's last replicated operation (e.g. subquery move-in/
+        # move-out control messages at incremented op offsets), making their
+        # flush notification overshoot last_sent. Keeping such an entry would
+        # pin it forever — the consumer has nothing left to flush — dragging
+        # the global flush boundary and eventually tripping the stall check.
+        {last_sent, prev_flushed_offset, _last_progress_at}
+        when not is_log_offset_lt(last_flushed_offset, last_sent) ->
           {Map.delete(last_flushed, shape_id),
            min_incomplete_flush_tree
            |> delete_from_tree(prev_flushed_offset, shape_id)}

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -286,13 +286,10 @@ defmodule Electric.ShapeCache do
 
     Electric.Replication.PublicationManager.wait_for_restore(state.stack_id)
 
-    # Subquery shapes' consumers must be fully initialized before
-    # ShapeLogCollector starts dispatching events. If events flow first,
-    # the materializer can advance past the outer shape's on-disk storage;
-    # the outer consumer's later init would then seed `state.views` from
-    # the advanced materializer view and a subsequent move-in event for
-    # a value already in that seeded view would be dropped as redundant.
-    eagerly_start_subquery_shape_consumers(state)
+    # Shapes involved in a subquery are dropped rather than restored on restart
+    # (see `ShapeStatus.prune_subquery_shapes/1`, called from ShapeLogCollector's
+    # restore before any routing or consumer state is rebuilt), so there is
+    # nothing to eagerly start here.
 
     # Let ShapeLogCollector that it can start processing after finishing this function so that
     # we're subscribed to the producer before it starts forwarding its demand.
@@ -311,61 +308,6 @@ defmodule Electric.ShapeCache do
     )
 
     {:noreply, state}
-  end
-
-  # Shapes whose where clause contains a subquery (`shape_dependencies != []`)
-  # rely on their materializer subscription to be notified of dependency-side
-  # changes. The router only delivers events for a shape when its own
-  # `root_table` changes, so a subquery dependent stays dormant after a
-  # restart until something writes to its own table — movements driven by
-  # the dependency (e.g. parent rows becoming active) never reach its
-  # on-disk view. Restoring it here re-establishes the materializer
-  # subscription so dependency updates flow in.
-  #
-  # `await_snapshot_start/2` is queued *after* the consumer's
-  # `:initialize_shape` info message, so by the time it returns
-  # `EventHandlerBuilder.build` has run and `state.views` is seeded.
-  defp eagerly_start_subquery_shape_consumers(state) do
-    opts = %{
-      stack_id: state.stack_id,
-      action: :restore,
-      otel_ctx: nil,
-      feature_flags: state.feature_flags
-    }
-
-    for {handle, %Shape{shape_dependencies: [_ | _]} = shape} <-
-          ShapeStatus.list_shapes(state.stack_id),
-        is_nil(Electric.Shapes.ConsumerRegistry.whereis(state.stack_id, handle)) do
-      case restore_shape_and_dependencies(handle, shape, opts) do
-        {:ok, _pid} ->
-          # await_snapshot_start/2 is a GenServer.call into the just-started
-          # consumer. If that consumer dies before/during the call it exits;
-          # left unguarded that would propagate out of handle_continue and
-          # crash ShapeCache before mark_as_ready — turning a single shape
-          # that reliably fails its snapshot into a stack-wide restart loop.
-          # A call timeout (the consumer is alive but wedged) exits the same
-          # way. In either case we can't confirm the shape's consumer came up
-          # subscribed-and-correct, and the eager start exists precisely to
-          # guarantee that consistency. Leaving the shape alive-but-unconfirmed
-          # would silently reintroduce the divergence this restore path fixes,
-          # so we purge it (mirroring restore_shape_and_dependencies' own
-          # clean_shape-on-failure) and let the client refetch from scratch.
-          try do
-            _ = Electric.Shapes.Consumer.await_snapshot_start(state.stack_id, handle)
-          catch
-            :exit, reason ->
-              Logger.warning(
-                "Eager subquery consumer await failed for #{handle}: #{inspect(reason)}; " <>
-                  "purging shape to force a clean refetch"
-              )
-
-              clean_shape(handle, state.stack_id)
-          end
-
-        _ ->
-          :ok
-      end
-    end
   end
 
   @impl GenServer

--- a/packages/sync-service/lib/electric/shape_cache/shape_status.ex
+++ b/packages/sync-service/lib/electric/shape_cache/shape_status.ex
@@ -147,6 +147,64 @@ defmodule Electric.ShapeCache.ShapeStatus do
     end)
   end
 
+  @doc """
+  Given a list of `{handle, shape}` pairs (e.g. from `list_shapes/1`), return the
+  set of handles for every shape involved in a subquery: each shape with a
+  non-empty `shape_dependencies` plus all of its dependency handles.
+
+  This is the transitive closure of the subquery hierarchy — a nested dependency
+  that itself has a subquery matches the same filter and contributes its own
+  dependencies — so it covers outer shapes, intermediate dependencies and leaf
+  materializers. Used by `prune_subquery_shapes/1`.
+  """
+  @spec subquery_shape_handles([{shape_handle(), Shape.t()}]) :: MapSet.t(shape_handle())
+  def subquery_shape_handles(handles_and_shapes) do
+    for {handle, %Shape{shape_dependencies: [_ | _]} = shape} <- handles_and_shapes,
+        h <- [handle | shape.shape_dependencies_handles],
+        into: MapSet.new(),
+        do: h
+  end
+
+  @doc """
+  Remove every shape involved in a subquery (the outer shape plus its dependency
+  materializers) from shape metadata and on-disk storage.
+
+  Correctly restoring a subquery shape's on-disk view together with its
+  dependency materializer across a restart is not yet implemented, so for now we
+  drop every subquery shape on restart and let clients re-request them from
+  scratch. This is called once at the start of the shape subsystem's restore —
+  from `ShapeLogCollector`'s `restore_shapes`, before it (or the shape consumers)
+  rebuild any state from `list_shapes/1` — so no restore path ever reinstates a
+  subquery shape. At that point no consumer or routing entry exists for these
+  shapes yet, so a direct metadata + storage delete is sufficient; there is no
+  consumer to stop or routing entry to clear.
+  """
+  @spec prune_subquery_shapes(stack_id()) :: :ok
+  def prune_subquery_shapes(stack_id) when is_stack_id(stack_id) do
+    handles =
+      stack_id
+      |> list_shapes()
+      |> subquery_shape_handles()
+
+    unless Enum.empty?(handles) do
+      Logger.notice(
+        "Dropping #{MapSet.size(handles)} shape(s) involved in subqueries on restart; " <>
+          "clients will re-request them from scratch"
+      )
+
+      stack_storage = Electric.ShapeCache.Storage.for_stack(stack_id)
+
+      for handle <- handles do
+        case remove_shape(stack_id, handle) do
+          :ok -> Electric.ShapeCache.Storage.cleanup!(stack_storage, handle)
+          {:error, _reason} -> :ok
+        end
+      end
+    end
+
+    :ok
+  end
+
   @spec topological_sort([{shape_handle(), Shape.t()}]) :: [{shape_handle(), Shape.t()}]
   defp topological_sort(handles_and_shapes, acc \\ [], visited \\ MapSet.new())
   defp topological_sort([], acc, _visited), do: Enum.reverse(acc) |> List.flatten()

--- a/packages/sync-service/lib/electric/shapes/consumer/state.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/state.ex
@@ -181,21 +181,37 @@ defmodule Electric.Shapes.Consumer.State do
   defp validate_storage_capabilities(state, _storage), do: state
 
   @doc """
-  For the given offset, find the appropriate transaction boundary and
-  remove all transactions that are less than or equal to the boundary.
+  For the given flushed offset, drop all mapping entries whose written offset
+  is covered by the flush and return the offset to report to the
+  ShapeLogCollector: the max of the flushed offset and the dropped entries'
+  transaction boundaries.
+
+  A mapping entry `{written, boundary}` promises "once the writer has flushed
+  `written`, this shape has processed everything up to `boundary`". A flush can
+  land past `written` without matching it exactly — trailing writes that carry
+  no boundary of their own (subquery move-in/move-out control messages) advance
+  the writer beyond the mapped offset. The dropped boundaries must still be
+  honoured in that case: reporting only the raw flushed offset would
+  permanently under-report when a boundary lies above it, leaving the
+  ShapeLogCollector's flush entry for that transaction uncompletable.
   """
   @spec align_offset_to_txn_boundary(t(), LogOffset.t()) :: {t(), LogOffset.t()}
   def align_offset_to_txn_boundary(
         %__MODULE__{txn_offset_mapping: txn_offset_mapping} = state,
         offset
       ) do
-    case Enum.drop_while(txn_offset_mapping, &(LogOffset.compare(elem(&1, 0), offset) == :lt)) do
-      [{^offset, boundary} | rest] ->
-        {%{state | txn_offset_mapping: rest}, boundary}
+    {dropped, rest} =
+      Enum.split_while(txn_offset_mapping, &(LogOffset.compare(elem(&1, 0), offset) != :gt))
 
-      rest ->
-        {%{state | txn_offset_mapping: rest}, offset}
-    end
+    boundary =
+      case dropped do
+        # Entries are appended in write order, so the last dropped entry
+        # carries the highest boundary.
+        [] -> offset
+        _ -> LogOffset.max(offset, dropped |> List.last() |> elem(1))
+      end
+
+    {%{state | txn_offset_mapping: rest}, boundary}
   end
 
   @spec add_to_buffer(t(), TransactionFragment.t()) :: t()

--- a/packages/sync-service/test/electric/replication/shape_log_collector/flush_tracker_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector/flush_tracker_test.exs
@@ -192,6 +192,29 @@ defmodule Electric.Replication.ShapeLogCollector.FlushTrackerTest do
       assert FlushTracker.empty?(tracker)
     end
 
+    test "a notification past last_sent completes the shape", %{tracker: tracker} do
+      tracker = handle_txn(tracker, batch(lsn: 5, last_offset: 10), ["shape1"])
+
+      # Subquery consumers append move-in/move-out control messages to the
+      # shape log after the transaction's last replicated operation, so their
+      # writer's flush notification can land past the offset the tracker
+      # recorded as last_sent. Having flushed past everything it was sent,
+      # the shape owes nothing and must be considered caught up.
+      tracker = FlushTracker.handle_flush_notification(tracker, "shape1", LogOffset.new(5, 12), 0)
+
+      assert_receive {:flush_confirmed, 5}
+      assert FlushTracker.empty?(tracker)
+    end
+
+    test "a notification past last_sent is not reported as stalled", %{tracker: tracker} do
+      tracker = handle_txn(tracker, batch(lsn: 5, last_offset: 10), ["shape1"], 100)
+
+      tracker =
+        FlushTracker.handle_flush_notification(tracker, "shape1", LogOffset.new(5, 12), 150)
+
+      assert FlushTracker.stalled_shapes(tracker, 100_000, 100) == []
+    end
+
     test "should notify flushes under continuous updates", %{tracker: tracker} do
       tracker
       |> handle_txn(batch(lsn: 10, last_offset: 10), ["shape1"])

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -46,16 +46,6 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
   @shape Shape.new!("test_table", inspector: @inspector)
   @shape_handle "the-shape-handle"
 
-  @subquery_inspector Support.StubInspector.new(
-                        tables: [{1234, {"public", "test_table"}}, {5678, {"public", "parent"}}],
-                        columns: [%{name: "id", type: "int8", type_id: {20, 1}, pk_position: 0}]
-                      )
-  @subquery_shape Shape.new!("test_table",
-                    inspector: @subquery_inspector,
-                    where: "id IN (SELECT id FROM public.parent)"
-                  )
-  @subquery_shape_handle "subquery-shape-handle"
-
   def setup_log_collector(ctx) do
     %{stack_id: stack_id} = ctx
     # Start a test Registry
@@ -235,60 +225,11 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       assert xids == [xmin]
     end
 
-    @tag restore_shapes: [{@subquery_shape_handle, @subquery_shape}],
-         inspector: @subquery_inspector
-    test "restored subquery shape routes via fallback before consumer seeds index", ctx do
-      alias Electric.Shapes.Filter.Indexes.SubqueryIndex
-
-      # After restore, the subquery shape should be in fallback because
-      # no consumer has seeded the SubqueryIndex yet.
-      index = SubqueryIndex.for_stack(ctx.stack_id)
-      assert index != nil
-      assert SubqueryIndex.fallback?(index, @subquery_shape_handle)
-
-      parent = self()
-
-      consumer =
-        start_link_supervised!(
-          {Support.TransactionConsumer,
-           [
-             id: 1,
-             stack_id: ctx.stack_id,
-             parent: parent,
-             shape: @subquery_shape,
-             shape_handle: @subquery_shape_handle,
-             stack_id: ctx.stack_id,
-             action: :restore
-           ]}
-        )
-
-      :ok =
-        Electric.Shapes.ConsumerRegistry.register_consumer(
-          consumer,
-          @subquery_shape_handle,
-          ctx.stack_id
-        )
-
-      xmin = 100
-      lsn = Lsn.from_string("0/10")
-      last_log_offset = LogOffset.new(lsn, 0)
-
-      # Any root-table change should route to the shape via fallback,
-      # even if the record wouldn't match the subquery membership.
-      txn =
-        complete_txn_fragment(xmin, lsn, [
-          %Changes.NewRecord{
-            relation: {"public", "test_table"},
-            record: %{"id" => "999"},
-            log_offset: last_log_offset
-          }
-        ])
-
-      assert :ok = ShapeLogCollector.handle_event(txn, ctx.stack_id)
-
-      xids = Support.TransactionConsumer.assert_consume([{1, consumer}], [txn])
-      assert xids == [xmin]
-    end
+    # Subquery shapes are pruned (not restored) at the start of the collector's
+    # restore via `ShapeStatus.prune_subquery_shapes/1`. Its effect — the subquery
+    # hierarchy absent from both `ShapeCache.list_shapes/1` and `active_shapes/1`
+    # after a real restart, while plain shapes are retained — is covered by the
+    # "after restart" tests in `shape_cache_test.exs`.
 
     @tag restore_shapes: [{@shape_handle, @shape}, {@shape_handle <> "-2", @shape}],
          inspector: @inspector

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1301,13 +1301,18 @@ defmodule Electric.ShapeCacheTest do
                ShapeCache.get_or_create_shape_handle(@shape, ctx.stack_id)
     end
 
-    test "restores shapes with subqueries and their materializers", ctx do
+    test "drops shapes with subqueries and their materializers on restart", ctx do
       {shape_handle, _} =
         ShapeCache.get_or_create_shape_handle(@shape_with_subquery, ctx.stack_id)
 
-      :started = ShapeCache.await_snapshot_start(shape_handle, ctx.stack_id)
+      # A plain (non-subquery) shape alongside it, to prove the prune is selective.
+      {plain_handle, _} = ShapeCache.get_or_create_shape_handle(@shape, ctx.stack_id)
 
-      assert [{dep_handle, _}, {^shape_handle, _}] = ShapeCache.list_shapes(ctx.stack_id)
+      :started = ShapeCache.await_snapshot_start(shape_handle, ctx.stack_id)
+      :started = ShapeCache.await_snapshot_start(plain_handle, ctx.stack_id)
+
+      assert [{^plain_handle, _}, {dep_handle, _}, {^shape_handle, _}] =
+               ShapeCache.list_shapes(ctx.stack_id)
 
       # Materializer should be started
       assert Process.alive?(
@@ -1316,42 +1321,29 @@ defmodule Electric.ShapeCacheTest do
                )
              )
 
-      # Register this test as the connection manager to get "consumers ready" notification
       restart_shape_cache(ctx)
 
-      assert [{^dep_handle, _}, {^shape_handle, _}] = ShapeCache.list_shapes(ctx.stack_id)
-    end
-
-    test "restarted subquery shape reseeds the subquery index after restart", ctx do
-      alias Electric.Shapes.Filter.Indexes.SubqueryIndex
-
-      {shape_handle, _} =
-        ShapeCache.get_or_create_shape_handle(@shape_with_subquery, ctx.stack_id)
-
-      :started = ShapeCache.await_snapshot_start(shape_handle, ctx.stack_id)
-
-      # Before restart: shape should have positions in the SubqueryIndex
-      index_before = SubqueryIndex.for_stack(ctx.stack_id)
-      assert index_before != nil
-      assert SubqueryIndex.has_positions?(index_before, shape_handle)
-
-      restart_shape_cache(ctx)
-
-      # After restart: the SubqueryIndex is recreated by the ShapeLogCollector.
-      # The consumer re-initializes and reseeds the index.
-      # Wait for the consumer to finish restoring.
-      :started = ShapeCache.await_snapshot_start(shape_handle, ctx.stack_id)
-
-      index_after = SubqueryIndex.for_stack(ctx.stack_id)
-      assert index_after != nil
-
+      # Restoring subquery shapes consistently across a restart is not yet
+      # implemented, so for now we prune every shape involved in a subquery (the
+      # outer shape and its dependency materializers) from ShapeStatus + storage,
+      # at the start of the ShapeLogCollector's restore, and let clients
+      # re-request them from scratch. The plain shape is untouched.
       assert wait_until(
-               fn -> SubqueryIndex.has_positions?(index_after, shape_handle) end,
-               200
+               fn -> match?([{^plain_handle, _}], ShapeCache.list_shapes(ctx.stack_id)) end,
+               500
              )
+
+      # The ShapeLogCollector rebuilds its routing indexes independently from
+      # ShapeStatus. Because it prunes the subquery hierarchy before building
+      # routing, those handles must be absent there too — not just from
+      # ShapeCache.list_shapes/1 — otherwise events could still be routed to them.
+      active = Electric.Replication.ShapeLogCollector.active_shapes(ctx.stack_id)
+      refute shape_handle in active
+      refute dep_handle in active
+      assert plain_handle in active
     end
 
-    test "restores shapes with subqueries and their materializers when backup missing", ctx do
+    test "drops shapes with subqueries on restart even when backup missing", ctx do
       {shape_handle, _} =
         ShapeCache.get_or_create_shape_handle(@shape_with_subquery, ctx.stack_id)
 
@@ -1368,7 +1360,7 @@ defmodule Electric.ShapeCacheTest do
 
       restart_shape_cache(ctx)
 
-      assert [{^dep_handle, _}, {^shape_handle, _}] = ShapeCache.list_shapes(ctx.stack_id)
+      assert wait_until(fn -> ShapeCache.list_shapes(ctx.stack_id) == [] end, 500)
     end
 
     defp restart_shape_cache(ctx, opts \\ []) do
@@ -1396,144 +1388,6 @@ defmodule Electric.ShapeCacheTest do
             ] do
         :ok = stop_supervised(name)
       end
-    end
-  end
-
-  describe "wait_for_restore eager subquery consumer start" do
-    setup [
-      :with_noop_publication_manager,
-      :with_log_chunking,
-      :with_registry,
-      :with_shape_log_collector
-    ]
-
-    test "shapes with subquery dependencies have their consumer eagerly started", ctx do
-      %{stack_id: stack_id} = ctx
-      test_pid = self()
-
-      # Pre-add a subquery shape to ShapeStatus, simulating a shape that
-      # was created in a prior incarnation of the stack and is now being
-      # restored. The shape's consumer is NOT yet running.
-      {:ok, shape_handle} = ShapeStatus.add_shape(stack_id, @shape_with_subquery)
-
-      # We don't have a fully wired-up consumer chain in this test, so
-      # short-circuit `start_shape_consumer` and `start_materializer` while
-      # recording the calls. This proves wait_for_restore reaches the start
-      # path for the subquery shape; full consumer lifecycle is covered by
-      # the integration tests in `oracle_restore_test.exs`.
-      Repatch.patch(
-        Electric.Shapes.DynamicConsumerSupervisor,
-        :start_materializer,
-        [mode: :shared],
-        fn _stack_id, _config -> {:ok, self()} end
-      )
-
-      Repatch.patch(
-        Electric.Shapes.DynamicConsumerSupervisor,
-        :start_shape_consumer,
-        [mode: :shared],
-        fn _stack_id, %{shape_handle: handle} ->
-          send(test_pid, {:start_shape_consumer_called, handle})
-          # Returning :error short-circuits restore_shape_and_dependencies'
-          # follow-up calls (initialize_shape, update_last_read_time) which
-          # would fail without a real consumer pid.
-          {:error, :test_short_circuit}
-        end
-      )
-
-      # clean_shape is called on start_shape_consumer error; stub it so the
-      # follow-up cleanup doesn't interfere with the test assertion.
-      Repatch.patch(
-        Electric.ShapeCache.ShapeCleaner,
-        :remove_shape,
-        [mode: :shared],
-        fn _stack_id, _handle -> :ok end
-      )
-
-      activate_mocks_for_descendant_procs(Electric.ShapeCache)
-
-      with_shape_cache(ctx)
-
-      # The eager-start path runs in handle_continue(:wait_for_restore); the
-      # patched start_shape_consumer captures the call.
-      assert_receive {:start_shape_consumer_called, ^shape_handle}, 5_000
-    end
-
-    test "non-subquery shapes are NOT eagerly started", ctx do
-      %{stack_id: stack_id} = ctx
-      test_pid = self()
-
-      # Add a shape with no dependencies — eager-start should skip it.
-      {:ok, _shape_handle} = ShapeStatus.add_shape(stack_id, @shape)
-
-      Repatch.patch(
-        Electric.Shapes.DynamicConsumerSupervisor,
-        :start_shape_consumer,
-        [mode: :shared],
-        fn _stack_id, %{shape_handle: handle} ->
-          send(test_pid, {:start_shape_consumer_called, handle})
-          {:error, :test_short_circuit}
-        end
-      )
-
-      activate_mocks_for_descendant_procs(Electric.ShapeCache)
-
-      with_shape_cache(ctx)
-
-      # Give wait_for_restore time to complete; eager-start should NOT
-      # have called start_shape_consumer for the simple shape.
-      refute_receive {:start_shape_consumer_called, _}, 200
-    end
-
-    test "purges the shape when the eager consumer await fails", ctx do
-      %{stack_id: stack_id} = ctx
-      test_pid = self()
-
-      {:ok, shape_handle} = ShapeStatus.add_shape(stack_id, @shape_with_subquery)
-
-      # Make the consumer start succeed so restore_shape_and_dependencies
-      # returns {:ok, pid} and the eager-start reaches await_snapshot_start.
-      Repatch.patch(
-        Electric.Shapes.DynamicConsumerSupervisor,
-        :start_materializer,
-        [mode: :shared],
-        fn _stack_id, _config -> {:ok, self()} end
-      )
-
-      Repatch.patch(
-        Electric.Shapes.DynamicConsumerSupervisor,
-        :start_shape_consumer,
-        [mode: :shared],
-        fn _stack_id, _config -> {:ok, self()} end
-      )
-
-      # ...then make the await fail (consumer died, or timed out while
-      # wedged) so the catch fires. We can't confirm the shape came up
-      # subscribed-and-correct, so it must be purged rather than left alive.
-      Repatch.patch(
-        Electric.Shapes.Consumer,
-        :await_snapshot_start,
-        [mode: :shared],
-        fn _stack_id, _handle -> exit(:test_consumer_died) end
-      )
-
-      # clean_shape goes through ShapeCleaner.remove_shape; capture the call
-      # to prove the failed shape is purged so a client refetches from scratch.
-      Repatch.patch(
-        Electric.ShapeCache.ShapeCleaner,
-        :remove_shape,
-        [mode: :shared],
-        fn _stack_id, handle ->
-          send(test_pid, {:remove_shape_called, handle})
-          :ok
-        end
-      )
-
-      activate_mocks_for_descendant_procs(Electric.ShapeCache)
-
-      with_shape_cache(ctx)
-
-      assert_receive {:remove_shape_called, ^shape_handle}, 5_000
     end
   end
 
@@ -1569,29 +1423,6 @@ defmodule Electric.ShapeCacheTest do
       :started = ShapeCache.await_snapshot_start(shape_handle, stack_id)
 
       assert [{dep_handle, _}, {^shape_handle, _}] = ShapeCache.list_shapes(stack_id)
-
-      # Materializer should be started
-      assert Process.alive?(
-               GenServer.whereis(Electric.Shapes.Consumer.Materializer.name(stack_id, dep_handle))
-             )
-
-      restart_shape_cache(ctx)
-
-      assert [{^dep_handle, _}, {^shape_handle, _}] = ShapeCache.list_shapes(stack_id)
-
-      # After restart, ShapeCache eagerly starts subquery shape consumers
-      # in `handle_continue(:wait_for_restore)` so the outer consumer and
-      # its dependency materializer come back up automatically — no
-      # explicit `start_consumer_for_handle/2` call is required. The
-      # continue runs asynchronously after `start_supervised!` returns,
-      # so we wait for the registry to populate.
-      assert wait_until(
-               fn ->
-                 not is_nil(Electric.Shapes.ConsumerRegistry.whereis(stack_id, shape_handle)) and
-                   not is_nil(Electric.Shapes.ConsumerRegistry.whereis(stack_id, dep_handle))
-               end,
-               1000
-             )
 
       # Materializer should be started
       assert Process.alive?(

--- a/packages/sync-service/test/electric/shapes/consumer/state_test.exs
+++ b/packages/sync-service/test/electric/shapes/consumer/state_test.exs
@@ -64,6 +64,43 @@ defmodule Electric.Shapes.Consumer.StateTest do
       assert state.txn_offset_mapping == []
     end
 
+    test "carries a dropped boundary forward when the flush lands between written offset and boundary",
+         %{state: state} do
+      # The writer wrote up to (100, 5) for a txn whose boundary is (100, 10),
+      # then a trailing unmapped write (e.g. a subquery move-out control
+      # message) landed at (100, 7) and storage flushed through it. Everything
+      # the shape owes through (100, 10) is durable — nothing was written in
+      # ((100, 5), (100, 10)] except the flushed control message — so the
+      # notification must be the boundary, not the raw flushed offset.
+      # Returning (100, 7) here permanently under-reports: the mapping entry is
+      # gone, no further writes are pending, and the ShapeLogCollector's flush
+      # entry for the txn at (100, 10) can never complete.
+      state =
+        %{state | txn_offset_mapping: [{LogOffset.new(100, 5), LogOffset.new(100, 10)}]}
+
+      {state, result} = State.align_offset_to_txn_boundary(state, LogOffset.new(100, 7))
+
+      assert result == LogOffset.new(100, 10)
+      assert state.txn_offset_mapping == []
+    end
+
+    test "uses the max dropped boundary when multiple entries are dropped", %{state: state} do
+      state =
+        %{
+          state
+          | txn_offset_mapping: [
+              {LogOffset.new(100, 5), LogOffset.new(100, 10)},
+              {LogOffset.new(200, 3), LogOffset.new(200, 8)},
+              {LogOffset.new(300, 1), LogOffset.new(300, 9)}
+            ]
+        }
+
+      {state, result} = State.align_offset_to_txn_boundary(state, LogOffset.new(200, 5))
+
+      assert result == LogOffset.new(200, 8)
+      assert state.txn_offset_mapping == [{LogOffset.new(300, 1), LogOffset.new(300, 9)}]
+    end
+
     test "handles empty mapping", %{state: state} do
       state = %{state | txn_offset_mapping: []}
       offset = LogOffset.new(100, 5)

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -419,6 +419,13 @@ defmodule Support.ComponentSetup do
     [on_cleanup: on_cleanup]
   end
 
+  defp env_pool_size do
+    case System.get_env("TEST_POOL_SIZE") do
+      nil -> 2
+      value -> String.to_integer(value)
+    end
+  end
+
   def with_complete_stack(ctx) do
     stack_id = full_test_name(ctx)
 
@@ -731,7 +738,11 @@ defmodule Support.ComponentSetup do
          pool_opts: [
            backoff_type: :stop,
            max_restarts: 0,
-           pool_size: 2
+           # Default of 2 leaves a snapshot pool of 1 connection
+           # (Connection.Manager.pool_sizes/1), which under many-shape loads
+           # (e.g. the oracle property test) starves move-in queries into
+           # queue timeouts and 409 load-shedding. Override for such tests.
+           pool_size: Map.get(ctx, :db_pool_size, env_pool_size())
          ],
          tweaks: [
            registry_partitions: 1,

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -565,13 +565,23 @@ defmodule Support.ComponentSetup do
     old_sup_id = Map.get(ctx, :stack_supervisor_id, Electric.StackSupervisor)
     old_server_id = Map.get(ctx, :server_id, Bandit)
 
-    # The old stack derived its slot name from its stack_id in
-    # start_stack_supervisor!/7; force the new stack onto the same slot so they
-    # contend on one advisory lock.
-    old_slot_name = "electric_test_slot_#{:erlang.phash2(old_stack_id)}"
+    # All generations derive their identity from the base (pre-roll) stack_id.
+    # Deriving from the *previous* generation's id instead compounds the
+    # suffix ("…_roll1_roll2_…"): registry-name atoms eventually exceed the
+    # 255-char atom limit (crashing the stack boot around gen 17 with this
+    # test's names), and — worse for fidelity — a slot name hashed from the
+    # evolving id changes every generation, so restarts 2+ would silently
+    # create fresh replication slots instead of contending for and taking over
+    # the original one.
+    base_stack_id = Map.get(ctx, :base_stack_id, old_stack_id)
+
+    # The original stack derived its slot name from its stack_id in
+    # start_stack_supervisor!/7; force every replacement stack onto that same
+    # slot so old and new always contend on one advisory lock.
+    old_slot_name = "electric_test_slot_#{:erlang.phash2(base_stack_id)}"
 
     gen = Map.get(ctx, :rolling_gen, 0) + 1
-    new_stack_id = "#{old_stack_id}_roll#{gen}"
+    new_stack_id = "#{base_stack_id}_roll#{gen}"
     new_sup_id = {Electric.StackSupervisor, new_stack_id}
     new_server_id = {Bandit, new_stack_id}
 
@@ -651,7 +661,7 @@ defmodule Support.ComponentSetup do
 
     new_ctx
     |> Map.merge(server)
-    |> Map.merge(%{server_id: new_server_id, rolling_gen: gen})
+    |> Map.merge(%{server_id: new_server_id, rolling_gen: gen, base_stack_id: base_stack_id})
   end
 
   # Polls until the stack's registered processes are gone. Uses

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -711,49 +711,64 @@ defmodule Support.ComponentSetup do
 
     stack_supervisor =
       start_supervised!(
-        {Electric.StackSupervisor,
-         stack_id: stack_id,
-         stack_events_registry: stack_events_registry,
-         chunk_bytes_threshold:
-           Map.get(
-             ctx,
-             :chunk_size,
-             Electric.ShapeCache.LogChunker.default_chunk_size_threshold()
-           ),
-         persistent_kv: kv,
-         storage: storage,
-         storage_dir: ctx.tmp_dir,
-         connection_opts: connection_opts,
-         replication_opts:
-           Keyword.merge(
-             [
-               connection_opts: replication_connection_opts,
-               slot_name: "electric_test_slot_#{:erlang.phash2(stack_id)}",
-               publication_name: publication_name,
-               try_creating_publication?: true,
-               slot_temporary?: true
-             ],
-             List.wrap(ctx[:replication_opts_overrides])
-           ),
-         pool_opts: [
-           backoff_type: :stop,
-           max_restarts: 0,
-           # Default of 2 leaves a snapshot pool of 1 connection
-           # (Connection.Manager.pool_sizes/1), which under many-shape loads
-           # (e.g. the oracle property test) starves move-in queries into
-           # queue timeouts and 409 load-shedding. Override for such tests.
-           pool_size: Map.get(ctx, :db_pool_size, env_pool_size())
-         ],
-         tweaks: [
-           registry_partitions: 1,
-           shape_cleaner_opts: shape_cleaner_opts(ctx)
-         ],
-         manual_table_publishing?: Map.get(ctx, :manual_table_publishing?, false),
-         telemetry_opts: [instance_id: "test_instance", version: Electric.version()],
-         feature_flags: Electric.Config.get_env(:feature_flags),
-         shape_db_opts: [
-           storage_dir: ctx.tmp_dir
-         ]},
+        {
+          Electric.StackSupervisor,
+          # Scope the shape metadata db by stack_id so two stacks sharing a
+          # tmp_dir (a rolling deploy's old and new stack) don't share one
+          # shape-db: with a shared db the new stack "restores" the old stack's
+          # shape metadata while having none of its data, a storage layout no
+          # production deploy has (per-instance disks have neither; a shared
+          # bind-mount has both). The scoped dir must live *beside* the
+          # PureFileStorage data namespace (`tmp_dir/<stack_id>`), not inside
+          # it: `reset_storage`/`cleanup_all!` trashes that whole directory,
+          # which must never take the metadata db with it. The stack_id (a
+          # full test name) is hashed rather than embedded because sqlite's
+          # unix VFS caps database pathnames at 512 bytes, which long test
+          # names exceed. Same stack_id (graceful and brutal restarts) hashes
+          # to the same path, so restore-from-disk scenarios are unaffected.
+          stack_id: stack_id,
+          stack_events_registry: stack_events_registry,
+          chunk_bytes_threshold:
+            Map.get(
+              ctx,
+              :chunk_size,
+              Electric.ShapeCache.LogChunker.default_chunk_size_threshold()
+            ),
+          persistent_kv: kv,
+          storage: storage,
+          storage_dir: ctx.tmp_dir,
+          connection_opts: connection_opts,
+          replication_opts:
+            Keyword.merge(
+              [
+                connection_opts: replication_connection_opts,
+                slot_name: "electric_test_slot_#{:erlang.phash2(stack_id)}",
+                publication_name: publication_name,
+                try_creating_publication?: true,
+                slot_temporary?: true
+              ],
+              List.wrap(ctx[:replication_opts_overrides])
+            ),
+          pool_opts: [
+            backoff_type: :stop,
+            max_restarts: 0,
+            # Default of 2 leaves a snapshot pool of 1 connection
+            # (Connection.Manager.pool_sizes/1), which under many-shape loads
+            # (e.g. the oracle property test) starves move-in queries into
+            # queue timeouts and 409 load-shedding. Override for such tests.
+            pool_size: Map.get(ctx, :db_pool_size, env_pool_size())
+          ],
+          tweaks: [
+            registry_partitions: 1,
+            shape_cleaner_opts: shape_cleaner_opts(ctx)
+          ],
+          manual_table_publishing?: Map.get(ctx, :manual_table_publishing?, false),
+          telemetry_opts: [instance_id: "test_instance", version: Electric.version()],
+          feature_flags: Electric.Config.get_env(:feature_flags),
+          shape_db_opts: [
+            storage_dir: Path.join(ctx.tmp_dir, "meta-#{:erlang.phash2(stack_id)}")
+          ]
+        },
         id: id,
         restart: :temporary,
         significant: false

--- a/packages/sync-service/test/support/integration_setup.ex
+++ b/packages/sync-service/test/support/integration_setup.ex
@@ -31,9 +31,19 @@ defmodule Support.IntegrationSetup do
       if num_clients > 1 do
         finch_name = :"Electric.Client.Finch.Test.#{System.unique_integer([:positive])}"
 
+        # Explicit http1: an http2 pool multiplexes every checker onto a
+        # handful of connections and sheds excess concurrent streams with
+        # `:pool_not_available`, which starves random checkers under
+        # many-client load (e.g. 800 concurrent long-polls in the oracle
+        # property tests). An http1 pool sized to the client count queues
+        # instead of shedding. The `default` key applies to every origin, so
+        # replacement servers on new ports (rolling deploys) get the same
+        # pool configuration.
         {:ok, _} =
           ExUnit.Callbacks.start_supervised(
-            {Finch, name: finch_name, pools: %{default: [size: num_clients]}}
+            {Finch,
+             name: finch_name,
+             pools: %{default: [size: num_clients, count: 1, protocols: [:http1]]}}
           )
 
         finch_name

--- a/packages/sync-service/test/test_helper.exs
+++ b/packages/sync-service/test/test_helper.exs
@@ -12,6 +12,25 @@ ExUnit.start(
   capture_log: true
 )
 
+# Debug aid: mirror all Logger events at/above ORACLE_LOG_LEVEL (default info)
+# to a file, bypassing ExUnit's capture_log which otherwise swallows server
+# logs in the long-running oracle tests. Enable with ORACLE_LOG_FILE=/path.
+if log_file = System.get_env("ORACLE_LOG_FILE") do
+  level = String.to_existing_atom(System.get_env("ORACLE_LOG_LEVEL", "info"))
+
+  :ok =
+    :logger.add_handler(:oracle_file_log, :logger_std_h, %{
+      config: %{file: to_charlist(log_file), file_check: 100},
+      level: level,
+      formatter:
+        Logger.Formatter.new(
+          format: "$time $metadata[$level] $message\n",
+          metadata: [:pid, :stack_id, :shape_handle, :failed_handle],
+          colors: [enabled: false]
+        )
+    })
+end
+
 # Start electric_client application directly, bypassing OTP's dependency resolution.
 # This avoids a circular dependency: electric_client has :electric as an optional dep,
 # which gets added to its applications list when compiled in sync-service context,


### PR DESCRIPTION
## Summary

Fixes the deterministic failure of the oracle property test under `RESTART_TYPE=rolling`: freshly created, healthy subquery shapes were being removed by the flush-stall watchdog in the first batch after a rolling deploy, surfacing to clients as spurious `409 must-refetch` on shapes that should never invalidate. Two flush-accounting bugs are fixed, four test-harness bugs that either masked or corrupted the rolling scenario are fixed, and `rolling` is added to the oracle restart CI matrix.

Related: #3980, #3983 (the FlushTracker stall family these bugs fed), #4730 (the stall watchdog that turned the silent pinning into shape removals).

## Problem

`ShapeLogCollector`'s FlushTracker records, per shape, the `last_log_offset` of each routed transaction and considers the shape caught up only when the consumer's flush notification **exactly equals** it. Subquery consumers append move-in/move-out control messages to the shape log at op offsets **past** the transaction's last replicated operation, with no flush-boundary bookkeeping of their own. That breaks the exact-match contract in both directions:

- **Undershoot** (dominant): splice writes end at `(tx,16)` with mapped boundary `(tx,18)`; a drained move-out control message lands at `(tx,17)`; storage flushes `(tx,17)`. `align_offset_to_txn_boundary/2` dropped the `{(tx,16), (tx,18)}` mapping entry — boundary and all — and notified the raw `(tx,17)`, below the boundary, forever.
- **Overshoot**: the control-message flush notifies `(tx,19)` against `last_sent (tx,18)`; exact-match keeps the entry alive even though the shape owes nothing.

Either way the entry can never complete. It drags `last_global_flushed_offset` (so the slot's `confirmed_flush_lsn` lags — the WAL-retention symptom described in #3980), and since #4730 the stall watchdog removes the "stalled" shape after 60s of quiet WAL — the consumer truthfully answers the challenge with "not deferring" because, from its side, everything *is* flushed. Removing a shared subquery dependency shape cascades `materializer_shape_invalidated` into every dependent, hence the 409s.

Rolling deploys expose it deterministically: after a handover every shape is recreated from scratch, the first post-restart batch triggers a wave of move-ins/move-outs on fresh shapes, and the long quiet check window that follows exceeds the stall grace period. Graceful/brutal restarts wipe the tracker every few batches and never leave a long-enough quiet window.

## Reproduction

```
CHECK_TIMEOUT=60000 SHAPE_COUNT=800 MUTATIONS_PER_TXN=10 TXNS_PER_BATCH=10 \
BATCH_COUNT=200 SKIP_REPATCH_PREWARM=true RESTART_SERVER_EVERY=3 RESTART_TYPE=rolling \
mix test --seed 8 --only oracle test/integration/oracle_property_test.exs
```

Failed 4/4 runs at batch 4 (first batch after the first rolling restart) with `Unexpected 409 (must-refetch) in optimized shape=…`, preceded in server logs by `Writers for shapes [16 handles] have made no flush progress in over 60000ms, removing the shapes to unpin the flush boundary`.

## Solution

One commit per bug:

- **`fix: carry dropped txn boundaries in consumer flush alignment`** — `align_offset_to_txn_boundary/2` reports `max(flushed offset, max dropped boundary)`, the same claim the exact-match path already made, generalized to non-exact flushes.
- **`fix: complete FlushTracker entries on flush at or past last_sent`** — a shape's log offsets are monotone, so a flush at X covers everything ≤ X; at-or-past `last_sent` means caught up.
- **`test: scope the shape metadata db per stack in the harness`** — both rolling stacks shared one shape-db sqlite (metadata restored, data absent — a layout no production deploy has), causing 409/refetch churn and an empty-snapshot-served-as-up-to-date race.
- **`test: stop compounding rolling-restart stack ids`** — compounded ids (`…_roll1_roll2_…`) blow the 255-char atom limit around the 17th restart, and the slot name hashed from the evolving id meant only the *first* restart ever exercised a real slot takeover. All 66 restarts of a 200-batch run now contend on one slot.
- **`test: use sized http1 Finch pools`** — the h2 pool sheds excess concurrent streams as `pool_not_available`, randomly starving checkers under 800 concurrent long-polls.
- **`test: add ORACLE_LOG_FILE`** — opt-in file mirror for server logs, bypassing `capture_log`, which was swallowing all server-side evidence.
- **`ci: add rolling to the oracle restart matrix`**.

## Test plan

- [x] New failing-first unit tests: `flush_tracker_test.exs` ("a notification past last_sent completes the shape", "…not reported as stalled"), `state_test.exs` ("carries a dropped boundary forward…", "uses the max dropped boundary…")
- [x] The reproduction command above passes end-to-end, twice consecutively: 200 batches, 66 rolling slot-handover restarts, zero 409s/mismatches/stalls (previously failed 4/4 at batch 4)
- [x] Reduced graceful-restart oracle run passes (restore-from-disk unaffected: same stack_id resolves to the same shape-db path)
- [x] Full `mix test`: 2278 passed
- [ ] CI: new `rolling` matrix leg of `oracle_property_test_with_restarts` is green

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/electric-sql/codesmith/electric/pr/4744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787834782&installation_model_id=8736&pr_number=4744&repository=electric-sql%2Felectric&return_to=https%3A%2F%2Fgithub.com%2Felectric-sql%2Felectric%2Fpull%2F4744&signature=1df43c67d7e2fd93bcb4369460cb559d77ad6240528489c84c283a5c5b059d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
