### PR TITLE
Add TCP keepalive options for database connections

### DIFF
--- a/.changeset/db-tcp-keepalive.md
+++ b/.changeset/db-tcp-keepalive.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add `ELECTRIC_DATABASE_TCP_KEEPALIVE_IDLE`, `ELECTRIC_DATABASE_TCP_KEEPALIVE_INTERVAL`, `ELECTRIC_DATABASE_TCP_KEEPALIVE_COUNT` and `ELECTRIC_DATABASE_TCP_USER_TIMEOUT` for configuring TCP keepalive and user timeout on database connections. All of them are opt-in; when unset the OS defaults are kept.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -265,6 +265,25 @@ config :electric,
   prometheus_port: prometheus_port,
   live_dashboard_port: live_dashboard_port,
   db_pool_size: env!("ELECTRIC_DB_POOL_SIZE", :integer, nil),
+  db_tcp_keepalive_idle:
+    env!(
+      "ELECTRIC_DATABASE_TCP_KEEPALIVE_IDLE",
+      &Electric.Config.parse_human_readable_time!/1,
+      nil
+    ),
+  db_tcp_keepalive_interval:
+    env!(
+      "ELECTRIC_DATABASE_TCP_KEEPALIVE_INTERVAL",
+      &Electric.Config.parse_human_readable_time!/1,
+      nil
+    ),
+  db_tcp_keepalive_count: env!("ELECTRIC_DATABASE_TCP_KEEPALIVE_COUNT", :integer, nil),
+  db_tcp_user_timeout:
+    env!(
+      "ELECTRIC_DATABASE_TCP_USER_TIMEOUT",
+      &Electric.Config.parse_human_readable_time!/1,
+      nil
+    ),
   replication_stream_id: replication_stream_id,
   replication_slot_temporary?: env!("CLEANUP_REPLICATION_SLOTS_ON_SHUTDOWN", :boolean, nil),
   replication_slot_temporary_random_name?:

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -140,12 +140,7 @@ defmodule Electric.Application do
       ],
       pool_opts:
         get_env_lazy(opts, :pool_opts, fn -> [pool_size: get_env(opts, :db_pool_size)] end),
-      tcp_opts: [
-        keepalive_idle: get_env(opts, :db_tcp_keepalive_idle),
-        keepalive_interval: get_env(opts, :db_tcp_keepalive_interval),
-        keepalive_count: get_env(opts, :db_tcp_keepalive_count),
-        user_timeout: get_env(opts, :db_tcp_user_timeout)
-      ],
+      tcp_opts: tcp_opts(opts),
       chunk_bytes_threshold: get_env(opts, :chunk_bytes_threshold),
       telemetry_opts:
         telemetry_opts([instance_id: instance_id, installation_id: installation_id] ++ opts),
@@ -245,6 +240,39 @@ defmodule Electric.Application do
       feature_flags: get_env(opts, :feature_flags),
       max_concurrent_requests: get_env(opts, :max_concurrent_requests)
     ]
+  end
+
+  # The keepidle, keepintvl, keepcnt and user_timeout socket options are only
+  # compiled into Erlang's inet driver where the OS headers define the
+  # corresponding TCP_* constants. Where they are missing, setting any of them
+  # makes the driver reject the connection with einval. They are all available
+  # on Linux; elsewhere we drop them, so that the database connection still
+  # works, and tell the user.
+  defp tcp_opts(opts) do
+    tcp_opts = [
+      keepalive_idle: get_env(opts, :db_tcp_keepalive_idle),
+      keepalive_interval: get_env(opts, :db_tcp_keepalive_interval),
+      keepalive_count: get_env(opts, :db_tcp_keepalive_count),
+      user_timeout: get_env(opts, :db_tcp_user_timeout)
+    ]
+
+    configured = Enum.reject(tcp_opts, fn {_key, val} -> is_nil(val) end)
+
+    cond do
+      configured == [] ->
+        []
+
+      :os.type() == {:unix, :linux} ->
+        configured
+
+      true ->
+        Logger.warning(
+          "Ignoring database TCP keepalive/user timeout settings " <>
+            "#{inspect(Keyword.keys(configured))}: they are only supported on Linux."
+        )
+
+        []
+    end
   end
 
   defp get_env(opts, key) do

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -140,6 +140,12 @@ defmodule Electric.Application do
       ],
       pool_opts:
         get_env_lazy(opts, :pool_opts, fn -> [pool_size: get_env(opts, :db_pool_size)] end),
+      tcp_opts: [
+        keepalive_idle: get_env(opts, :db_tcp_keepalive_idle),
+        keepalive_interval: get_env(opts, :db_tcp_keepalive_interval),
+        keepalive_count: get_env(opts, :db_tcp_keepalive_count),
+        user_timeout: get_env(opts, :db_tcp_user_timeout)
+      ],
       chunk_bytes_threshold: get_env(opts, :chunk_bytes_threshold),
       telemetry_opts:
         telemetry_opts([instance_id: instance_id, installation_id: installation_id] ++ opts),

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -45,6 +45,13 @@ defmodule Electric.Config do
     ## Database
     provided_database_id: "single_stack",
     db_pool_size: 20,
+    # TCP-level liveness detection for database connections. All nil by
+    # default, leaving the OS defaults in place. See
+    # Electric.Connection.Manager.ConnectionResolver for what these do.
+    db_tcp_keepalive_idle: nil,
+    db_tcp_keepalive_interval: nil,
+    db_tcp_keepalive_count: nil,
+    db_tcp_user_timeout: nil,
     replication_stream_id: "default",
     replication_slot_temporary?: false,
     replication_slot_temporary_random_name?: false,

--- a/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
+++ b/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
@@ -59,7 +59,10 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
       connection_mod =
       Keyword.get(opts, :connection_mod, {Postgrex.SimpleConnection, :start_link, []})
 
-    {:ok, %{connection_mod: connection_mod, stack_id: stack_id}, {:continue, :notify_ready}}
+    tcp_opts = Keyword.get(opts, :tcp_opts, [])
+
+    {:ok, %{connection_mod: connection_mod, stack_id: stack_id, tcp_opts: tcp_opts},
+     {:continue, :notify_ready}}
   end
 
   @impl GenServer
@@ -72,7 +75,7 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
   @impl GenServer
   def handle_call({:validate, connection}, _from, state) do
     # convert to postgrex style for return to conn.manager
