### PR TITLE
Fix authentication bypass on /v1/shape via path-normalization mismatch

### DIFF
--- a/.changeset/shape-auth-path-normalization-bypass.md
+++ b/.changeset/shape-auth-path-normalization-bypass.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix an authentication bypass on `/v1/shape` in secure mode. Authentication now gates on the route resolved by the router rather than on the raw request path, so requests whose target normalizes to `/v1/shape` (e.g. a trailing slash, a doubled slash, or a percent-encoded character) can no longer skip the secret check. CORS headers for shape routes are matched the same way.

--- a/packages/sync-service/lib/electric/plug/router.ex
+++ b/packages/sync-service/lib/electric/plug/router.ex
@@ -55,14 +55,10 @@ defmodule Electric.Plug.Router do
   # OPTIONS requests should not be authenticated
   def authenticate(%Plug.Conn{method: "OPTIONS"} = conn, _opts), do: conn
 
-  # Gate on the route the router already resolved (`conn.private.plug_route`,
-  # set by `plug :match` before this plug runs) rather than on the raw
-  # `request_path`. `match/2` dispatches on the percent-decoded,
-  # empty-segment-stripped path, so any request whose decoded path routes to
-  # "/v1/shape" — e.g. "/v1/shape/", "/v1//shape", "/v1/%73hape" — must be
-  # authenticated here, even though its raw request target is not exactly
-  # "/v1/shape". Matching `request_path` or `path_info` (which is never decoded)
-  # would leave those variants as an authentication bypass.
+  # `conn.private.plug_route` is set by `plug :match` before this plug runs, turning e.g.
+  # "/v1/shape/", "/v1//shape", "/v1/%73hape" into the same normalized path.
+  # Matching `request_path` or `path_info` (which is never decoded) would leave those variants
+  # as an authentication bypass.
   def authenticate(%Plug.Conn{private: %{plug_route: {"/v1/shape", _}}} = conn, _opts) do
     api_secret = conn.assigns.config[:secret]
 
@@ -90,10 +86,7 @@ defmodule Electric.Plug.Router do
   def authenticate(conn, _opts), do: conn
 
   # Match the resolved route rather than the never-decoded `path_info`, for the
-  # same reason as `authenticate/2` above: `path_info` still holds the raw,
-  # percent-encoded segments at this point, so a request like "/v1/%73hape"
-  # would route to the shape handler yet miss this clause and get the default
-  # CORS method list.
+  # same reason as `authenticate/2` above.
   def put_cors_headers(%Plug.Conn{private: %{plug_route: {"/v1/shape", _}}} = conn, _opts),
     do: CORSHeaderPlug.call(conn, %{methods: ["GET", "POST", "HEAD", "DELETE", "OPTIONS"]})
 

--- a/packages/sync-service/lib/electric/plug/router.ex
+++ b/packages/sync-service/lib/electric/plug/router.ex
@@ -89,7 +89,12 @@ defmodule Electric.Plug.Router do
   # For unmatched routes, just pass through
   def authenticate(conn, _opts), do: conn
 
-  def put_cors_headers(%Plug.Conn{path_info: ["v1", "shape" | _]} = conn, _opts),
+  # Match the resolved route rather than the never-decoded `path_info`, for the
+  # same reason as `authenticate/2` above: `path_info` still holds the raw,
+  # percent-encoded segments at this point, so a request like "/v1/%73hape"
+  # would route to the shape handler yet miss this clause and get the default
+  # CORS method list.
+  def put_cors_headers(%Plug.Conn{private: %{plug_route: {"/v1/shape", _}}} = conn, _opts),
     do: CORSHeaderPlug.call(conn, %{methods: ["GET", "POST", "HEAD", "DELETE", "OPTIONS"]})
 
   def put_cors_headers(conn, _opts),

--- a/packages/sync-service/lib/electric/plug/router.ex
+++ b/packages/sync-service/lib/electric/plug/router.ex
@@ -55,7 +55,15 @@ defmodule Electric.Plug.Router do
   # OPTIONS requests should not be authenticated
   def authenticate(%Plug.Conn{method: "OPTIONS"} = conn, _opts), do: conn
 
-  def authenticate(%Plug.Conn{request_path: "/v1/shape"} = conn, _opts) do
+  # Gate on the route the router already resolved (`conn.private.plug_route`,
+  # set by `plug :match` before this plug runs) rather than on the raw
+  # `request_path`. `match/2` dispatches on the percent-decoded,
+  # empty-segment-stripped path, so any request whose decoded path routes to
+  # "/v1/shape" — e.g. "/v1/shape/", "/v1//shape", "/v1/%73hape" — must be
+  # authenticated here, even though its raw request target is not exactly
+  # "/v1/shape". Matching `request_path` or `path_info` (which is never decoded)
+  # would leave those variants as an authentication bypass.
+  def authenticate(%Plug.Conn{private: %{plug_route: {"/v1/shape", _}}} = conn, _opts) do
     api_secret = conn.assigns.config[:secret]
 
     if is_nil(api_secret) do

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -98,6 +98,30 @@ defmodule Electric.Plug.RouterTest do
              ] = response
     end
 
