### PR TITLE
fix(client): don't skip live changes after transaction ID wraparound

### DIFF
--- a/.changeset/tidy-xids-wrap.md
+++ b/.changeset/tidy-xids-wrap.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/client": patch
+---
+
+Fix subset snapshot filtering after PostgreSQL transaction ID wraparound.

--- a/.changeset/tidy-xids-wrap.md
+++ b/.changeset/tidy-xids-wrap.md
@@ -2,4 +2,5 @@
 "@electric-sql/client": patch
 ---
 
-Fix subset snapshot filtering after PostgreSQL transaction ID wraparound.
+Fix subset snapshot filtering after PostgreSQL transaction ID wraparound and
+retire filters once the stream passes each snapshot's database LSN.

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -1573,6 +1573,17 @@ export class ShapeStream<T extends Row<unknown> = Row>
       if (isChangeMessage(message)) {
         return !this.#snapshotTracker.shouldRejectMessage(message)
       }
+
+      if (isUpToDateMessage(message)) {
+        const lastSeenLsn = message.headers.global_last_seen_lsn
+        if (typeof lastSeenLsn === `string` && lastSeenLsn) {
+          // Process this in message order: changes before the up-to-date
+          // boundary still need snapshot deduplication, while later changes do
+          // not once the database has passed the snapshot's LSN.
+          this.#snapshotTracker.lastSeenUpdate(BigInt(lastSeenLsn))
+        }
+      }
+
       return true // Always process control messages
     })
 

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -1571,6 +1571,13 @@ export class ShapeStream<T extends Row<unknown> = Row>
     // Filter messages using snapshot tracker
     const messagesToProcess = batch.filter((message) => {
       if (isChangeMessage(message)) {
+        const changeLsn = message.headers.lsn
+        if (typeof changeLsn === `string` && changeLsn) {
+          // A quiet SSE stream may deliver its first later change before the
+          // next up-to-date boundary. Retire snapshots against that change's
+          // WAL position before resolving its wrapped transaction ID.
+          this.#snapshotTracker.lastSeenUpdate(BigInt(changeLsn))
+        }
         return !this.#snapshotTracker.shouldRejectMessage(message)
       }
 

--- a/packages/typescript-client/src/snapshot-tracker.ts
+++ b/packages/typescript-client/src/snapshot-tracker.ts
@@ -92,6 +92,31 @@ export class SnapshotTracker {
   }
 
   /**
+   * Resolves a 32-bit xid against an epoch-aware xid8.
+   *
+   * PostgreSQL keeps transaction IDs within 2^31 of each other through regular
+   * autovacuuming. The signed modulo-2^32 difference therefore identifies the
+   * correct xid8 epoch.
+   *
+   * Mirrors `Electric.Postgres.Xid`
+   * (`packages/sync-service/lib/electric/postgres/xid.ex`).
+   */
+  #toXid8(xid: number, referenceXid8: bigint): bigint {
+    return referenceXid8 + BigInt.asIntN(32, BigInt(xid) - referenceXid8)
+  }
+
+  /**
+   * Resolves each contributing xid into the epoch nearest `referenceXid8` and
+   * returns the latest. Snapshot callers use `xmax` as the reference.
+   */
+  #resolveLatestXid8(xids: number[], referenceXid8: bigint): bigint {
+    return xids.reduce((latest, xid) => {
+      const xid8 = this.#toXid8(xid, referenceXid8)
+      return xid8 > latest ? xid8 : latest
+    }, BigInt(-1))
+  }
+
+  /**
    * Check if a change message should be filtered because its already in an active snapshot
    * Returns true if the message should be filtered out (not processed)
    */