-    connection = populate_connection_opts(connection)
+    connection = populate_connection_opts(connection, state.tcp_opts)
 
     result = attempt_connection({:cont, connection}, state)
 
@@ -108,7 +111,7 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
 
       {:error, error} ->
         error
-        |> mutate_based_on_error(conn_opts)
+        |> mutate_based_on_error(conn_opts, state.tcp_opts)
         |> attempt_connection(state)
     end
   end
@@ -117,8 +120,8 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
     {:error, error}
   end
 
-  defp populate_connection_opts(conn_opts) do
-    conn_opts |> populate_ssl_opts() |> populate_tcp_opts()
+  defp populate_connection_opts(conn_opts, tcp_opts) do
+    conn_opts |> populate_ssl_opts() |> populate_tcp_opts(tcp_opts)
   end
 
   defp populate_ssl_opts(connection_opts) do
@@ -180,7 +183,7 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
     ]
   end
 
-  defp populate_tcp_opts(connection_opts) do
+  defp populate_tcp_opts(connection_opts, tcp_opts) do
     inet_opts =
       if connection_opts[:ipv6] do
         [:inet6]
@@ -188,17 +191,10 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
         []
       end
 
-    liveness_config = [
-      keepalive_idle: Electric.Config.get_env(:db_tcp_keepalive_idle),
-      keepalive_interval: Electric.Config.get_env(:db_tcp_keepalive_interval),
-      keepalive_count: Electric.Config.get_env(:db_tcp_keepalive_count),
-      user_timeout: Electric.Config.get_env(:db_tcp_user_timeout)
-    ]
-
     Keyword.put(
       connection_opts,
       :socket_options,
-      inet_opts ++ tcp_liveness_opts(liveness_config, :os.type())
+      inet_opts ++ tcp_liveness_opts(tcp_opts, :os.type())
     )
   end
 
@@ -249,25 +245,31 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
   defp ms_to_sec(nil), do: nil
   defp ms_to_sec(ms) when is_integer(ms), do: max(div(ms, 1000), 1)
 
-  defp mutate_based_on_error(%Postgrex.Error{message: "ssl not available"} = error, conn_opts) do
+  defp mutate_based_on_error(
+         %Postgrex.Error{message: "ssl not available"} = error,
+         conn_opts,
+         _tcp_opts
+       ) do
     maybe_fallback_to_no_ssl(conn_opts, error)
   end
 
   defp mutate_based_on_error(
          %DBConnection.ConnectionError{message: "ssl connect: closed"} = error,
-         conn_opts
+         conn_opts,
+         _tcp_opts
        ) do
     maybe_fallback_to_no_ssl(conn_opts, error)
   end
 
   defp mutate_based_on_error(
          %DBConnection.ConnectionError{severity: :error} = error,
-         conn_opts
+         conn_opts,
+         tcp_opts
        ) do
-    maybe_fallback_to_ipv4(error, conn_opts)
+    maybe_fallback_to_ipv4(error, conn_opts, tcp_opts)
   end
 
-  defp mutate_based_on_error(error, _conn_opts) do
+  defp mutate_based_on_error(error, _conn_opts, _tcp_opts) do
     {:halt, error}
   end
 
@@ -291,7 +293,8 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
 
   defp maybe_fallback_to_ipv4(
          %DBConnection.ConnectionError{message: message, severity: :error} = error,
-         conn_opts
+         conn_opts,
+         tcp_opts
        ) do
     # If network is unreachable, IPv6 is not enabled on the machine
     # If domain cannot be resolved, assume there is no AAAA record for it
@@ -305,7 +308,7 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
         "Database connection failed to find valid IPv6 address for #{conn_opts[:hostname]} - falling back to IPv4"
       )
 
-      {:cont, conn_opts |> Keyword.put(:ipv6, false) |> populate_tcp_opts()}
+      {:cont, conn_opts |> Keyword.put(:ipv6, false) |> populate_tcp_opts(tcp_opts)}
     else
       {:halt, error}
     end

--- a/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
+++ b/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
@@ -186,7 +186,7 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
     Keyword.put(
       connection_opts,
       :socket_options,
-      inet_opts ++ tcp_liveness_opts(tcp_opts, :os.type())
+      inet_opts ++ tcp_liveness_opts(tcp_opts)
     )
   end
 
@@ -198,13 +198,14 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
   # which keepalive alone does not.
   #
   # Everything here is opt-in: with no configuration we emit no options and
-  # inherit the OS defaults.
+  # inherit the OS defaults. Platform support is checked upstream, in
+  # Electric.Application, before these options reach us.
   #
   # Time values are in milliseconds, as produced by parse_human_readable_time!.
   # TCP_KEEPIDLE and TCP_KEEPINTVL are expressed in seconds by the kernel, while
   # TCP_USER_TIMEOUT takes milliseconds.
   @doc false
-  def tcp_liveness_opts(config, os_type) do
+  def tcp_liveness_opts(config) do
     keepalive_idle = Keyword.get(config, :keepalive_idle)
     keepalive_interval = Keyword.get(config, :keepalive_interval)
     keepalive_count = Keyword.get(config, :keepalive_count)
@@ -218,18 +219,14 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
       end
 
     keepalive_opt ++
-      linux_tcp_opt(:keepidle, ms_to_sec(keepalive_idle), os_type) ++
-      linux_tcp_opt(:keepintvl, ms_to_sec(keepalive_interval), os_type) ++
-      linux_tcp_opt(:keepcnt, keepalive_count, os_type) ++
-      linux_tcp_opt(:user_timeout, user_timeout, os_type)
+      tcp_opt(:keepidle, ms_to_sec(keepalive_idle)) ++
+      tcp_opt(:keepintvl, ms_to_sec(keepalive_interval)) ++
+      tcp_opt(:keepcnt, keepalive_count) ++
+      tcp_opt(:user_timeout, user_timeout)
   end
 
-  # :inet documents keepidle, keepintvl, keepcnt and user_timeout as
-  # Linux-specific. Skip them elsewhere so that a developer on macOS still gets
-  # a working connection, while :keepalive (a portable option) still applies.
-  defp linux_tcp_opt(_opt, nil, _os_type), do: []
-  defp linux_tcp_opt(opt, value, {:unix, :linux}) when is_integer(value), do: [{opt, value}]
-  defp linux_tcp_opt(_opt, _value, _os_type), do: []
+  defp tcp_opt(_opt, nil), do: []
+  defp tcp_opt(opt, value) when is_integer(value), do: [{opt, value}]
 
   defp ms_to_sec(nil), do: nil
   defp ms_to_sec(ms) when is_integer(ms), do: max(div(ms, 1000), 1)