+    @tag with_sql: [
+           "INSERT INTO items VALUES (gen_random_uuid(), 'test value 1')"
+         ]
+    test "GET on path-normalization variants still routes to the shape handler", %{opts: opts} do
+      # In insecure mode (no secret) these variants must still be dispatched to
+      # the shape handler and served — gating auth on `plug_route` must not
+      # over-block or break routing for paths that normalize to "/v1/shape".
+      for path <- ["/v1/shape/", "/v1//shape", "/v1/shape//", "/v1/%73hape"] do
+        conn =
+          conn("GET", path <> "?table=items&offset=-1")
+          |> Router.call(opts)
+
+        assert %{status: 200} = conn, "expected 200 (routed to shape handler) for GET #{path}"
+
+        assert [
+                 %{
+                   "headers" => %{"operation" => "insert"},
+                   "value" => %{"value" => "test value 1"}
+                 },
+                 %{"headers" => %{"control" => "snapshot-end"}}
+               ] = Jason.decode!(conn.resp_body)
+      end
+    end
+
     test "GET returns an error when table is not found", %{opts: opts} do
       conn =
         conn("GET", "/v1/shape?table=nonexistent&offset=-1")

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -1793,6 +1793,28 @@ defmodule Electric.Plug.RouterTest do
       assert allowed_methods == MapSet.new(["GET", "POST", "HEAD", "OPTIONS", "DELETE"])
     end
 
+    test "OPTIONS on a percent-encoded shape path still receives shape methods", %{opts: opts} do
+      # `%73` decodes to `s`, so `match/2` dispatches this to the shape handler.
+      # CORS headers must follow the route the router resolved (plug_route), not
+      # the never-decoded path_info — otherwise this falls back to the default
+      # GET/HEAD method list.
+      conn =
+        conn("OPTIONS", "/v1/%73hape?table=items")
+        |> Router.call(opts)
+
+      assert %{status: 204} = conn
+
+      allowed_methods =
+        conn
+        |> Plug.Conn.get_resp_header("access-control-allow-methods")
+        |> List.first("")
+        |> String.split(",")
+        |> Enum.map(&String.trim/1)
+        |> MapSet.new()
+
+      assert allowed_methods == MapSet.new(["GET", "POST", "HEAD", "OPTIONS", "DELETE"])
+    end
+
     @tag slow: true
     test "GET with a concurrent transaction doesn't crash irrecoverably", %{
       opts: opts,

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -4063,6 +4063,34 @@ defmodule Electric.Plug.RouterTest do
 
       # Note: Returns 400 because shape params are required, but authentication passed
     end
+
+    test "requires secret for path-normalization variants of /v1/shape", %{
+      secret: secret,
+      api_opts: api_opts
+    } do
+      # Each of these raw request targets routes to the shape handler once
+      # `match/2` percent-decodes and empty-segment-strips the path, but its raw
+      # request_path is not exactly "/v1/shape". Authentication must gate on the
+      # resolved route, so all of them still require the secret.
+      #
+      # `//v1/shape` is provable only over the wire: Plug.Test runs paths through
+      # URI.parse, which reads a leading "//" as an authority (host=v1) and 404s
+      # regardless of the fix, so it's intentionally omitted here.
+      for path <- ["/v1/shape/", "/v1//shape", "/v1/shape//", "/v1/%73hape"] do
+        opts = Keyword.merge([secret: secret], api_opts)
+
+        assert %{status: 401} = Router.call(conn("GET", path), opts),
+               "expected 401 for GET #{path}"
+
+        assert %{status: 401} = Router.call(conn("DELETE", path), opts),
+               "expected 401 for DELETE #{path}"
+
+        # And the secret still grants access via the normalized path (proving we
+        # gate on the resolved route rather than rejecting these outright).
+        assert %{status: 400} = Router.call(conn("GET", path <> "?secret=#{secret}"), opts),
+               "expected 400 (authenticated) for GET #{path} with secret"
+      end
+    end
   end
 
   defp get_resp_shape_handle(conn), do: get_resp_header(conn, "electric-handle")


### PR DESCRIPTION
## Summary

Fixes an authentication bypass on `/v1/shape` in secure mode (private advisory **GHSA-m4f6-p2j8-rq76**).

`authenticate/2` guarded on `conn.request_path` — the raw request target — while `plug :match` dispatches on the percent-decoded, empty-segment-stripped path. Any request whose decoded path routes to `/v1/shape` but whose raw target is not exactly `"/v1/shape"` was dispatched to `ServeShapePlug` / `DeleteShapePlug` while falling through the unauthenticated catch-all clause, bypassing secure mode entirely — no credential required:

```
GET /v1/shape      -> 401 Unauthorized   (enforced)
GET /v1/shape/     -> 200                 (bypass)
GET /v1//shape     -> 200                 (bypass)
GET /v1/%73hape    -> 200                 (bypass, %73 = "s")
```

Affects GET, POST, DELETE and HEAD; OPTIONS is exempt by design. Only secure-mode deployments (`secret != nil`) are affected.

## Fix

- `authenticate/2` now matches on the route the router already resolved (`conn.private.plug_route`, set by `plug :match` before the later plugs run) instead of the raw `request_path`. This authenticates exactly what dispatch will serve, for every encoding and slash variant and on every method, with OPTIONS still exempt and unmatched routes still reaching the 404 catch-all.
- `put_cors_headers/2` shared the same latent weakness — it keyed on the never-decoded `path_info` — and is switched to the same `plug_route` basis so CORS headers follow the resolved route.

## Credit

Reported by Yahya Jirari, Beeldi (GHSA-m4f6-p2j8-rq76).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