@@ -99,19 +124,20 @@ export class SnapshotTracker {
     const txids = message.headers.txids || []
     if (txids.length === 0) return false
 
-    const xid = Math.max(...txids) // Use the maximum transaction ID
-
     for (const [xmax, snapshots] of this.xmaxSnapshots.entries()) {
-      if (xid >= xmax) {
+      const xid8 = this.#resolveLatestXid8(txids, xmax)
+      if (xid8 >= xmax) {
         for (const snapshot of snapshots) {
           this.removeSnapshot(snapshot)
         }
       }
     }
 
-    return [...this.activeSnapshots.values()].some(
-      (x) => x.keys.has(message.key) && isVisibleInSnapshot(xid, x)
-    )
+    return [...this.activeSnapshots.values()].some((snapshot) => {
+      if (!snapshot.keys.has(message.key)) return false
+      const xid8 = this.#resolveLatestXid8(txids, snapshot.xmax)
+      return isVisibleInSnapshot(xid8, snapshot)
+    })
   }
 
   lastSeenUpdate(newDatabaseLsn: bigint): void {

--- a/packages/typescript-client/src/snapshot-tracker.ts
+++ b/packages/typescript-client/src/snapshot-tracker.ts
@@ -94,9 +94,9 @@ export class SnapshotTracker {
   /**
    * Resolves a 32-bit xid against an epoch-aware xid8.
    *
-   * PostgreSQL keeps transaction IDs within 2^31 of each other through regular
-   * autovacuuming. The signed modulo-2^32 difference therefore identifies the
-   * correct xid8 epoch.
+   * This signed modulo-2^32 calculation requires the reference and xid to be
+   * within 2^31 transactions. ShapeStream enforces that lifetime bound by
+   * retiring snapshots as global_last_seen_lsn passes their database_lsn.
    *
    * Mirrors `Electric.Postgres.Xid`
    * (`packages/sync-service/lib/electric/postgres/xid.ex`).

--- a/packages/typescript-client/test/pbt-micro.test.ts
+++ b/packages/typescript-client/test/pbt-micro.test.ts
@@ -263,21 +263,14 @@ describe(`isVisibleInSnapshot PBT`, () => {
 // TARGET 3: SnapshotTracker (stateful / model-based)
 // ═══════════════════════════════════════════════════════════════════
 //
-// SnapshotTracker keeps two reverse indexes (`xmaxSnapshots`,
-// `snapshotsByDatabaseLsn`) that are *populated* on addSnapshot but
-// *never cleaned up* on removeSnapshot. Any sequence that:
-//   1. add a snapshot
-//   2. remove it (or let shouldRejectMessage evict it)
-//   3. add a different snapshot that happens to reuse the same xmax
-//      or database_lsn as #1
-// leaves stale entries in the reverse index. Later eviction loops
-// then mutate the reverse index unexpectedly, potentially causing the
-// wrong snapshot to be removed.
-//
-// We run commands against the real tracker AND a simple oracle model,
-// and check that shouldRejectMessage agrees at every step.
+// We run commands against the real tracker and an independent oracle model.
+// Snapshot values span xid8 epochs, while wire txids cover wrap boundaries
+// and may contain several contributing transactions.
 
 describe(`SnapshotTracker stateful PBT`, () => {
+  const XID_MODULUS = BigInt(2) ** BigInt(32)
+  const XID_HALF_RANGE = BigInt(2) ** BigInt(31)
+
   type ModelSnap = {
     mark: number
     xmin: bigint
@@ -289,6 +282,24 @@ describe(`SnapshotTracker stateful PBT`, () => {
 
   class OracleModel {
     snapshots = new Map<number, ModelSnap>()
+
+    #toXid8(xid: number, reference: bigint): bigint {
+      const epochStart = reference - (reference % XID_MODULUS)
+      let candidate = epochStart + BigInt(xid)
+      const difference = candidate - reference
+
+      if (difference >= XID_HALF_RANGE) candidate -= XID_MODULUS
+      if (difference < -XID_HALF_RANGE) candidate += XID_MODULUS
+
+      return candidate
+    }
+
+    #latestXid8(txids: number[], reference: bigint): bigint {
+      return txids.reduce((latest, txid) => {
+        const xid8 = this.#toXid8(txid, reference)
+        return xid8 > latest ? xid8 : latest
+      }, BigInt(-1))
+    }
 
     add(s: ModelSnap) {
       this.snapshots.set(s.mark, s)
@@ -304,13 +315,14 @@ describe(`SnapshotTracker stateful PBT`, () => {
     shouldReject(msg: ChangeMessage<Row<unknown>>): boolean {
       const txids = msg.headers.txids || []
       if (txids.length === 0) return false
-      const xid = BigInt(Math.max(...txids))
-      // Evict any snapshot whose xmax <= xid — matches real tracker behavior.
+
       for (const [mark, s] of this.snapshots) {
+        const xid = this.#latestXid8(txids, s.xmax)
         if (xid >= s.xmax) this.snapshots.delete(mark)
       }
       for (const s of this.snapshots.values()) {
         if (!s.keys.has(msg.key)) continue
+        const xid = this.#latestXid8(txids, s.xmax)
         if (xid < s.xmin) return true
         if (xid < s.xmax && !s.xip.includes(xid)) return true
       }
@@ -322,24 +334,36 @@ describe(`SnapshotTracker stateful PBT`, () => {
   const keyArb = fc.constantFrom(`k1`, `k2`, `k3`)
 
   const bi = (n: number) => BigInt(n)
+  const wireXidArb = fc.oneof(
+    fc.integer({ min: 0, max: 2 ** 32 - 1 }),
+    fc.constantFrom(0, 1, 2 ** 31 - 1, 2 ** 31, 2 ** 32 - 2, 2 ** 32 - 1)
+  )
   const addCmdArb = fc
     .record({
       mark: fc.integer({ min: 1, max: 6 }), // small range → collisions possible
-      xmin: fc.bigInt({ min: bi(1), max: bi(50) }),
+      epoch: fc.integer({ min: 0, max: 3 }),
+      xmin: wireXidArb,
       xmaxDelta: fc.bigInt({ min: bi(1), max: bi(50) }),
-      xip: fc.array(fc.bigInt({ min: bi(1), max: bi(100) }), { maxLength: 3 }),
+      xipOffsets: fc.array(fc.bigInt({ min: bi(0), max: bi(49) }), {
+        maxLength: 3,
+      }),
       keys: fc.array(keyArb, { minLength: 1, maxLength: 3 }),
       dbLsn: fc.bigInt({ min: bi(1), max: bi(20) }),
     })
-    .map((r) => ({
-      kind: `add` as const,
-      mark: r.mark,
-      xmin: r.xmin,
-      xmax: r.xmin + r.xmaxDelta,
-      xip: r.xip,
-      keys: new Set(r.keys),
-      dbLsn: r.dbLsn,
-    }))
+    .map((r) => {
+      const xmin = BigInt(r.epoch) * XID_MODULUS + BigInt(r.xmin)
+      return {
+        kind: `add` as const,
+        mark: r.mark,
+        xmin,
+        xmax: xmin + r.xmaxDelta,
+        xip: r.xipOffsets
+          .filter((offset) => offset < r.xmaxDelta)
+          .map((offset) => xmin + offset),
+        keys: new Set(r.keys),
+        dbLsn: r.dbLsn,
+      }
+    })
 
   const removeCmdArb = fc
     .integer({ min: 1, max: 6 })
@@ -352,7 +376,7 @@ describe(`SnapshotTracker stateful PBT`, () => {
   const rejectCmdArb = fc
     .record({
       key: keyArb,
-      txid: fc.integer({ min: 1, max: 100 }),
+      txids: fc.array(wireXidArb, { minLength: 1, maxLength: 3 }),
     })
     .map((r) => ({ kind: `reject` as const, ...r }))
 
@@ -399,7 +423,7 @@ describe(`SnapshotTracker stateful PBT`, () => {
               const msg: ChangeMessage<Row<unknown>> = {
                 key: cmd.key,
                 value: { id: 1 },
-                headers: { operation: `insert`, txids: [cmd.txid] },
+                headers: { operation: `insert`, txids: cmd.txids },
               }
               const realResult = real.shouldRejectMessage(msg)
               const oracleResult = oracle.shouldReject(msg)
@@ -415,6 +439,204 @@ describe(`SnapshotTracker stateful PBT`, () => {
       }),
       pbtOpts
     )
+  })
+
+  it(`deterministic: oracle agrees with SnapshotTracker across an xid epoch boundary`, () => {
+    const real = new SnapshotTracker()
+    const oracle = new OracleModel()
+    const snapshot = {
+      mark: 1,
+      xmin: BigInt(9_269_800_000),
+      xmax: BigInt(9_269_801_000),
+      xip: [] as bigint[],
+      keys: new Set([`k1`]),
+      dbLsn: BigInt(123),
+    }
+
+    real.addSnapshot(
+      {
+        snapshot_mark: snapshot.mark,
+        xmin: `${snapshot.xmin}`,
+        xmax: `${snapshot.xmax}`,
+        xip_list: [],
+        database_lsn: `${snapshot.dbLsn}`,
+      },
+      snapshot.keys
+    )
+    oracle.add(snapshot)
+
+    const message: ChangeMessage<Row<unknown>> = {
+      key: `k1`,
+      value: { id: 1 },
+      headers: { operation: `update`, txids: [679_907_981] },
+    }
+
+    expect(oracle.shouldReject(message)).toBe(real.shouldRejectMessage(message))
+  })
+})
+
+describe(`SnapshotTracker database LSN retirement`, () => {
+  it(`does not reject a future wrapped xid after the stream passes the snapshot LSN`, async () => {
+    const aborter = new AbortController()
+    let mainRequestCount = 0
+
+    const responseHeaders = (offset: string, cursor: string) => ({
+      'electric-handle': `h1`,
+      'electric-offset': offset,
+      'electric-schema': JSON.stringify({ id: `int4`, version: `text` }),
+      'electric-cursor': cursor,
+      'electric-up-to-date': ``,
+    })
+
+    const fetchClient = async (
+      input: RequestInfo | URL,
+      init?: RequestInit
+    ): Promise<Response> => {
+      const url = new URL(input.toString())
+      if (url.searchParams.has(`subset__limit`)) {
+        return new Response(
+          JSON.stringify({
+            metadata: {
+              snapshot_mark: 1,
+              xmin: `9269800000`,
+              xmax: `9269801000`,
+              xip_list: [],
+              database_lsn: `123`,
+            },
+            data: [
+              {
+                key: `k1`,
+                value: { id: 1, version: `snapshot` },
+                headers: { operation: `insert` },
+              },
+            ],
+          }),
+          { status: 200, headers: responseHeaders(`10_0`, `snapshot`) }
+        )
+      }
+
+      mainRequestCount += 1
+      if (mainRequestCount === 1) {
+        return new Response(
+          JSON.stringify([
+            {
+              headers: {
+                control: `up-to-date`,
+                global_last_seen_lsn: `100`,
+              },
+            },
+          ]),
+          { status: 200, headers: responseHeaders(`5_0`, `initial`) }
+        )
+      }
+
+      if (mainRequestCount === 2) {
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            `abort`,
+            () => reject(new Error(`AbortError`)),
+            { once: true }
+          )
+        })
+      }
+
+      if (mainRequestCount === 3) {
+        return new Response(
+          JSON.stringify([
+            {
+              key: `k1`,
+              value: { id: 1, version: `duplicate` },
+              headers: { operation: `update`, txids: [679_865_407] },
+            },
+            {
+              headers: {
+                control: `up-to-date`,
+                global_last_seen_lsn: `123`,
+              },
+            },
+          ]),
+          { status: 200, headers: responseHeaders(`10_0`, `caught-up`) }
+        )
+      }
+
+      if (mainRequestCount === 4) {
+        return new Response(
+          JSON.stringify([
+            {
+              key: `k1`,
+              value: { id: 1, version: `future` },
+              headers: { operation: `update`, txids: [2_827_350_156] },
+            },
+            {
+              headers: {
+                control: `up-to-date`,
+                global_last_seen_lsn: `124`,
+              },
+            },
+          ]),
+          { status: 200, headers: responseHeaders(`11_0`, `future`) }
+        )
+      }
+
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          `abort`,
+          () => reject(new Error(`AbortError`)),
+          { once: true }
+        )
+      })
+    }
+
+    const stream = new ShapeStream<{ id: number; version: string }>({
+      url: `https://example.com/v1/shape`,
+      params: { table: `test_table` },
+      log: `changes_only`,
+      fetchClient,
+      signal: aborter.signal,
+    })
+    const seen: Array<Message<{ id: number; version: string }>> = []
+    const initialUpToDate = new Promise<void>((resolve) => {
+      stream.subscribe((messages) => {
+        seen.push(...messages)
+        if (
+          messages.some(
+            (message) =>
+              `control` in message.headers &&
+              message.headers.control === `up-to-date`
+          )
+        ) {
+          resolve()
+        }
+      })
+    })
+
+    try {
+      await initialUpToDate
+      await vi.waitFor(() => expect(mainRequestCount).toBe(2))
+      await stream.requestSnapshot({ limit: 1, orderBy: `id ASC` })
+
+      await vi.waitFor(() => {
+        expect(
+          seen.some(
+            (message) =>
+              `operation` in message.headers &&
+              `value` in message &&
+              message.value.version === `future`
+          ),
+          JSON.stringify({ mainRequestCount, seen })
+        ).toBe(true)
+        expect(
+          seen.some(
+            (message) =>
+              `operation` in message.headers &&
+              `value` in message &&
+              message.value.version === `duplicate`
+          )
+        ).toBe(false)
+      })
+    } finally {
+      aborter.abort()
+    }
   })
 })
 

--- a/packages/typescript-client/test/pbt-micro.test.ts
+++ b/packages/typescript-client/test/pbt-micro.test.ts
@@ -546,12 +546,16 @@ describe(`SnapshotTracker database LSN retirement`, () => {
             {
               key: `k1`,
               value: { id: 1, version: `duplicate` },
-              headers: { operation: `update`, txids: [679_865_407] },
+              headers: {
+                operation: `update`,
+                txids: [679_865_407],
+                lsn: `122`,
+              },
             },
             {
               headers: {
                 control: `up-to-date`,
-                global_last_seen_lsn: `123`,
+                global_last_seen_lsn: `100`,
               },
             },
           ]),
@@ -565,7 +569,11 @@ describe(`SnapshotTracker database LSN retirement`, () => {
             {
               key: `k1`,
               value: { id: 1, version: `future` },
-              headers: { operation: `update`, txids: [2_827_350_156] },
+              headers: {
+                operation: `update`,
+                txids: [2_827_350_156],
+                lsn: `124`,
+              },
             },
             {
               headers: {

--- a/packages/typescript-client/test/snapshot-tracker.test.ts
+++ b/packages/typescript-client/test/snapshot-tracker.test.ts
@@ -126,6 +126,17 @@ describe(`SnapshotTracker`, () => {
       }
 
       expect(tracker.shouldRejectMessage(message)).toBe(false)
+
+      const olderMessage: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `update`,
+          txids: [679_800_000],
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(olderMessage)).toBe(false)
     })
   })
 

--- a/packages/typescript-client/test/snapshot-tracker.test.ts
+++ b/packages/typescript-client/test/snapshot-tracker.test.ts
@@ -105,6 +105,28 @@ describe(`SnapshotTracker`, () => {
 
       expect(tracker.shouldRejectMessage(message)).toBe(false)
     })
+
+    it(`should NOT reject a wrapped xid newer than an xid8 snapshot`, () => {
+      const metadata: SnapshotMetadata = {
+        snapshot_mark: 1,
+        xmin: `9269800000`,
+        xmax: `9269801000`,
+        xip_list: [],
+        database_lsn: `123`,
+      }
+      tracker.addSnapshot(metadata, new Set([`user:1`]))
+
+      const message: ChangeMessage<Row<unknown>> = {
+        key: `user:1`,
+        value: { id: 1, name: `Alice` },
+        headers: {
+          operation: `update`,
+          txids: [679_907_981], // xid8 9_269_842_573 in epoch 2
+        },
+      }
+
+      expect(tracker.shouldRejectMessage(message)).toBe(false)
+    })
   })
 
   describe(`Keys not in snapshots are always let through`, () => {

--- a/packages/typescript-client/test/snapshot-tracker.test.ts
+++ b/packages/typescript-client/test/snapshot-tracker.test.ts
@@ -116,7 +116,7 @@ describe(`SnapshotTracker`, () => {
       }
       tracker.addSnapshot(metadata, new Set([`user:1`]))
 
-      const message: ChangeMessage<Row<unknown>> = {
+      const newerMessage: ChangeMessage<Row<unknown>> = {
         key: `user:1`,
         value: { id: 1, name: `Alice` },
         headers: {
@@ -125,9 +125,11 @@ describe(`SnapshotTracker`, () => {
         },
       }
 
-      expect(tracker.shouldRejectMessage(message)).toBe(false)
+      expect(tracker.shouldRejectMessage(newerMessage)).toBe(false)
 
-      const olderMessage: ChangeMessage<Row<unknown>> = {
+      // This would be rejected if the newer message had not retired the
+      // snapshot after resolving its wrapped xid against xmax.
+      const messageAfterRetirement: ChangeMessage<Row<unknown>> = {
         key: `user:1`,
         value: { id: 1, name: `Alice` },
         headers: {
@@ -136,7 +138,7 @@ describe(`SnapshotTracker`, () => {
         },
       }
 
-      expect(tracker.shouldRejectMessage(olderMessage)).toBe(false)
+      expect(tracker.shouldRejectMessage(messageAfterRetirement)).toBe(false)
     })
   })
 


### PR DESCRIPTION
Fixes subset snapshot filtering when PostgreSQL 32-bit transaction IDs wrap across an xid8 epoch. Clients now keep live collections current instead of discarding valid changes after wraparound, including on quiet SSE streams that have not received another up-to-date boundary.

## Root Cause

Change messages carry 32-bit transaction IDs, while subset snapshot metadata uses 64-bit epoch-aware IDs. Comparing them directly loses the epoch and can classify a new wrapped transaction as visible in an old snapshot.

Reconstructing the epoch also has a half-range constraint: the 32-bit xid and its 64-bit reference must be within `2^31` transactions. A quiet stream could retain a snapshot past that bound because its next change may arrive before another `up-to-date` message.

## Approach

- Resolve every wire xid into the epoch nearest the snapshot `xmax`, then use the latest resolved xid for snapshot eviction and duplicate filtering.
- Advance snapshot retirement in message order from both `global_last_seen_lsn` control messages and each change message `lsn`.
- Expand the model-based tests across xid8 epochs, wrap boundaries, and multi-xid messages.
- Add regressions for wrapped xid eviction and for a quiet stream whose first later change passes the snapshot WAL position.

This mirrors the xid reconstruction strategy already used by the sync service in [#2320](https://github.com/electric-sql/electric/pull/2320).

## Key Invariants

- An active snapshot never outlives the point where the stream WAL position passes its `database_lsn`.
- Changes before that boundary still receive snapshot duplicate filtering; later changes do not.
- Each wire xid is resolved before the latest contributing transaction is chosen.

## Non-goals

- No sync-service or wire-protocol changes.
- No changes to subset snapshot semantics outside transaction ID resolution and retirement.

## Trade-offs

Using `xmax` as the epoch reference keeps the fix local and matches PostgreSQL wraparound arithmetic. Its half-range requirement is safe because LSN-based retirement bounds each snapshot lifetime without adding protocol state.

## Verification

```bash
pnpm --dir packages/typescript-client test --run
pnpm --dir packages/typescript-client typecheck
pnpm --dir packages/typescript-client stylecheck
```

The full TypeScript client unit suite passed (440 tests), along with focused regression tests, type checking, linting, and formatting checks.

## Files changed

- `packages/typescript-client/src/client.ts` — retires snapshots from control and change LSNs in stream order.
- `packages/typescript-client/src/snapshot-tracker.ts` — reconstructs epoch-aware transaction IDs before filtering.
- `packages/typescript-client/test/pbt-micro.test.ts` — adds cross-epoch property coverage and stream retirement regression.
- `packages/typescript-client/test/snapshot-tracker.test.ts` — adds a wrapped xid retirement regression.
- `.changeset/tidy-xids-wrap.md` — records the client patch.

---

## Related

Related: [#2320](https://github.com/electric-sql/electric/pull/2320)

_AI disclosure: Codex helped investigate, test, and prepare this change._