--- a/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
+++ b/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
@@ -4,14 +4,6 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
 
   require Logger
 
-  # Socket option numbers from the Linux headers, for use with :inet's `:raw`
-  # option. IPPROTO_TCP is from netinet/in.h, the rest from netinet/tcp.h.
-  @ipproto_tcp 6
-  @tcp_keepidle 4
-  @tcp_keepintvl 5
-  @tcp_keepcnt 6
-  @tcp_user_timeout 18
-
   defmodule Connection do
     @moduledoc false
     @behaviour Postgrex.SimpleConnection
@@ -209,6 +201,8 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
   # inherit the OS defaults.
   #
   # Time values are in milliseconds, as produced by parse_human_readable_time!.
+  # TCP_KEEPIDLE and TCP_KEEPINTVL are expressed in seconds by the kernel, while
+  # TCP_USER_TIMEOUT takes milliseconds.
   @doc false
   def tcp_liveness_opts(config, os_type) do
     keepalive_idle = Keyword.get(config, :keepalive_idle)
@@ -224,23 +218,18 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
       end
 
     keepalive_opt ++
-      raw_tcp_opt(@tcp_keepidle, ms_to_sec(keepalive_idle), os_type) ++
-      raw_tcp_opt(@tcp_keepintvl, ms_to_sec(keepalive_interval), os_type) ++
-      raw_tcp_opt(@tcp_keepcnt, keepalive_count, os_type) ++
-      raw_tcp_opt(@tcp_user_timeout, user_timeout, os_type)
+      linux_tcp_opt(:keepidle, ms_to_sec(keepalive_idle), os_type) ++
+      linux_tcp_opt(:keepintvl, ms_to_sec(keepalive_interval), os_type) ++
+      linux_tcp_opt(:keepcnt, keepalive_count, os_type) ++
+      linux_tcp_opt(:user_timeout, user_timeout, os_type)
   end
 
-  # The raw socket options below are Linux-specific: the option numbers differ
-  # on other platforms and TCP_USER_TIMEOUT has no equivalent at all. Skip them
-  # elsewhere so a developer on macOS gets a working connection rather than an
-  # obscure einval, while :keepalive (a portable inet option) still applies.
-  defp raw_tcp_opt(_opt, nil, _os_type), do: []
-
-  defp raw_tcp_opt(opt, value, {:unix, :linux}) when is_integer(value) do
-    [{:raw, @ipproto_tcp, opt, <<value::native-32>>}]
-  end
-
-  defp raw_tcp_opt(_opt, _value, _os_type), do: []
+  # :inet documents keepidle, keepintvl, keepcnt and user_timeout as
+  # Linux-specific. Skip them elsewhere so that a developer on macOS still gets
+  # a working connection, while :keepalive (a portable option) still applies.
+  defp linux_tcp_opt(_opt, nil, _os_type), do: []
+  defp linux_tcp_opt(opt, value, {:unix, :linux}) when is_integer(value), do: [{opt, value}]
+  defp linux_tcp_opt(_opt, _value, _os_type), do: []
 
   defp ms_to_sec(nil), do: nil
   defp ms_to_sec(ms) when is_integer(ms), do: max(div(ms, 1000), 1)

--- a/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
+++ b/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
@@ -188,7 +188,18 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
         []
       end
 
-    Keyword.put(connection_opts, :socket_options, inet_opts ++ tcp_liveness_opts())
+    liveness_config = [
+      keepalive_idle: Electric.Config.get_env(:db_tcp_keepalive_idle),
+      keepalive_interval: Electric.Config.get_env(:db_tcp_keepalive_interval),
+      keepalive_count: Electric.Config.get_env(:db_tcp_keepalive_count),
+      user_timeout: Electric.Config.get_env(:db_tcp_user_timeout)
+    ]
+
+    Keyword.put(
+      connection_opts,
+      :socket_options,
+      inet_opts ++ tcp_liveness_opts(liveness_config, :os.type())
+    )
   end
 
   # Options for configuring TCP keepalives and TCP user timeout.
@@ -200,11 +211,14 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
   #
   # Everything here is opt-in: with no configuration we emit no options and
   # inherit the OS defaults.
-  defp tcp_liveness_opts do
-    keepalive_idle = Electric.Config.get_env(:db_tcp_keepalive_idle)
-    keepalive_interval = Electric.Config.get_env(:db_tcp_keepalive_interval)
-    keepalive_count = Electric.Config.get_env(:db_tcp_keepalive_count)
-    user_timeout = Electric.Config.get_env(:db_tcp_user_timeout)
+  #
+  # Time values are in milliseconds, as produced by parse_human_readable_time!.
+  @doc false
+  def tcp_liveness_opts(config, os_type) do
+    keepalive_idle = Keyword.get(config, :keepalive_idle)
+    keepalive_interval = Keyword.get(config, :keepalive_interval)
+    keepalive_count = Keyword.get(config, :keepalive_count)
+    user_timeout = Keyword.get(config, :user_timeout)
 
     keepalive_opt =
       if is_nil(keepalive_idle) and is_nil(keepalive_interval) and is_nil(keepalive_count) do
@@ -214,24 +228,23 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
       end
 
     keepalive_opt ++
-      raw_tcp_opt(@tcp_keepidle, ms_to_sec(keepalive_idle)) ++
-      raw_tcp_opt(@tcp_keepintvl, ms_to_sec(keepalive_interval)) ++
-      raw_tcp_opt(@tcp_keepcnt, keepalive_count) ++
-      raw_tcp_opt(@tcp_user_timeout, user_timeout)
+      raw_tcp_opt(@tcp_keepidle, ms_to_sec(keepalive_idle), os_type) ++
+      raw_tcp_opt(@tcp_keepintvl, ms_to_sec(keepalive_interval), os_type) ++
+      raw_tcp_opt(@tcp_keepcnt, keepalive_count, os_type) ++
+      raw_tcp_opt(@tcp_user_timeout, user_timeout, os_type)
   end
 
   # The raw socket options below are Linux-specific: the option numbers differ
   # on other platforms and TCP_USER_TIMEOUT has no equivalent at all. Skip them
   # elsewhere so a developer on macOS gets a working connection rather than an
   # obscure einval, while :keepalive (a portable inet option) still applies.
