### PR TITLE
feat(agents): add OrcaRouter as a named model provider

### DIFF
--- a/.changeset/orcarouter-provider.md
+++ b/.changeset/orcarouter-provider.md
@@ -1,0 +1,8 @@
+---
+'@electric-ax/agents-runtime': patch
+'@electric-ax/agents': patch
+'@electric-ax/agents-server-ui': patch
+'@electric-ax/agents-desktop': patch
+---
+
+Add OrcaRouter as a named provider. Mirrors the Moonshot OpenAI-compatible gateway wiring: new `orcarouter-models.ts` (4 gateway models routed to `https://api.orcarouter.ai/v1`), `ORCAROUTER_API_KEY` env detection, low-cost model support, and model-catalog integration so the desktop/server UI can pick OrcaRouter models.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,7 @@ const bootstrapTodoListAction = createOptimisticAction<string>({
 
 The agents subsystem spans seven packages: `agents-runtime`, `agents-mcp` (MCP bridge library used by built-ins), `agents-server`, `agents` (built-in Horton & Worker), `agents-server-ui`, `agents-desktop` (Electron wrapper for the UI), and `agents-server-conformance-tests`.
 
-**Quick start** (from project root, ensure `.env` has `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`):
+**Quick start** (from project root, ensure `.env` has `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or another supported provider key such as `ORCAROUTER_API_KEY`):
 
 ```sh
 ./scripts/dev.sh build       # install + build typescript-client, agents-runtime,

--- a/examples/deep-survey/README.md
+++ b/examples/deep-survey/README.md
@@ -134,23 +134,24 @@ node packages/electric-ax/bin/electric-dev.mjs agent stop
 
 ## Tech Stack
 
-| Layer             | Technology                                                    |
-| ----------------- | ------------------------------------------------------------- |
-| Agent runtime     | [@electric-ax/agents-runtime](../../packages/agents-runtime/) |
-| LLM               | Claude (Anthropic API) and/or Kimi (Moonshot API)             |
-| Web search        | Brave Search API                                              |
-| Frontend          | React 19, Vite 7, TypeScript                                  |
-| Real-time state   | TanStack DB, Durable Streams                                  |
-| Visualization     | D3.js force simulation                                        |
-| Schema validation | Zod 4                                                         |
-| UI components     | Radix UI                                                      |
+| Layer             | Technology                                                                                  |
+| ----------------- | ------------------------------------------------------------------------------------------- |
+| Agent runtime     | [@electric-ax/agents-runtime](../../packages/agents-runtime/)                               |
+| LLM               | Claude (Anthropic API), Kimi (Moonshot API), and/or [OrcaRouter](https://www.orcarouter.ai) |
+| Web search        | Brave Search API                                                                            |
+| Frontend          | React 19, Vite 7, TypeScript                                                                |
+| Real-time state   | TanStack DB, Durable Streams                                                                |
+| Visualization     | D3.js force simulation                                                                      |
+| Schema validation | Zod 4                                                                                       |
+| UI components     | Radix UI                                                                                    |
 
 ## Environment Variables
 
 | Variable               | Default                  | Description                                                                                                  |
 | ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `ANTHROPIC_API_KEY`    | —                        | Anthropic API key. Uses Sonnet for coordinator and workers when Moonshot is absent                           |
+| `ANTHROPIC_API_KEY`    | —                        | Anthropic API key. Uses Sonnet for coordinator and workers when Moonshot/OrcaRouter are absent               |
 | `MOONSHOT_API_KEY`     | —                        | Moonshot API key. Uses `kimi-k2.6`; when both keys are set, workers use Kimi and the coordinator uses Sonnet |
+| `ORCAROUTER_API_KEY`   | —                        | [OrcaRouter](https://www.orcarouter.ai) API key. Uses `orcarouter/auto` for workers when set                 |
 | `BRAVE_SEARCH_API_KEY` | —                        | Brave Search API key for web research                                                                        |
 | `DARIX_URL`            | `http://localhost:4437`  | Electric Agents server URL                                                                                   |
 | `PORT`                 | `4700`                   | Backend server port                                                                                          |

--- a/examples/deep-survey/src/server/model-config.ts
+++ b/examples/deep-survey/src/server/model-config.ts
@@ -3,6 +3,8 @@ import type { AgentConfig } from '@electric-ax/agents-runtime'
 const SONNET_MODEL = `claude-sonnet-4-5-20250929`
 const KIMI_MODEL = `kimi-k2.6`
 const KIMI_BASE_URL = `https://api.moonshot.ai/v1`
+const ORCAROUTER_MODEL = `orcarouter/auto`
+const ORCAROUTER_BASE_URL = `https://api.orcarouter.ai/v1`
 
 type AgentModelConfig = Pick<
   AgentConfig,
@@ -71,10 +73,43 @@ function kimiConfig(): AgentModelConfig {
   }
 }
 
+function orcarouterConfig(): AgentModelConfig {
+  const apiKey = getUsableEnv(`ORCAROUTER_API_KEY`)
+  if (!apiKey) {
+    throw new Error(`ORCAROUTER_API_KEY must be set to use ${ORCAROUTER_MODEL}`)
+  }
+
+  return {
+    model: {
+      id: ORCAROUTER_MODEL,
+      name: `OrcaRouter Auto`,
+      api: `openai-completions`,
+      provider: `orcarouter`,
+      baseUrl: ORCAROUTER_BASE_URL,
+      reasoning: true,
+      input: [`text`],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 262144,
+      maxTokens: 32768,
+      compat: {
+        supportsStore: false,
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: false,
+        maxTokensField: `max_completion_tokens`,
+      },
+    },
+    getApiKey: (provider) => (provider === `orcarouter` ? apiKey : undefined),
+  }
+}
+
 function assertModelEnv(): void {
-  if (!hasEnv(`ANTHROPIC_API_KEY`) && !hasEnv(`MOONSHOT_API_KEY`)) {
+  if (
+    !hasEnv(`ANTHROPIC_API_KEY`) &&
+    !hasEnv(`MOONSHOT_API_KEY`) &&
+    !hasEnv(`ORCAROUTER_API_KEY`)
+  ) {
     throw new Error(
-      `Set ANTHROPIC_API_KEY or MOONSHOT_API_KEY before running Deep Survey`
+      `Set ANTHROPIC_API_KEY, MOONSHOT_API_KEY, or ORCAROUTER_API_KEY before running Deep Survey`
     )
   }
 }
@@ -86,5 +121,6 @@ export function orchestratorModelConfig(): AgentModelConfig {
 
 export function surveyWorkerModelConfig(): AgentModelConfig {
   assertModelEnv()
+  if (hasEnv(`ORCAROUTER_API_KEY`)) return orcarouterConfig()
   return hasEnv(`MOONSHOT_API_KEY`) ? kimiConfig() : sonnetConfig()
 }

--- a/packages/agents-desktop/src/credentials/api-keys.ts
+++ b/packages/agents-desktop/src/credentials/api-keys.ts
@@ -7,6 +7,7 @@ export const EMPTY_API_KEYS: ApiKeys = {
   openai: null,
   deepseek: null,
   moonshot: null,
+  orcarouter: null,
   brave: null,
   e2b: null,
 }
@@ -19,6 +20,7 @@ export function captureEnvApiKeys(env: NodeJS.ProcessEnv): ApiKeys {
     openai: env.OPENAI_API_KEY?.trim() || null,
     deepseek: env.DEEPSEEK_API_KEY?.trim() || null,
     moonshot: env.MOONSHOT_API_KEY?.trim() || null,
+    orcarouter: env.ORCAROUTER_API_KEY?.trim() || null,
     brave: env.BRAVE_SEARCH_API_KEY?.trim() || null,
     e2b: env.E2B_API_KEY?.trim() || null,
   }
@@ -37,6 +39,7 @@ export function normalizeApiKeys(value: unknown): ApiKeys {
     openai: pick(maybe.openai),
     deepseek: pick(maybe.deepseek),
     moonshot: pick(maybe.moonshot),
+    orcarouter: pick(maybe.orcarouter),
     brave: pick(maybe.brave),
     e2b: pick(maybe.e2b),
   }
@@ -48,6 +51,7 @@ export function hasAnyApiKey(keys: ApiKeys): boolean {
       keys.openai ||
       keys.deepseek ||
       keys.moonshot ||
+      keys.orcarouter ||
       keys.brave ||
       keys.e2b
   )
@@ -96,6 +100,7 @@ export function applyApiKeysToEnv(
       | `OPENAI_API_KEY`
       | `DEEPSEEK_API_KEY`
       | `MOONSHOT_API_KEY`
+      | `ORCAROUTER_API_KEY`
       | `BRAVE_SEARCH_API_KEY`
       | `E2B_API_KEY`
   ): void => {
@@ -110,6 +115,7 @@ export function applyApiKeysToEnv(
   resolveSlot(saved.openai, launchEnv.openai, `OPENAI_API_KEY`)
   resolveSlot(saved.deepseek, launchEnv.deepseek, `DEEPSEEK_API_KEY`)
   resolveSlot(saved.moonshot, launchEnv.moonshot, `MOONSHOT_API_KEY`)
+  resolveSlot(saved.orcarouter, launchEnv.orcarouter, `ORCAROUTER_API_KEY`)
   resolveSlot(saved.brave, launchEnv.brave, `BRAVE_SEARCH_API_KEY`)
   resolveSlot(saved.e2b, launchEnv.e2b, `E2B_API_KEY`)
 }
@@ -128,13 +134,18 @@ export async function getApiKeysStatus(
   // Brave and E2B are optional: search falls back to Anthropic's built-in tool,
   // and E2B only enables the remote sandbox profile.
   const hasAnyKey = Boolean(
-    saved.anthropic || saved.openai || saved.deepseek || saved.moonshot
+    saved.anthropic ||
+      saved.openai ||
+      saved.deepseek ||
+      saved.moonshot ||
+      saved.orcarouter
   )
   const suggested: ApiKeys = {
     anthropic: saved.anthropic ? null : deps.launchEnv.anthropic,
     openai: saved.openai ? null : deps.launchEnv.openai,
     deepseek: saved.deepseek ? null : deps.launchEnv.deepseek,
     moonshot: saved.moonshot ? null : deps.launchEnv.moonshot,
+    orcarouter: saved.orcarouter ? null : deps.launchEnv.orcarouter,
     brave: saved.brave ? null : deps.launchEnv.brave,
     e2b: saved.e2b ? null : deps.launchEnv.e2b,
   }
@@ -174,6 +185,7 @@ export async function setApiKeys(
     normalized.openai !== deps.apiKeys.openai ||
     normalized.deepseek !== deps.apiKeys.deepseek ||
     normalized.moonshot !== deps.apiKeys.moonshot ||
+    normalized.orcarouter !== deps.apiKeys.orcarouter ||
     normalized.brave !== deps.apiKeys.brave ||
     normalized.e2b !== deps.apiKeys.e2b
   Object.assign(deps.apiKeys, normalized)

--- a/packages/agents-desktop/src/credentials/controller.ts
+++ b/packages/agents-desktop/src/credentials/controller.ts
@@ -94,6 +94,7 @@ export function createCredentialsController(deps: {
           deps.apiKeys.openai ||
           deps.apiKeys.deepseek ||
           deps.apiKeys.moonshot ||
+          deps.apiKeys.orcarouter ||
           deps.settings.codex?.enabled
       ),
       signedIn: deps.getCloudAuthStatus() === `signed-in`,

--- a/packages/agents-desktop/src/credentials/model-picker.ts
+++ b/packages/agents-desktop/src/credentials/model-picker.ts
@@ -22,6 +22,7 @@ export const DEFAULT_ENABLED_MODEL_VALUES = [
   `deepseek:deepseek-v4-flash`,
   `deepseek:deepseek-v4-pro`,
   `moonshot:kimi-k2.6`,
+  `orcarouter:orcarouter/auto`,
 ]
 
 export function normalizeEnabledModelValues(value: unknown): Array<string> {
@@ -48,7 +49,10 @@ export function resolveEnabledModelValues(
 function hasModelKey(
   saved: ApiKeys,
   suggested: ApiKeys,
-  key: keyof Pick<ApiKeys, `anthropic` | `openai` | `deepseek` | `moonshot`>
+  key: keyof Pick<
+    ApiKeys,
+    `anthropic` | `openai` | `deepseek` | `moonshot` | `orcarouter`
+  >
 ): boolean {
   return Boolean(saved[key] || suggested[key])
 }
@@ -63,6 +67,7 @@ function configuredProviders(
   if (hasModelKey(saved, suggested, `openai`)) providers.push(`openai`)
   if (hasModelKey(saved, suggested, `deepseek`)) providers.push(`deepseek`)
   if (hasModelKey(saved, suggested, `moonshot`)) providers.push(`moonshot`)
+  if (hasModelKey(saved, suggested, `orcarouter`)) providers.push(`orcarouter`)
   if (codex.enabled) providers.push(`openai-codex`)
   return providers
 }

--- a/packages/agents-desktop/src/shared/types.ts
+++ b/packages/agents-desktop/src/shared/types.ts
@@ -99,6 +99,7 @@ export type ApiKeys = {
   openai: string | null
   deepseek: string | null
   moonshot: string | null
+  orcarouter: string | null
   brave: string | null
   e2b: string | null
 }

--- a/packages/agents-runtime/src/index.ts
+++ b/packages/agents-runtime/src/index.ts
@@ -404,6 +404,16 @@ export {
 } from './moonshot-models'
 export type { MoonshotModel, MoonshotProvider } from './moonshot-models'
 
+export {
+  ORCAROUTER_API_BASE_URL,
+  ORCAROUTER_API_KEY_ENV,
+  ORCAROUTER_PROVIDER,
+  getOrcaRouterApiKey,
+  getOrcaRouterModel,
+  getOrcaRouterModels,
+} from './orcarouter-models'
+export type { OrcaRouterModel, OrcaRouterProvider } from './orcarouter-models'
+
 export { createRuntimeHandler, createRuntimeRouter } from './create-handler'
 export { verifyWebhookSignature } from './webhook-signature'
 export { createPullWakeRunner } from './pull-wake-runner'

--- a/packages/agents-runtime/src/model-runner.ts
+++ b/packages/agents-runtime/src/model-runner.ts
@@ -7,6 +7,11 @@ import {
   getMoonshotApiKey,
   getMoonshotModel,
 } from './moonshot-models'
+import {
+  ORCAROUTER_PROVIDER,
+  getOrcaRouterApiKey,
+  getOrcaRouterModel,
+} from './orcarouter-models'
 import type { AgentConfig } from './types'
 import type { KnownProvider } from '@mariozechner/pi-ai'
 
@@ -32,6 +37,11 @@ const PREFERRED_IDS_BY_PROVIDER: Record<string, Array<string>> = {
   'openai-codex': [`gpt-5.4-mini`, `gpt-5.1-codex-mini`],
   deepseek: [`deepseek-v4-flash`, `deepseek-v4-pro`],
   moonshot: [`kimi-k2.6`, `kimi-k2.5`, `moonshot-v1-8k`],
+  orcarouter: [
+    `orcarouter/auto`,
+    `orcarouter/fusion`,
+    `orcarouter/fusion-flash`,
+  ],
 }
 
 function hasEnv(name: string): boolean {
@@ -65,6 +75,7 @@ export type AvailableProvider =
   | `openai-codex`
   | `deepseek`
   | typeof MOONSHOT_PROVIDER
+  | typeof ORCAROUTER_PROVIDER
 
 export function detectAvailableProviders(): Array<AvailableProvider> {
   const providers: Array<AvailableProvider> = []
@@ -72,6 +83,7 @@ export function detectAvailableProviders(): Array<AvailableProvider> {
   if (hasEnv(`OPENAI_API_KEY`)) providers.push(`openai`)
   if (hasEnv(`DEEPSEEK_API_KEY`)) providers.push(`deepseek`)
   if (getMoonshotApiKey()) providers.push(MOONSHOT_PROVIDER)
+  if (getOrcaRouterApiKey()) providers.push(ORCAROUTER_PROVIDER)
   if (readCodexAccessToken() !== undefined) providers.push(`openai-codex`)
   return providers
 }
@@ -116,6 +128,13 @@ function envCatalog(): LowCostModelCatalog {
       reasoning: false,
     })
   }
+  if (providers.includes(ORCAROUTER_PROVIDER)) {
+    choices.push({
+      provider: ORCAROUTER_PROVIDER,
+      id: `orcarouter/auto`,
+      reasoning: true,
+    })
+  }
   return { choices, defaultChoice: choices[0] }
 }
 
@@ -131,6 +150,7 @@ export function selectLowCostModelChoice(
     `anthropic`,
     `deepseek`,
     MOONSHOT_PROVIDER,
+    ORCAROUTER_PROVIDER,
   ].filter((provider): provider is string => Boolean(provider))
 
   for (const provider of providerOrder) {
@@ -167,6 +187,8 @@ export function selectLowCostModelChoice(
 
 function resolveLowCostModel(choice: LowCostModelChoice) {
   if (choice.provider === MOONSHOT_PROVIDER) return getMoonshotModel(choice.id)
+  if (choice.provider === ORCAROUTER_PROVIDER)
+    return getOrcaRouterModel(choice.id)
   return getModel(
     choice.provider as Parameters<typeof getModel>[0],
     choice.id as Parameters<typeof getModel>[1]
@@ -182,6 +204,7 @@ async function resolveLowCostApiKey(input: {
   }
   if (input.provider === `openai-codex`) return readCodexAccessToken()
   if (input.provider === MOONSHOT_PROVIDER) return getMoonshotApiKey()
+  if (input.provider === ORCAROUTER_PROVIDER) return getOrcaRouterApiKey()
   return undefined
 }
 

--- a/packages/agents-runtime/src/orcarouter-models.ts
+++ b/packages/agents-runtime/src/orcarouter-models.ts
@@ -1,0 +1,89 @@
+import type { Model } from '@mariozechner/pi-ai'
+
+export const ORCAROUTER_PROVIDER = `orcarouter` as const
+export type OrcaRouterProvider = typeof ORCAROUTER_PROVIDER
+
+export const ORCAROUTER_API_KEY_ENV = `ORCAROUTER_API_KEY`
+export const ORCAROUTER_API_BASE_URL = `https://api.orcarouter.ai/v1`
+
+export type OrcaRouterModel = Model<`openai-completions`> & {
+  provider: OrcaRouterProvider
+}
+
+const ORCAROUTER_OPENAI_COMPAT: OrcaRouterModel[`compat`] = {
+  supportsStore: false,
+  supportsDeveloperRole: false,
+  supportsReasoningEffort: false,
+  maxTokensField: `max_completion_tokens`,
+}
+
+const ORCAROUTER_MODELS: Array<OrcaRouterModel> = [
+  {
+    id: `orcarouter/auto`,
+    name: `Auto (smart routing)`,
+    api: `openai-completions`,
+    provider: ORCAROUTER_PROVIDER,
+    baseUrl: ORCAROUTER_API_BASE_URL,
+    compat: ORCAROUTER_OPENAI_COMPAT,
+    reasoning: true,
+    input: [`text`, `image`],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 262_144,
+    maxTokens: 32_768,
+  },
+  {
+    id: `orcarouter/fusion`,
+    name: `Fusion`,
+    api: `openai-completions`,
+    provider: ORCAROUTER_PROVIDER,
+    baseUrl: ORCAROUTER_API_BASE_URL,
+    compat: ORCAROUTER_OPENAI_COMPAT,
+    reasoning: true,
+    input: [`text`, `image`],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_048_576,
+    maxTokens: 65_536,
+  },
+  {
+    id: `orcarouter/fusion-flash`,
+    name: `Fusion Flash`,
+    api: `openai-completions`,
+    provider: ORCAROUTER_PROVIDER,
+    baseUrl: ORCAROUTER_API_BASE_URL,
+    compat: ORCAROUTER_OPENAI_COMPAT,
+    reasoning: false,
+    input: [`text`],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 32_768,
+  },
+  {
+    id: `orcarouter/fusion-mini`,
+    name: `Fusion Mini`,
+    api: `openai-completions`,
+    provider: ORCAROUTER_PROVIDER,
+    baseUrl: ORCAROUTER_API_BASE_URL,
+    compat: ORCAROUTER_OPENAI_COMPAT,
+    reasoning: false,
+    input: [`text`],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_048_576,
+    maxTokens: 65_536,
+  },
+]
+
+const ORCAROUTER_MODELS_BY_ID = new Map(
+  ORCAROUTER_MODELS.map((model) => [model.id, model])
+)
+
+export function getOrcaRouterModels(): Array<OrcaRouterModel> {
+  return ORCAROUTER_MODELS.slice()
+}
+
+export function getOrcaRouterModel(id: string): OrcaRouterModel | undefined {
+  return ORCAROUTER_MODELS_BY_ID.get(id)
+}
+
+export function getOrcaRouterApiKey(): string | undefined {
+  return process.env[ORCAROUTER_API_KEY_ENV]?.trim() || undefined
+}

--- a/packages/agents-runtime/src/pi-adapter.ts
+++ b/packages/agents-runtime/src/pi-adapter.ts
@@ -11,6 +11,7 @@ import { Agent } from '@mariozechner/pi-agent-core'
 import { getModel, streamSimple } from '@mariozechner/pi-ai'
 import { createOutboundBridge } from './outbound-bridge'
 import { MOONSHOT_PROVIDER, getMoonshotModel } from './moonshot-models'
+import { ORCAROUTER_PROVIDER, getOrcaRouterModel } from './orcarouter-models'
 import { runtimeLog } from './log'
 import { approxTokens } from './token-budget'
 import type { AgentMessageLike, CompactContextFn } from './compaction-midturn'
@@ -130,10 +131,12 @@ export function resolvePiModel(opts: {
   const model =
     provider === MOONSHOT_PROVIDER
       ? getMoonshotModel(opts.model)
-      : getModel(
-          provider as KnownProvider,
-          opts.model as Parameters<typeof getModel>[1]
-        )
+      : provider === ORCAROUTER_PROVIDER
+        ? getOrcaRouterModel(opts.model)
+        : getModel(
+            provider as KnownProvider,
+            opts.model as Parameters<typeof getModel>[1]
+          )
 
   if (!model) {
     throw new Error(

--- a/packages/agents-runtime/test/model-runner.test.ts
+++ b/packages/agents-runtime/test/model-runner.test.ts
@@ -18,6 +18,7 @@ describe(`completeWithLowCostModel`, () => {
     vi.clearAllMocks()
     process.env = { ...originalEnv }
     delete process.env.MOONSHOT_API_KEY
+    delete process.env.ORCAROUTER_API_KEY
     completeSimple.mockResolvedValue({
       content: [{ type: `text`, text: `ok` }],
       stopReason: `stop`,
@@ -97,6 +98,37 @@ describe(`completeWithLowCostModel`, () => {
       apiKey: `moonshot-key`,
     })
   })
+
+  test(`passes ORCAROUTER_API_KEY for orcarouter low-cost models`, async () => {
+    process.env.ORCAROUTER_API_KEY = `orcarouter-key`
+
+    await completeWithLowCostModel({
+      catalog: {
+        choices: [
+          { provider: `orcarouter`, id: `orcarouter/auto`, reasoning: true },
+        ],
+        defaultChoice: {
+          provider: `orcarouter`,
+          id: `orcarouter/auto`,
+          reasoning: true,
+        },
+      },
+      purpose: `URL extraction`,
+      systemPrompt: `Custom instructions`,
+      prompt: `Extract the title`,
+      maxTokens: 128,
+    })
+
+    expect(completeSimple).toHaveBeenCalledOnce()
+    expect(completeSimple.mock.calls[0][0]).toMatchObject({
+      provider: `orcarouter`,
+      id: `orcarouter/auto`,
+      baseUrl: `https://api.orcarouter.ai/v1`,
+    })
+    expect(completeSimple.mock.calls[0][2]).toMatchObject({
+      apiKey: `orcarouter-key`,
+    })
+  })
 })
 
 describe(`detectAvailableProviders`, () => {
@@ -106,6 +138,7 @@ describe(`detectAvailableProviders`, () => {
     delete process.env.OPENAI_API_KEY
     delete process.env.DEEPSEEK_API_KEY
     delete process.env.MOONSHOT_API_KEY
+    delete process.env.ORCAROUTER_API_KEY
     process.env.CODEX_AUTH_PATH = `/nonexistent/auth.json`
   })
 
@@ -131,14 +164,25 @@ describe(`detectAvailableProviders`, () => {
     expect(detectAvailableProviders()).not.toContain(`moonshot`)
   })
 
+  test(`detects orcarouter when ORCAROUTER_API_KEY is set`, () => {
+    process.env.ORCAROUTER_API_KEY = `test-key`
+    expect(detectAvailableProviders()).toContain(`orcarouter`)
+  })
+
+  test(`does not include orcarouter when ORCAROUTER_API_KEY is absent`, () => {
+    expect(detectAvailableProviders()).not.toContain(`orcarouter`)
+  })
+
   test(`detects multiple providers simultaneously`, () => {
     process.env.ANTHROPIC_API_KEY = `ant-key`
     process.env.DEEPSEEK_API_KEY = `ds-key`
     process.env.MOONSHOT_API_KEY = `moonshot-key`
+    process.env.ORCAROUTER_API_KEY = `orcarouter-key`
     const providers = detectAvailableProviders()
     expect(providers).toContain(`anthropic`)
     expect(providers).toContain(`deepseek`)
     expect(providers).toContain(`moonshot`)
+    expect(providers).toContain(`orcarouter`)
   })
 })
 
@@ -183,5 +227,35 @@ describe(`selectLowCostModelChoice with moonshot`, () => {
     })
     expect(choice.provider).toBe(`moonshot`)
     expect(choice.id).toBe(`kimi-k2.6`)
+  })
+})
+
+describe(`selectLowCostModelChoice with orcarouter`, () => {
+  test(`selects orcarouter/auto as preferred orcarouter low-cost model`, () => {
+    const catalog = {
+      choices: [
+        {
+          provider: `orcarouter`,
+          id: `orcarouter/fusion`,
+          reasoning: true,
+        },
+        {
+          provider: `orcarouter`,
+          id: `orcarouter/auto`,
+          reasoning: true,
+        },
+      ],
+      defaultChoice: {
+        provider: `orcarouter`,
+        id: `orcarouter/fusion`,
+        reasoning: true,
+      },
+    }
+    const choice = selectLowCostModelChoice(catalog, {
+      provider: `orcarouter`,
+      model: `orcarouter/fusion`,
+    })
+    expect(choice.provider).toBe(`orcarouter`)
+    expect(choice.id).toBe(`orcarouter/auto`)
   })
 })

--- a/packages/agents-runtime/test/pi-adapter.test.ts
+++ b/packages/agents-runtime/test/pi-adapter.test.ts
@@ -900,6 +900,18 @@ describe(`resolvePiModel`, () => {
     expect(model.baseUrl).toBe(`https://api.moonshot.ai/v1`)
   })
 
+  it(`resolves OrcaRouter string model ids to OpenAI-compatible models`, () => {
+    const model = resolvePiModel({
+      provider: `orcarouter`,
+      model: `orcarouter/auto`,
+    })
+
+    expect(model.provider).toBe(`orcarouter`)
+    expect(model.id).toBe(`orcarouter/auto`)
+    expect(model.api).toBe(`openai-completions`)
+    expect(model.baseUrl).toBe(`https://api.orcarouter.ai/v1`)
+  })
+
   it(`accepts custom Model objects directly`, () => {
     const customModel: Model<`openai-completions`> = {
       id: `deepseek-v4-flash`,

--- a/packages/agents-server-ui/src/components/ApiKeysForm.tsx
+++ b/packages/agents-server-ui/src/components/ApiKeysForm.tsx
@@ -13,6 +13,7 @@ export type ApiKeysFormValues = {
   openai: string
   deepseek: string
   moonshot: string
+  orcarouter: string
   brave: string
   e2b: string
 }
@@ -89,6 +90,7 @@ export function ApiKeysForm({
   const [openai, setOpenai] = useState(initial.openai)
   const [deepseek, setDeepseek] = useState(initial.deepseek)
   const [moonshot, setMoonshot] = useState(initial.moonshot)
+  const [orcarouter, setOrcarouter] = useState(initial.orcarouter)
   const [brave, setBrave] = useState(initial.brave)
   const [e2b, setE2b] = useState(initial.e2b)
   const [visibleKeys, setVisibleKeys] = useState<
@@ -98,6 +100,7 @@ export function ApiKeysForm({
     openai: false,
     deepseek: false,
     moonshot: false,
+    orcarouter: false,
     brave: false,
     e2b: false,
   })
@@ -115,6 +118,7 @@ export function ApiKeysForm({
     openai: false,
     deepseek: false,
     moonshot: false,
+    orcarouter: false,
     brave: false,
     e2b: false,
   })
@@ -124,7 +128,8 @@ export function ApiKeysForm({
       (anthropic.trim().length > 0 ||
         openai.trim().length > 0 ||
         deepseek.trim().length > 0 ||
-        moonshot.trim().length > 0)) ||
+        moonshot.trim().length > 0 ||
+        orcarouter.trim().length > 0)) ||
     (showBrave && brave.trim().length > 0) ||
     (showE2b && e2b.trim().length > 0)
 
@@ -132,12 +137,21 @@ export function ApiKeysForm({
     if (!canSave || saving) return
     setSaving(true)
     try {
-      await onSave({ anthropic, openai, deepseek, moonshot, brave, e2b })
+      await onSave({
+        anthropic,
+        openai,
+        deepseek,
+        moonshot,
+        orcarouter,
+        brave,
+        e2b,
+      })
       persistedRef.current = {
         anthropic,
         openai,
         deepseek,
         moonshot,
+        orcarouter,
         brave,
         e2b,
       }
@@ -149,6 +163,7 @@ export function ApiKeysForm({
     openai,
     deepseek,
     moonshot,
+    orcarouter,
     brave,
     e2b,
     canSave,
@@ -191,6 +206,7 @@ export function ApiKeysForm({
         openai,
         deepseek,
         moonshot,
+        orcarouter,
         brave,
         e2b,
       })
@@ -201,6 +217,7 @@ export function ApiKeysForm({
       openai,
       deepseek,
       moonshot,
+      orcarouter,
       brave,
       e2b,
       persistIfDirty,
@@ -315,6 +332,23 @@ export function ApiKeysForm({
               }
             />
             {modelControls?.moonshot}
+            <SettingsRow
+              label="OrcaRouter API"
+              description="Smart-routed gateway for open models. Looks like sk-orca-…"
+              splitLayout
+              control={
+                <ApiKeyInput
+                  field="orcarouter"
+                  placeholder="sk-orca-…"
+                  value={orcarouter}
+                  visible={visibleKeys.orcarouter}
+                  onChange={wrapOnChange(`orcarouter`, setOrcarouter)}
+                  onBlur={() => handleAutoSaveBlur(`orcarouter`)}
+                  onToggleVisible={toggleVisible}
+                />
+              }
+            />
+            {modelControls?.orcarouter}
           </>
         )}
         {showBrave && (
@@ -446,6 +480,19 @@ export function ApiKeysForm({
                 value={moonshot}
                 visible={visibleKeys.moonshot}
                 onChange={setMoonshot}
+                onToggleVisible={toggleVisible}
+              />
+            </Field>
+            <Field
+              label="OrcaRouter API (optional)"
+              description="Smart-routed gateway for open models. Looks like sk-orca-…"
+            >
+              <ApiKeyInput
+                field="orcarouter"
+                placeholder="sk-orca-…"
+                value={orcarouter}
+                visible={visibleKeys.orcarouter}
+                onChange={setOrcarouter}
                 onToggleVisible={toggleVisible}
               />
             </Field>

--- a/packages/agents-server-ui/src/components/OnboardingModal.tsx
+++ b/packages/agents-server-ui/src/components/OnboardingModal.tsx
@@ -81,6 +81,7 @@ const MODEL_PROVIDER_IDS: ReadonlyArray<ProviderId> = [
   `openai`,
   `deepseek`,
   `moonshot`,
+  `orcarouter`,
 ]
 
 const MODEL_PROVIDERS: ReadonlyArray<{
@@ -116,6 +117,13 @@ const MODEL_PROVIDERS: ReadonlyArray<{
     name: `Kimi / Moonshot API`,
     description: `Kimi models from Moonshot's OpenAI-compatible API.`,
     placeholder: `sk-…`,
+    kind: `model`,
+  },
+  {
+    id: `orcarouter`,
+    name: `OrcaRouter API`,
+    description: `Smart-routed gateway for open models via OpenAI-compatible API.`,
+    placeholder: `sk-orca-…`,
     kind: `model`,
   },
 ]
@@ -866,6 +874,7 @@ function ProviderItem({
         openai: keysStatus.saved.openai ?? null,
         deepseek: keysStatus.saved.deepseek ?? null,
         moonshot: keysStatus.saved.moonshot ?? null,
+        orcarouter: keysStatus.saved.orcarouter ?? null,
         brave: keysStatus.saved.brave ?? null,
         // e2b is configured in Settings → Credentials, not onboarding;
         // preserve any saved value so editing another key here can't wipe it.

--- a/packages/agents-server-ui/src/components/settings/pages/CredentialsPage.tsx
+++ b/packages/agents-server-ui/src/components/settings/pages/CredentialsPage.tsx
@@ -166,6 +166,8 @@ export function CredentialsPage(): React.ReactElement {
                   status.saved.deepseek ?? status.suggested.deepseek ?? ``,
                 moonshot:
                   status.saved.moonshot ?? status.suggested.moonshot ?? ``,
+                orcarouter:
+                  status.saved.orcarouter ?? status.suggested.orcarouter ?? ``,
                 brave: status.saved.brave ?? ``,
                 e2b: status.saved.e2b ?? ``,
               }}
@@ -177,15 +179,23 @@ export function CredentialsPage(): React.ReactElement {
                   status.suggested.anthropic ||
                     status.suggested.openai ||
                     status.suggested.deepseek ||
-                    status.suggested.moonshot
+                    status.suggested.moonshot ||
+                    status.suggested.orcarouter
                 )
               }
-              onSave={async ({ anthropic, openai, deepseek, moonshot }) => {
+              onSave={async ({
+                anthropic,
+                openai,
+                deepseek,
+                moonshot,
+                orcarouter,
+              }) => {
                 await persistApiKeys({
                   anthropic: anthropic.trim() || null,
                   openai: openai.trim() || null,
                   deepseek: deepseek.trim() || null,
                   moonshot: moonshot.trim() || null,
+                  orcarouter: orcarouter.trim() || null,
                   brave: status.saved.brave ?? null,
                   e2b: status.saved.e2b ?? null,
                 })
@@ -232,6 +242,16 @@ export function CredentialsPage(): React.ReactElement {
                     }}
                   />
                 ),
+                orcarouter: (
+                  <ProviderModelSettings
+                    status={status.modelPicker}
+                    provider="orcarouter"
+                    onSave={async (values) => {
+                      await persistEnabledModels(values)
+                      await refreshStatus()
+                    }}
+                  />
+                ),
               }}
             />
           </>
@@ -250,6 +270,7 @@ export function CredentialsPage(): React.ReactElement {
               openai: status.saved.openai ?? ``,
               deepseek: status.saved.deepseek ?? ``,
               moonshot: status.saved.moonshot ?? ``,
+              orcarouter: status.saved.orcarouter ?? ``,
               brave: status.saved.brave ?? status.suggested.brave ?? ``,
               e2b: status.saved.e2b ?? status.suggested.e2b ?? ``,
             }}
@@ -264,6 +285,7 @@ export function CredentialsPage(): React.ReactElement {
                 openai: status.saved.openai ?? null,
                 deepseek: status.saved.deepseek ?? null,
                 moonshot: status.saved.moonshot ?? null,
+                orcarouter: status.saved.orcarouter ?? null,
                 brave: brave.trim() || null,
                 e2b: e2b.trim() || null,
               })

--- a/packages/agents-server-ui/src/lib/schemaProperties.ts
+++ b/packages/agents-server-ui/src/lib/schemaProperties.ts
@@ -173,6 +173,7 @@ export const MODEL_PROVIDER_LABELS: Record<string, string> = {
   'openai-codex': `OpenAI Codex`,
   deepseek: `DeepSeek`,
   moonshot: `Kimi`,
+  orcarouter: `OrcaRouter`,
 }
 
 /** The provider prefix of a `provider:model` id, or `other` when unprefixed. */

--- a/packages/agents-server-ui/src/lib/server-connection.ts
+++ b/packages/agents-server-ui/src/lib/server-connection.ts
@@ -86,9 +86,9 @@ export interface ServerConnectionState {
  * `null` means "not set". The renderer never reads these from
  * `process.env` directly — that only exists in main.
  *
- * - `anthropic` / `openai` / `deepseek` / `moonshot`: LLM provider
- *   keys. At least one is required for the local Horton runtime to be
- *   useful; the first-launch dialog auto-opens until one is set.
+ * - `anthropic` / `openai` / `deepseek` / `moonshot` / `orcarouter`: LLM
+ *   provider keys. At least one is required for the local Horton runtime
+ *   to be useful; the first-launch dialog auto-opens until one is set.
  * - `brave`: optional search-tool auxiliary. Mirrored to
  *   `BRAVE_SEARCH_API_KEY` to enable Horton's `brave_search` tool;
  *   without it, web search falls back to Anthropic's built-in search.
@@ -114,6 +114,13 @@ export interface ApiKeys {
    * `anthropic`, `openai`, and `deepseek`.
    */
   moonshot: string | null
+  /**
+   * Optional. Mirrored to `ORCAROUTER_API_KEY` so the runtime can use
+   * OrcaRouter's smart-routed OpenAI-compatible gateway models. Treated
+   * as a peer LLM provider alongside `anthropic`, `openai`, `deepseek`,
+   * and `moonshot`.
+   */
+  orcarouter: string | null
   brave: string | null
   e2b: string | null
 }
@@ -126,6 +133,7 @@ export type ModelProvider =
   | `openai-codex`
   | `deepseek`
   | `moonshot`
+  | `orcarouter`
 
 export interface ModelPickerChoice {
   provider: ModelProvider
@@ -166,8 +174,8 @@ export interface ApiKeysStatus {
    * Per-slot ENV-derived suggestions: a value is provided only for
    * slots that are NOT already saved, so the dialog can pre-fill
    * empty inputs from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` /
-   * `DEEPSEEK_API_KEY` / `MOONSHOT_API_KEY` without overwriting the
-   * user's saved choice.
+   * `DEEPSEEK_API_KEY` / `MOONSHOT_API_KEY` / `ORCAROUTER_API_KEY`
+   * without overwriting the user's saved choice.
    */
   suggested: ApiKeys
   codex: CodexStatus

--- a/packages/agents/src/bootstrap.ts
+++ b/packages/agents/src/bootstrap.ts
@@ -181,7 +181,7 @@ export async function createBuiltinAgentHandler(
 
   if (!modelCatalog) {
     serverLog.warn(
-      `[builtin-agents] no supported model provider API key found — set ANTHROPIC_API_KEY, OPENAI_API_KEY, DEEPSEEK_API_KEY, or MOONSHOT_API_KEY`
+      `[builtin-agents] no supported model provider API key found — set ANTHROPIC_API_KEY, OPENAI_API_KEY, DEEPSEEK_API_KEY, MOONSHOT_API_KEY, or ORCAROUTER_API_KEY`
     )
     return null
   }

--- a/packages/agents/src/model-catalog.ts
+++ b/packages/agents/src/model-catalog.ts
@@ -2,10 +2,15 @@ import { getModels } from '@mariozechner/pi-ai'
 import {
   MOONSHOT_API_BASE_URL,
   MOONSHOT_PROVIDER,
+  ORCAROUTER_API_BASE_URL,
+  ORCAROUTER_PROVIDER,
   detectAvailableProviders,
   getMoonshotApiKey,
   getMoonshotModel,
   getMoonshotModels,
+  getOrcaRouterApiKey,
+  getOrcaRouterModel,
+  getOrcaRouterModels,
   readCodexAccessToken,
 } from '@electric-ax/agents-runtime'
 import type {
@@ -65,6 +70,7 @@ const DEFAULT_OPENAI_MODEL = `gpt-4.1`
 const DEFAULT_CODEX_MODEL = `gpt-5.4`
 const DEFAULT_DEEPSEEK_MODEL = `deepseek-v4-flash`
 const DEFAULT_MOONSHOT_MODEL = `kimi-k2.6`
+const DEFAULT_ORCAROUTER_MODEL = `orcarouter/auto`
 
 function modelValue(provider: BuiltinModelProvider, id: string): string {
   return `${provider}:${id}`
@@ -77,6 +83,7 @@ export function builtinModelProviderLabel(
   if (provider === `openai-codex`) return `OpenAI Codex`
   if (provider === `deepseek`) return `DeepSeek`
   if (provider === MOONSHOT_PROVIDER) return `Kimi`
+  if (provider === ORCAROUTER_PROVIDER) return `OrcaRouter`
   return `OpenAI`
 }
 
@@ -123,12 +130,19 @@ async function fetchAvailableModelIds(
                 },
                 signal: AbortSignal.timeout(3_000),
               })
-            : await fetch(`https://api.openai.com/v1/models`, {
-                headers: {
-                  authorization: `Bearer ${process.env.OPENAI_API_KEY ?? ``}`,
-                },
-                signal: AbortSignal.timeout(3_000),
-              })
+            : provider === ORCAROUTER_PROVIDER
+              ? await fetch(`${ORCAROUTER_API_BASE_URL}/models`, {
+                  headers: {
+                    authorization: `Bearer ${getOrcaRouterApiKey() ?? ``}`,
+                  },
+                  signal: AbortSignal.timeout(3_000),
+                })
+              : await fetch(`https://api.openai.com/v1/models`, {
+                  headers: {
+                    authorization: `Bearer ${process.env.OPENAI_API_KEY ?? ``}`,
+                  },
+                  signal: AbortSignal.timeout(3_000),
+                })
 
     if (res.status === 401 || res.status === 403) return new Set()
     if (!res.ok) return null
@@ -149,9 +163,14 @@ async function fetchAvailableModelIds(
 function knownModelsForProvider(provider: BuiltinModelProvider) {
   return provider === MOONSHOT_PROVIDER
     ? getMoonshotModels()
-    : getModels(
-        provider as Exclude<BuiltinModelProvider, typeof MOONSHOT_PROVIDER>
-      )
+    : provider === ORCAROUTER_PROVIDER
+      ? getOrcaRouterModels()
+      : getModels(
+          provider as Exclude<
+            BuiltinModelProvider,
+            typeof MOONSHOT_PROVIDER | typeof ORCAROUTER_PROVIDER
+          >
+        )
 }
 
 export function resolveBuiltinModelContextWindow(
@@ -161,6 +180,10 @@ export function resolveBuiltinModelContextWindow(
 
   if (modelConfig.provider === MOONSHOT_PROVIDER) {
     return getMoonshotModel(modelId)?.contextWindow ?? null
+  }
+
+  if (modelConfig.provider === ORCAROUTER_PROVIDER) {
+    return getOrcaRouterModel(modelId)?.contextWindow ?? null
   }
 
   if (!modelConfig.provider) return null
@@ -353,6 +376,11 @@ export async function createBuiltinModelCatalog(
         choice.provider === MOONSHOT_PROVIDER &&
         choice.id === DEFAULT_MOONSHOT_MODEL
     ) ??
+    choices.find(
+      (choice) =>
+        choice.provider === ORCAROUTER_PROVIDER &&
+        choice.id === DEFAULT_ORCAROUTER_MODEL
+    ) ??
     choices[0]!
 
   return { choices, defaultChoice }
@@ -392,6 +420,9 @@ export function resolveBuiltinModelConfig(
     }),
     ...(choice.provider === MOONSHOT_PROVIDER && {
       getApiKey: () => getMoonshotApiKey(),
+    }),
+    ...(choice.provider === ORCAROUTER_PROVIDER && {
+      getApiKey: () => getOrcaRouterApiKey(),
     }),
   }
 

--- a/packages/agents/src/server.ts
+++ b/packages/agents/src/server.ts
@@ -317,7 +317,7 @@ export class BuiltinAgentsServer {
       })
       if (!this.bootstrap) {
         throw new Error(
-          `ANTHROPIC_API_KEY, OPENAI_API_KEY, DEEPSEEK_API_KEY, or MOONSHOT_API_KEY must be set before starting builtin agents`
+          `ANTHROPIC_API_KEY, OPENAI_API_KEY, DEEPSEEK_API_KEY, MOONSHOT_API_KEY, or ORCAROUTER_API_KEY must be set before starting builtin agents`
         )
       }
 

--- a/packages/agents/test/model-catalog.test.ts
+++ b/packages/agents/test/model-catalog.test.ts
@@ -23,6 +23,7 @@ describe(`model catalog`, () => {
     delete process.env.ANTHROPIC_API_KEY
     delete process.env.DEEPSEEK_API_KEY
     delete process.env.MOONSHOT_API_KEY
+    delete process.env.ORCAROUTER_API_KEY
     process.env.OPENAI_API_KEY = `test-openai-key`
     process.env.CODEX_AUTH_PATH = `/nonexistent/auth.json`
   })
@@ -358,5 +359,66 @@ describe(`model catalog`, () => {
     })
     expect(config.getApiKey).toBeTypeOf(`function`)
     expect(await config.getApiKey?.(`moonshot`)).toBe(`test-moonshot-key`)
+  })
+
+  it(`lists OrcaRouter models when ORCAROUTER_API_KEY is set`, async () => {
+    delete process.env.OPENAI_API_KEY
+    process.env.ORCAROUTER_API_KEY = `test-orcarouter-key`
+    vi.stubGlobal(
+      `fetch`,
+      vi.fn(async (url: string) => {
+        if (String(url).includes(`api.orcarouter.ai`)) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              data: [{ id: `orcarouter/auto` }, { id: `orcarouter/fusion` }],
+            }),
+          }
+        }
+        return { ok: false, status: 401, json: async () => ({}) }
+      })
+    )
+
+    const catalog = await createBuiltinModelCatalog()
+
+    expect(catalog).not.toBeNull()
+    expect(catalog!.choices.map((c) => c.provider)).toContain(`orcarouter`)
+    expect(catalog!.choices.map((c) => c.value)).toContain(
+      `orcarouter:orcarouter/auto`
+    )
+    expect(catalog!.choices.map((c) => c.value)).toContain(
+      `orcarouter:orcarouter/fusion`
+    )
+  })
+
+  it(`resolves OrcaRouter model config with a runtime API key hook`, async () => {
+    delete process.env.OPENAI_API_KEY
+    process.env.ORCAROUTER_API_KEY = `test-orcarouter-key`
+    vi.stubGlobal(
+      `fetch`,
+      vi.fn(async (url: string) => {
+        if (String(url).includes(`api.orcarouter.ai`)) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ data: [{ id: `orcarouter/auto` }] }),
+          }
+        }
+        return { ok: false, status: 401, json: async () => ({}) }
+      })
+    )
+
+    const catalog = await createBuiltinModelCatalog()
+    const config = resolveBuiltinModelConfig(catalog!, {
+      model: `orcarouter:orcarouter/auto`,
+    })
+
+    expect(config).toMatchObject({
+      provider: `orcarouter`,
+      model: `orcarouter/auto`,
+    })
+    expect(config.getApiKey).toBeTypeOf(`function`)
+    expect(await config.getApiKey?.(`orcarouter`)).toBe(`test-orcarouter-key`)
   })
 })

--- a/website/docs/agents/usage/embedded-builtins.md
+++ b/website/docs/agents/usage/embedded-builtins.md
@@ -88,7 +88,7 @@ interface BuiltinAgentsServerOptions {
 | `openAuthorizeUrl`     | Hook invoked when an `authorizationCode` MCP server first needs user consent. Receives the SDK-generated authorize URL. The desktop opens it in a sandboxed `BrowserWindow`; headless embedders can read the URL from the `authenticating` envelope of `addServer` and surface it themselves. |
 | `onConfigError`        | Invoked when applying an MCP config (initial boot or watcher reload) fails. Errors are always logged; this hook is for surfacing them programmatically.                                                                                                                                |
 
-Without `mockStreamFn`, at least one supported provider must be configured before the built-in handler starts: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DEEPSEEK_API_KEY`, `MOONSHOT_API_KEY`, or a valid OpenAI Codex CLI auth file for the `openai-codex` provider.
+Without `mockStreamFn`, at least one supported provider must be configured before the built-in handler starts: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DEEPSEEK_API_KEY`, `MOONSHOT_API_KEY`, `ORCAROUTER_API_KEY`, or a valid OpenAI Codex CLI auth file for the `openai-codex` provider.
 
 ### Pull-wake headers and principals
 


### PR DESCRIPTION
## Add OrcaRouter as a named model provider

This adds [OrcaRouter](https://www.orcarouter.ai) as a first-class, named LLM provider across the agents subsystem, mirroring the existing Moonshot OpenAI-compatible gateway wiring. Setting `ORCAROUTER_API_KEY` surfaces OrcaRouter models (`orcarouter/auto`, `fusion`, `fusion-flash`, `fusion-mini`) in the model picker and lets the built-in Horton/Worker agents route through `https://api.orcarouter.ai/v1`.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What changed

- **`@electric-ax/agents-runtime`**: new `orcarouter-models.ts` with 4 OpenAI-compatible gateway models routed to `https://api.orcarouter.ai/v1`; `ORCAROUTER_API_KEY` env detection, low-cost model selection, and pi-adapter model resolution.
- **`@electric-ax/agents`**: model-catalog integration so built-in agents can use OrcaRouter models (provider label + API-key hook), plus the "no provider key" error text.
- **`@electric-ax/agents-server-ui`** + **`@electric-ax/agents-desktop`**: OrcaRouter API key input, model-picker option, provider label, and onboarding/settings wiring.
- **`examples/deep-survey`**: optional `ORCAROUTER_API_KEY` worker model.
- **Docs**: provider env-key list updated.

### Verification

- `agents-runtime`: `model-runner` + `pi-adapter` tests pass (49 tests, incl. 7 new OrcaRouter ones).
- `agents`: `model-catalog` tests pass (18 tests, incl. 2 new OrcaRouter ones).
- `agents-server-ui`: 113 tests pass.
- Typecheck: `agents-runtime`, `agents`, `agents-server-ui`, `agents-desktop` (touched files), `examples/deep-survey` all clean.
- Prettier + ESLint clean on all touched files.
- **L3 live test**: a real OrcaRouter key round-trips through the actual provider code path (`getOrcaRouterModel('orcarouter/auto')` + `completeSimple`) against `https://api.orcarouter.ai/v1/chat/completions` → `200`, response contains `ORCA-LIVE-OK`.

Disclosure: I'm an engineer on the OrcaRouter team.