-  defp raw_tcp_opt(_opt, nil), do: []
+  defp raw_tcp_opt(_opt, nil, _os_type), do: []
 
-  defp raw_tcp_opt(opt, value) when is_integer(value) do
-    case :os.type() do
-      {:unix, :linux} -> [{:raw, @ipproto_tcp, opt, <<value::native-32>>}]
-      _ -> []
-    end
+  defp raw_tcp_opt(opt, value, {:unix, :linux}) when is_integer(value) do
+    [{:raw, @ipproto_tcp, opt, <<value::native-32>>}]
   end
+
+  defp raw_tcp_opt(_opt, _value, _os_type), do: []
 
   defp ms_to_sec(nil), do: nil
   defp ms_to_sec(ms) when is_integer(ms), do: max(div(ms, 1000), 1)

--- a/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
+++ b/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
@@ -191,16 +191,7 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
     Keyword.put(connection_opts, :socket_options, inet_opts ++ tcp_liveness_opts())
   end
 
-  # Options that let the kernel notice a connection whose peer has gone away
-  # without closing it.
-  #
-  # The replication connection can sit idle for long stretches and only writes a
-  # StandbyStatusUpdate every `wal_sender_timeout / 3`. If the peer disappears
-  # without a FIN or an RST -- a hard-killed container or proxy, a dropped route
-  # -- the socket stays ESTABLISHED here and those writes are simply
-  # retransmitted. Nothing surfaces an error until the kernel gives up, which on
-  # Linux takes `net.ipv4.tcp_retries2` retries (~15 minutes by default). Until
-  # then replication is stalled with no indication that anything is wrong.
+  # Options for configuring TCP keepalives and TCP user timeout.
   #
   # SO_KEEPALIVE makes the kernel probe an idle connection, and TCP_USER_TIMEOUT
   # caps how long unacknowledged data may stay outstanding before the connection

--- a/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
+++ b/packages/sync-service/lib/electric/connection/manager/connection_resolver.ex
@@ -4,6 +4,14 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
 
   require Logger
 
+  # Socket option numbers from the Linux headers, for use with :inet's `:raw`
+  # option. IPPROTO_TCP is from netinet/in.h, the rest from netinet/tcp.h.
+  @ipproto_tcp 6
+  @tcp_keepidle 4
+  @tcp_keepintvl 5
+  @tcp_keepcnt 6
+  @tcp_user_timeout 18
+
   defmodule Connection do
     @moduledoc false
     @behaviour Postgrex.SimpleConnection
@@ -173,15 +181,69 @@ defmodule Electric.Connection.Manager.ConnectionResolver do
   end
 
   defp populate_tcp_opts(connection_opts) do
-    tcp_opts =
+    inet_opts =
       if connection_opts[:ipv6] do
         [:inet6]
       else
         []
       end
 
-    Keyword.put(connection_opts, :socket_options, tcp_opts)
+    Keyword.put(connection_opts, :socket_options, inet_opts ++ tcp_liveness_opts())
   end
+
+  # Options that let the kernel notice a connection whose peer has gone away
+  # without closing it.
+  #
+  # The replication connection can sit idle for long stretches and only writes a
+  # StandbyStatusUpdate every `wal_sender_timeout / 3`. If the peer disappears
+  # without a FIN or an RST -- a hard-killed container or proxy, a dropped route
+  # -- the socket stays ESTABLISHED here and those writes are simply
+  # retransmitted. Nothing surfaces an error until the kernel gives up, which on
+  # Linux takes `net.ipv4.tcp_retries2` retries (~15 minutes by default). Until
+  # then replication is stalled with no indication that anything is wrong.
+  #
+  # SO_KEEPALIVE makes the kernel probe an idle connection, and TCP_USER_TIMEOUT
+  # caps how long unacknowledged data may stay outstanding before the connection
+  # is dropped -- the latter also bounds detection while data *is* being sent,
+  # which keepalive alone does not.
+  #
+  # Everything here is opt-in: with no configuration we emit no options and
+  # inherit the OS defaults.
+  defp tcp_liveness_opts do
+    keepalive_idle = Electric.Config.get_env(:db_tcp_keepalive_idle)
+    keepalive_interval = Electric.Config.get_env(:db_tcp_keepalive_interval)
+    keepalive_count = Electric.Config.get_env(:db_tcp_keepalive_count)
+    user_timeout = Electric.Config.get_env(:db_tcp_user_timeout)
+
+    keepalive_opt =
+      if is_nil(keepalive_idle) and is_nil(keepalive_interval) and is_nil(keepalive_count) do
+        []
+      else
+        [{:keepalive, true}]
+      end
+
+    keepalive_opt ++
+      raw_tcp_opt(@tcp_keepidle, ms_to_sec(keepalive_idle)) ++
+      raw_tcp_opt(@tcp_keepintvl, ms_to_sec(keepalive_interval)) ++
+      raw_tcp_opt(@tcp_keepcnt, keepalive_count) ++
+      raw_tcp_opt(@tcp_user_timeout, user_timeout)
+  end
+
+  # The raw socket options below are Linux-specific: the option numbers differ
+  # on other platforms and TCP_USER_TIMEOUT has no equivalent at all. Skip them
+  # elsewhere so a developer on macOS gets a working connection rather than an
+  # obscure einval, while :keepalive (a portable inet option) still applies.
+  defp raw_tcp_opt(_opt, nil), do: []
+
+  defp raw_tcp_opt(opt, value) when is_integer(value) do
+    case :os.type() do
+      {:unix, :linux} -> [{:raw, @ipproto_tcp, opt, <<value::native-32>>}]
+      _ -> []
+    end
+  end
+
+  defp ms_to_sec(nil), do: nil
+  defp ms_to_sec(ms) when is_integer(ms), do: max(div(ms, 1000), 1)
 
   defp mutate_based_on_error(%Postgrex.Error{message: "ssl not available"} = error, conn_opts) do
     maybe_fallback_to_no_ssl(conn_opts, error)

--- a/packages/sync-service/lib/electric/connection/manager/supervisor.ex
+++ b/packages/sync-service/lib/electric/connection/manager/supervisor.ex
@@ -20,7 +20,8 @@ defmodule Electric.Connection.Manager.Supervisor do
 
     children = [
       {Electric.Connection.Manager, opts},
-      {Electric.Connection.Manager.ConnectionResolver, stack_id: opts[:stack_id]}
+      {Electric.Connection.Manager.ConnectionResolver,
+       stack_id: opts[:stack_id], tcp_opts: Keyword.get(opts, :tcp_opts, [])}
     ]
 
     # Electric.Connection.Manager is a permanent child of the supervisor, so when it dies, the

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -102,6 +102,18 @@ defmodule Electric.StackSupervisor do
                    doc:
                      "will be passed on to the Postgrex connection pool. See `t:Postgrex.start_option()`, apart from the connection options."
                  ],
+                 tcp_opts: [
+                   type: :keyword_list,
+                   default: [],
+                   doc:
+                     "TCP-level liveness settings applied to every database connection socket. Any option left unset keeps the OS default.",
+                   keys: [
+                     keepalive_idle: [type: {:or, [:pos_integer, nil]}, default: nil],
+                     keepalive_interval: [type: {:or, [:pos_integer, nil]}, default: nil],
+                     keepalive_count: [type: {:or, [:pos_integer, nil]}, default: nil],
+                     user_timeout: [type: {:or, [:pos_integer, nil]}, default: nil]
+                   ]
+                 ],
                  storage: [type: :mod_arg, required: true],
                  storage_dir: [type: :string, required: true],
                  chunk_bytes_threshold: [
@@ -383,6 +395,7 @@ defmodule Electric.StackSupervisor do
           handle_event: {Electric.Replication.ShapeLogCollector, :handle_event_async, [stack_id]}
         ] ++ config.replication_opts,
       pool_opts: [types: PgInterop.Postgrex.Types] ++ config.pool_opts,
+      tcp_opts: config.tcp_opts,
       timeline_opts: [
         stack_id: stack_id,
         persistent_kv: config.persistent_kv

--- a/packages/sync-service/test/electric/connection/manager/connection_resolver_tcp_opts_test.exs
+++ b/packages/sync-service/test/electric/connection/manager/connection_resolver_tcp_opts_test.exs
@@ -90,4 +90,61 @@ defmodule Electric.Connection.Manager.ConnectionResolverTcpOptsTest do
       assert ConnectionResolver.tcp_liveness_opts([user_timeout: 60_000], @darwin) == []
     end
   end
+
+  # The raw option numbers and value encoding are hand-copied from the Linux
+  # kernel headers, so unit tests alone can't catch a wrong constant, byte
+  # width, or unit. These tests apply the generated options to a real loopback
+  # socket and read them back from the kernel.
+  describe "kernel read-back: portable options" do
+    test "SO_KEEPALIVE is enabled on a connected socket on any platform" do
+      opts = ConnectionResolver.tcp_liveness_opts([keepalive_idle: 33_000], :os.type())
+
+      assert {:ok, [keepalive: true]} = :inet.getopts(connect_loopback(opts), [:keepalive])
+    end
+  end
+
+  describe "kernel read-back: raw options" do
+    if :os.type() != {:unix, :linux} do
+      @describetag skip: "raw TCP socket options are only applied on Linux"
+    end
+
+    test "the kernel stores the configured raw option values" do
+      config = [
+        keepalive_idle: 33_000,
+        keepalive_interval: 7_000,
+        keepalive_count: 5,
+        user_timeout: 45_678
+      ]
+
+      socket = connect_loopback(ConnectionResolver.tcp_liveness_opts(config, :os.type()))
+
+      assert {:ok,
+              [
+                {:raw, @ipproto_tcp, @tcp_keepidle, <<33::native-32>>},
+                {:raw, @ipproto_tcp, @tcp_keepintvl, <<7::native-32>>},
+                {:raw, @ipproto_tcp, @tcp_keepcnt, <<5::native-32>>},
+                {:raw, @ipproto_tcp, @tcp_user_timeout, <<45_678::native-32>>}
+              ]} =
+               :inet.getopts(socket, [
+                 {:raw, @ipproto_tcp, @tcp_keepidle, 4},
+                 {:raw, @ipproto_tcp, @tcp_keepintvl, 4},
+                 {:raw, @ipproto_tcp, @tcp_keepcnt, 4},
+                 {:raw, @ipproto_tcp, @tcp_user_timeout, 4}
+               ])
+    end
+  end
+
+  # Opens a loopback connection with the given socket options and returns the
+  # client-side socket, mirroring how Postgrex passes :socket_options to
+  # :gen_tcp.connect. Sockets are closed automatically when the test process
+  # exits.
+  defp connect_loopback(socket_options) do
+    {:ok, listen} = :gen_tcp.listen(0, ip: {127, 0, 0, 1})
+    {:ok, port} = :inet.port(listen)
+
+    {:ok, socket} =
+      :gen_tcp.connect({127, 0, 0, 1}, port, socket_options ++ [active: false])
+
+    socket
+  end
 end

--- a/packages/sync-service/test/electric/connection/manager/connection_resolver_tcp_opts_test.exs
+++ b/packages/sync-service/test/electric/connection/manager/connection_resolver_tcp_opts_test.exs
@@ -1,0 +1,93 @@
+defmodule Electric.Connection.Manager.ConnectionResolverTcpOptsTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Connection.Manager.ConnectionResolver
+
+  # IPPROTO_TCP and the TCP_* option numbers from the Linux headers, as used
+  # by ConnectionResolver.
+  @ipproto_tcp 6
+  @tcp_keepidle 4
+  @tcp_keepintvl 5
+  @tcp_keepcnt 6
+  @tcp_user_timeout 18
+
+  @linux {:unix, :linux}
+  @darwin {:unix, :darwin}
+
+  describe "tcp_liveness_opts/2" do
+    test "returns no options when nothing is configured" do
+      for os_type <- [@linux, @darwin, {:win32, :nt}] do
+        assert ConnectionResolver.tcp_liveness_opts([], os_type) == []
+      end
+    end
+
+    test "emits keepalive and raw options for a full configuration on Linux" do
+      config = [
+        keepalive_idle: 30_000,
+        keepalive_interval: 5_000,
+        keepalive_count: 3,
+        user_timeout: 60_000
+      ]
+
+      assert ConnectionResolver.tcp_liveness_opts(config, @linux) == [
+               {:keepalive, true},
+               {:raw, @ipproto_tcp, @tcp_keepidle, <<30::native-32>>},
+               {:raw, @ipproto_tcp, @tcp_keepintvl, <<5::native-32>>},
+               {:raw, @ipproto_tcp, @tcp_keepcnt, <<3::native-32>>},
+               {:raw, @ipproto_tcp, @tcp_user_timeout, <<60_000::native-32>>}
+             ]
+    end
+
+    test "setting any single keepalive value enables keepalive and emits only its raw option" do
+      assert ConnectionResolver.tcp_liveness_opts([keepalive_idle: 30_000], @linux) == [
+               {:keepalive, true},
+               {:raw, @ipproto_tcp, @tcp_keepidle, <<30::native-32>>}
+             ]
+
+      assert ConnectionResolver.tcp_liveness_opts([keepalive_interval: 5_000], @linux) == [
+               {:keepalive, true},
+               {:raw, @ipproto_tcp, @tcp_keepintvl, <<5::native-32>>}
+             ]
+
+      assert ConnectionResolver.tcp_liveness_opts([keepalive_count: 3], @linux) == [
+               {:keepalive, true},
+               {:raw, @ipproto_tcp, @tcp_keepcnt, <<3::native-32>>}
+             ]
+    end
+
+    test "user timeout alone does not enable keepalive and stays in milliseconds" do
+      assert ConnectionResolver.tcp_liveness_opts([user_timeout: 60_000], @linux) == [
+               {:raw, @ipproto_tcp, @tcp_user_timeout, <<60_000::native-32>>}
+             ]
+    end
+
+    test "keepalive idle and interval are converted to seconds, clamped to a minimum of 1" do
+      assert ConnectionResolver.tcp_liveness_opts([keepalive_idle: 500], @linux) == [
+               {:keepalive, true},
+               {:raw, @ipproto_tcp, @tcp_keepidle, <<1::native-32>>}
+             ]
+
+      assert ConnectionResolver.tcp_liveness_opts([keepalive_interval: 1_500], @linux) == [
+               {:keepalive, true},
+               {:raw, @ipproto_tcp, @tcp_keepintvl, <<1::native-32>>}
+             ]
+    end
+
+    test "non-Linux platforms get the portable keepalive flag but no raw options" do
+      config = [
+        keepalive_idle: 30_000,
+        keepalive_interval: 5_000,
+        keepalive_count: 3,
+        user_timeout: 60_000
+      ]
+
+      for os_type <- [@darwin, {:win32, :nt}] do
+        assert ConnectionResolver.tcp_liveness_opts(config, os_type) == [{:keepalive, true}]
+      end
+    end
+
+    test "user timeout alone on non-Linux emits no options at all" do
+      assert ConnectionResolver.tcp_liveness_opts([user_timeout: 60_000], @darwin) == []
+    end
+  end
+end

--- a/packages/sync-service/test/electric/connection/manager/connection_resolver_tcp_opts_test.exs
+++ b/packages/sync-service/test/electric/connection/manager/connection_resolver_tcp_opts_test.exs
@@ -1,150 +1,124 @@
 defmodule Electric.Connection.Manager.ConnectionResolverTcpOptsTest do
+  # Verifies that the TCP liveness options configured via `tcp_opts` reach the
+  # kernel with the expected values, and that leaving them unset keeps the OS
+  # defaults untouched. Values are read back through raw `getsockopt` calls, so
+  # the test only runs on Linux where the option numbers below are valid.
   use ExUnit.Case, async: true
 
   alias Electric.Connection.Manager.ConnectionResolver
 
-  # IPPROTO_TCP and the TCP_* option numbers from the Linux headers, as used
-  # by ConnectionResolver.
+  import Support.ComponentSetup, only: [with_stack_id_from_test: 1]
+
+  # IPPROTO_TCP from netinet/in.h, TCP_* from netinet/tcp.h.
   @ipproto_tcp 6
   @tcp_keepidle 4
   @tcp_keepintvl 5
   @tcp_keepcnt 6
   @tcp_user_timeout 18
 
-  @linux {:unix, :linux}
-  @darwin {:unix, :darwin}
+  @raw_opts [
+    {:raw, @ipproto_tcp, @tcp_keepidle, 4},
+    {:raw, @ipproto_tcp, @tcp_keepintvl, 4},
+    {:raw, @ipproto_tcp, @tcp_keepcnt, 4},
+    {:raw, @ipproto_tcp, @tcp_user_timeout, 4}
+  ]
 
-  describe "tcp_liveness_opts/2" do
-    test "returns no options when nothing is configured" do
-      for os_type <- [@linux, @darwin, {:win32, :nt}] do
-        assert ConnectionResolver.tcp_liveness_opts([], os_type) == []
-      end
-    end
+  if :os.type() != {:unix, :linux} do
+    @moduletag skip: "raw TCP socket option numbers are Linux-specific"
+  end
 
-    test "emits keepalive and raw options for a full configuration on Linux" do
-      config = [
-        keepalive_idle: 30_000,
-        keepalive_interval: 5_000,
-        keepalive_count: 3,
-        user_timeout: 60_000
-      ]
+  setup :with_stack_id_from_test
 
-      assert ConnectionResolver.tcp_liveness_opts(config, @linux) == [
-               {:keepalive, true},
-               {:raw, @ipproto_tcp, @tcp_keepidle, <<30::native-32>>},
-               {:raw, @ipproto_tcp, @tcp_keepintvl, <<5::native-32>>},
-               {:raw, @ipproto_tcp, @tcp_keepcnt, <<3::native-32>>},
-               {:raw, @ipproto_tcp, @tcp_user_timeout, <<60_000::native-32>>}
-             ]
-    end
-
-    test "setting any single keepalive value enables keepalive and emits only its raw option" do
-      assert ConnectionResolver.tcp_liveness_opts([keepalive_idle: 30_000], @linux) == [
-               {:keepalive, true},
-               {:raw, @ipproto_tcp, @tcp_keepidle, <<30::native-32>>}
-             ]
-
-      assert ConnectionResolver.tcp_liveness_opts([keepalive_interval: 5_000], @linux) == [
-               {:keepalive, true},
-               {:raw, @ipproto_tcp, @tcp_keepintvl, <<5::native-32>>}
-             ]
-
-      assert ConnectionResolver.tcp_liveness_opts([keepalive_count: 3], @linux) == [
-               {:keepalive, true},
-               {:raw, @ipproto_tcp, @tcp_keepcnt, <<3::native-32>>}
-             ]
-    end
-
-    test "user timeout alone does not enable keepalive and stays in milliseconds" do
-      assert ConnectionResolver.tcp_liveness_opts([user_timeout: 60_000], @linux) == [
-               {:raw, @ipproto_tcp, @tcp_user_timeout, <<60_000::native-32>>}
-             ]
-    end
-
-    test "keepalive idle and interval are converted to seconds, clamped to a minimum of 1" do
-      assert ConnectionResolver.tcp_liveness_opts([keepalive_idle: 500], @linux) == [
-               {:keepalive, true},
-               {:raw, @ipproto_tcp, @tcp_keepidle, <<1::native-32>>}
-             ]
-
-      assert ConnectionResolver.tcp_liveness_opts([keepalive_interval: 1_500], @linux) == [
-               {:keepalive, true},
-               {:raw, @ipproto_tcp, @tcp_keepintvl, <<1::native-32>>}
-             ]
-    end
-
-    test "non-Linux platforms get the portable keepalive flag but no raw options" do
-      config = [
-        keepalive_idle: 30_000,
-        keepalive_interval: 5_000,
-        keepalive_count: 3,
-        user_timeout: 60_000
-      ]
-
-      for os_type <- [@darwin, {:win32, :nt}] do
-        assert ConnectionResolver.tcp_liveness_opts(config, os_type) == [{:keepalive, true}]
-      end
-    end
-
-    test "user timeout alone on non-Linux emits no options at all" do
-      assert ConnectionResolver.tcp_liveness_opts([user_timeout: 60_000], @darwin) == []
+  # Stands in for Postgrex.SimpleConnection: reports the socket options the
+  # resolver would pass to the real connection, then fails so the resolver
+  # returns without connecting anywhere.
+  defmodule CapturingConnection do
+    def start_link(_handler, _args, conn_opts, test_pid) do
+      send(test_pid, {:socket_options, Keyword.fetch!(conn_opts, :socket_options)})
+      {:error, %DBConnection.ConnectionError{message: "captured", severity: :info}}
     end
   end
 
-  # The raw option numbers and value encoding are hand-copied from the Linux
-  # kernel headers, so unit tests alone can't catch a wrong constant, byte
-  # width, or unit. These tests apply the generated options to a real loopback
-  # socket and read them back from the kernel.
-  describe "kernel read-back: portable options" do
-    test "SO_KEEPALIVE is enabled on a connected socket on any platform" do
-      opts = ConnectionResolver.tcp_liveness_opts([keepalive_idle: 33_000], :os.type())
+  defp resolved_socket_options(ctx, tcp_opts) do
+    start_supervised!(
+      {ConnectionResolver,
+       stack_id: ctx.stack_id,
+       tcp_opts: tcp_opts,
+       connection_mod: {CapturingConnection, :start_link, [self()]}}
+    )
 
-      assert {:ok, [keepalive: true]} = :inet.getopts(connect_loopback(opts), [:keepalive])
-    end
-  end
+    conn_opts = [
+      hostname: "localhost",
+      port: 5432,
+      database: "db",
+      username: "user",
+      password: fn -> "pass" end,
+      sslmode: :disable
+    ]
 
-  describe "kernel read-back: raw options" do
-    if :os.type() != {:unix, :linux} do
-      @describetag skip: "raw TCP socket options are only applied on Linux"
-    end
-
-    test "the kernel stores the configured raw option values" do
-      config = [
-        keepalive_idle: 33_000,
-        keepalive_interval: 7_000,
-        keepalive_count: 5,
-        user_timeout: 45_678
-      ]
-
-      socket = connect_loopback(ConnectionResolver.tcp_liveness_opts(config, :os.type()))
-
-      assert {:ok,
-              [
-                {:raw, @ipproto_tcp, @tcp_keepidle, <<33::native-32>>},
-                {:raw, @ipproto_tcp, @tcp_keepintvl, <<7::native-32>>},
-                {:raw, @ipproto_tcp, @tcp_keepcnt, <<5::native-32>>},
-                {:raw, @ipproto_tcp, @tcp_user_timeout, <<45_678::native-32>>}
-              ]} =
-               :inet.getopts(socket, [
-                 {:raw, @ipproto_tcp, @tcp_keepidle, 4},
-                 {:raw, @ipproto_tcp, @tcp_keepintvl, 4},
-                 {:raw, @ipproto_tcp, @tcp_keepcnt, 4},
-                 {:raw, @ipproto_tcp, @tcp_user_timeout, 4}
-               ])
-    end
+    assert {:error, _} = ConnectionResolver.validate(ctx.stack_id, conn_opts)
+    assert_receive {:socket_options, socket_options}
+    socket_options
   end
 
   # Opens a loopback connection with the given socket options and returns the
   # client-side socket, mirroring how Postgrex passes :socket_options to
-  # :gen_tcp.connect. Sockets are closed automatically when the test process
-  # exits.
+  # :gen_tcp.connect/3.
   defp connect_loopback(socket_options) do
     {:ok, listen} = :gen_tcp.listen(0, ip: {127, 0, 0, 1})
     {:ok, port} = :inet.port(listen)
-
-    {:ok, socket} =
-      :gen_tcp.connect({127, 0, 0, 1}, port, socket_options ++ [active: false])
-
+    {:ok, socket} = :gen_tcp.connect({127, 0, 0, 1}, port, socket_options ++ [active: false])
     socket
+  end
+
+  defp kernel_values(socket) do
+    {:ok, values} = :inet.getopts(socket, [:keepalive | @raw_opts])
+    values
+  end
+
+  test "configured values are applied to the socket", ctx do
+    socket_options =
+      resolved_socket_options(ctx,
+        keepalive_idle: 33_000,
+        keepalive_interval: 7_000,
+        keepalive_count: 5,
+        user_timeout: 45_678
+      )
+
+    assert [
+             {:keepalive, true},
+             {:raw, @ipproto_tcp, @tcp_keepidle, <<33::native-32>>},
+             {:raw, @ipproto_tcp, @tcp_keepintvl, <<7::native-32>>},
+             {:raw, @ipproto_tcp, @tcp_keepcnt, <<5::native-32>>},
+             {:raw, @ipproto_tcp, @tcp_user_timeout, <<45_678::native-32>>}
+           ] = socket_options |> connect_loopback() |> kernel_values()
+  end
+
+  test "unset options leave the OS defaults in place", ctx do
+    socket_options = resolved_socket_options(ctx, [])
+    assert socket_options == []
+
+    # Compare against a socket opened with no options at all rather than
+    # against hard-coded numbers: the defaults come from the host's sysctls.
+    assert socket_options |> connect_loopback() |> kernel_values() ==
+             [] |> connect_loopback() |> kernel_values()
+  end
+
+  test "setting a single keepalive option enables keepalive and leaves the rest at defaults",
+       ctx do
+    [{:keepalive, false} | defaults] = [] |> connect_loopback() |> kernel_values()
+
+    [{:keepalive, true} | values] =
+      resolved_socket_options(ctx, keepalive_count: 2) |> connect_loopback() |> kernel_values()
+
+    expected =
+      List.keyreplace(
+        defaults,
+        @tcp_keepcnt,
+        2,
+        {:raw, @ipproto_tcp, @tcp_keepcnt, <<2::native-32>>}
+      )
+
+    assert values == expected
   end
 end

--- a/packages/sync-service/test/electric/connection/manager/connection_resolver_test.exs
+++ b/packages/sync-service/test/electric/connection/manager/connection_resolver_test.exs
@@ -51,6 +51,10 @@ defmodule Electric.Connection.Manager.ConnectionResolverTest do
       assert Keyword.get(resolved_db_config, k) == v
     end
 
+    # with no TCP liveness settings configured, the default behaviour is to
+    # emit no socket options and leave the OS defaults in place
+    assert Keyword.get(resolved_db_config, :socket_options) == []
+
     assert_obfuscated_password(resolved_db_config)
   end
 
@@ -125,6 +129,10 @@ defmodule Electric.Connection.Manager.ConnectionResolverTest do
     for {k, v} <- expected do
       assert Keyword.get(resolved_db_config, k) == v
     end
+
+    # the ipv4 fallback rebuilds the socket options without :inet6; with no
+    # TCP liveness settings configured that leaves them empty
+    assert Keyword.get(resolved_db_config, :socket_options) == []
 
     assert_obfuscated_password(resolved_db_config)
   end

--- a/website/docs/sync/api/config.md
+++ b/website/docs/sync/api/config.md
@@ -96,6 +96,56 @@ How many connections Electric opens as a pool for handling shape queries.
 
 </EnvVarConfig>
 
+### ELECTRIC_DATABASE_TCP_KEEPALIVE_IDLE
+
+<EnvVarConfig
+    name="ELECTRIC_DATABASE_TCP_KEEPALIVE_IDLE"
+    optional="true"
+    example="30s">
+
+Enable TCP keepalive on database connections and set how long a connection may sit idle before the kernel starts sending probes.
+
+By default Electric leaves the operating system's settings in place. Setting this lets an idle replication connection detect the loss and reconnect sooner.
+
+See also `ELECTRIC_DATABASE_TCP_USER_TIMEOUT`, which bounds detection while data is actually in flight.
+
+</EnvVarConfig>
+
+### ELECTRIC_DATABASE_TCP_KEEPALIVE_INTERVAL
+
+<EnvVarConfig
+    name="ELECTRIC_DATABASE_TCP_KEEPALIVE_INTERVAL"
+    optional="true"
+    example="10s">
+
+How long to wait between individual TCP keepalive probes. Enables keepalive if set on its own.
+
+</EnvVarConfig>
+
+### ELECTRIC_DATABASE_TCP_KEEPALIVE_COUNT
+
+<EnvVarConfig
+    name="ELECTRIC_DATABASE_TCP_KEEPALIVE_COUNT"
+    optional="true"
+    example="3">
+
+How many unanswered TCP keepalive probes before the connection is dropped. Enables keepalive if set on its own.
+
+</EnvVarConfig>
+
+### ELECTRIC_DATABASE_TCP_USER_TIMEOUT
+
+<EnvVarConfig
+    name="ELECTRIC_DATABASE_TCP_USER_TIMEOUT"
+    optional="true"
+    example="60s">
+
+The maximum time data may remain unacknowledged before the connection is dropped (Linux `TCP_USER_TIMEOUT`).
+
+This complements the keepalive settings above. Keepalive probes only run while a connection is idle, whereas this bounds how long Electric keeps retransmitting a write to a peer that has stopped responding.
+
+</EnvVarConfig>
+
 ### ELECTRIC_DATABASE_CA_CERTIFICATE_FILE
 
 <EnvVarConfig


### PR DESCRIPTION
This adds the following config options. These are set on the underlying TCP socket.

* `ELECTRIC_DATABASE_TCP_KEEPALIVE_IDLE` - Idle time before probing. Enables `SO_KEEPALIVE`
* `ELECTRIC_DATABASE_TCP_KEEPALIVE_INTERVAL` - Gap between probes.
* `ELECTRIC_DATABASE_TCP_KEEPALIVE_COUNT` - Unanswered probes before drop.
* `ELECTRIC_DATABASE_TCP_USER_TIMEOUT` - Max time data may stay unacknowledged.

All unset by default, so behaviour is unchanged unless configured. Durations accept the usual 30s / 500ms forms.

Sample config:

```
ELECTRIC_DATABASE_TCP_KEEPALIVE_IDLE=30s
ELECTRIC_DATABASE_TCP_KEEPALIVE_INTERVAL=10s
ELECTRIC_DATABASE_TCP_KEEPALIVE_COUNT=3
ELECTRIC_DATABASE_TCP_USER_TIMEOUT=60s
```

Implementation:

`ConnectionResolver.populate_tcp_opts/1` now appends the options to `:socket_options`. `SO_KEEPALIVE` goes through :inet's portable `{:keepalive, true}`; the rest use :raw with the Linux `IPPROTO_TCP` option numbers, guarded on `:os.type()` so non-Linux developer machines skip them rather than failing with `einval`.

Note: I've generated the PR with AI, because I don't know Elixir, but the change looks fairly straightforward to me, so I'm hoping it's all correct. The one thing that feels a bit risky is what happens on non-Linux kernels. The code attempts to disable this automatically in that case.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/electric-sql/codesmith/electric/pr/4748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788095454&installation_model_id=8736&pr_number=4748&repository=electric-sql%2Felectric&return_to=https%3A%2F%2Fgithub.com%2Felectric-sql%2Felectric%2Fpull%2F4748&signature=e8372d8dc66f8eb1d71e56d1b2c4fb88d8f8244348fd8c04b075ff5b4a4c57d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->