### PR TITLE
Advance the global last seen LSN only on commit fragments

### DIFF
--- a/.changeset/global-lsn-commit-fragment-only.md
+++ b/.changeset/global-lsn-commit-fragment-only.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Only advance the global last seen LSN on commit-bearing transaction fragments. Large transactions are split into multiple fragments that all carry the transaction's final LSN, so a `up-to-date` response could previously advertise an LSN whose changes were not yet readable in the shape logs, and a later response could then return data at that same LSN.

--- a/packages/sync-service/lib/electric/replication/shape_log_collector.ex
+++ b/packages/sync-service/lib/electric/replication/shape_log_collector.ex
@@ -899,11 +899,6 @@ defmodule Electric.Replication.ShapeLogCollector do
            Map.merge(delivered_acc, layer_delivered)}
       end
 
-    OpenTelemetry.start_interval(:"shape_log_collector.set_last_processed_lsn.duration_µs")
-
-    lsn = Lsn.from_integer(state.last_processed_offset.tx_offset)
-    LsnTracker.set_last_processed_lsn(state.stack_id, lsn)
-
     delivered_shapes =
       MapSet.difference(affected_shapes, undeliverable |> Map.keys() |> MapSet.new())
 
@@ -925,6 +920,10 @@ defmodule Electric.Replication.ShapeLogCollector do
 
     case event do
       %TransactionFragment{commit: commit} when not is_nil(commit) ->
+        OpenTelemetry.start_interval(:"shape_log_collector.set_last_processed_lsn.duration_µs")
+
+        lsn = Lsn.from_integer(state.last_processed_offset.tx_offset)
+        LsnTracker.set_last_processed_lsn(state.stack_id, lsn)
         LsnTracker.broadcast_last_seen_lsn(state.stack_id, lsn)
 
         flush_tracker =

--- a/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
+++ b/packages/sync-service/test/electric/replication/shape_log_collector_test.exs
@@ -22,7 +22,8 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       patch_calls: 3,
       expect_calls: 2,
       register_as_replication_client: 1,
-      complete_txn_fragment: 3
+      complete_txn_fragment: 3,
+      txn_fragments: 3
     ]
 
   import Support.ComponentSetup
@@ -1445,6 +1446,176 @@ defmodule Electric.Replication.ShapeLogCollectorTest do
       assert :ok = ShapeLogCollector.handle_event(fragment, ctx.stack_id)
 
       refute_receive {:global_last_seen_lsn, _}
+    end
+  end
+
+  describe "public last processed LSN across transaction fragments" do
+    @shape Shape.new!("test_table", inspector: @inspector)
+    # Only matches the second of the two records used below, so it stays
+    # invisible to the EventRouter until the commit fragment arrives.
+    @late_shape Shape.new!("test_table", where: "id > 1", inspector: @inspector)
+
+    setup [:with_registry, :setup_log_collector]
+
+    setup ctx do
+      parent = self()
+
+      stub_inspector(
+        load_relation_oid: fn {"public", "test_table"}, _ ->
+          {:ok, {1234, {"public", "test_table"}}}
+        end,
+        load_relation_info: fn 1234, _ ->
+          {:ok, %{id: 1234, schema: "public", name: "test_table", parent: nil, children: nil}}
+        end,
+        load_column_info: fn 1234, _ ->
+          {:ok, [%{pk_position: 0, name: "id", is_generated: false}]}
+        end
+      )
+
+      consumers =
+        for id <- 1..2 do
+          consumer =
+            start_link_supervised!(%{
+              id: {:consumer, id},
+              start:
+                {Support.TransactionConsumer, :start_link,
+                 [
+                   [
+                     id: id,
+                     stack_id: ctx.stack_id,
+                     parent: parent,
+                     shape: @shape,
+                     shape_handle: "#{@shape_handle}-#{id}"
+                   ]
+                 ]},
+              restart: :temporary
+            })
+
+          {id, consumer}
+        end
+
+      # Start from a non-zero committed frontier so that "the public LSN has not
+      # moved" is distinguishable from "the public LSN was never populated".
+      prev_lsn = Lsn.from_integer(100)
+      :ok = LsnTracker.set_last_processed_lsn(ctx.stack_id, prev_lsn)
+      :ok = ShapeLogCollector.mark_as_ready(ctx.stack_id)
+
+      %{consumers: consumers, prev_lsn: prev_lsn, txn_lsn: Lsn.from_integer(200)}
+    end
+
+    test "stays at the previous transaction until the commit fragment is processed", ctx do
+      %{stack_id: stack_id, consumers: consumers, prev_lsn: prev_lsn, txn_lsn: txn_lsn} = ctx
+
+      [fragment1, fragment2] =
+        txn_fragments(100, txn_lsn, [
+          %{
+            changes: [new_record(txn_lsn, 0, "1"), new_record(txn_lsn, 2, "2")],
+            has_begin?: true
+          },
+          %{changes: [new_record(txn_lsn, 4, "3")], has_commit?: true}
+        ])
+
+      assert :ok = ShapeLogCollector.handle_event(fragment1, stack_id)
+      Support.TransactionConsumer.assert_consume(consumers, [fragment1])
+
+      # Every fragment inherits the transaction's final LSN, but a non-commit
+      # fragment's changes are not readable yet, so publishing that LSN as the
+      # global proof would let a client see proof T before any data at T.
+      assert LsnTracker.get_last_processed_lsn(stack_id) == prev_lsn
+
+      assert :ok = ShapeLogCollector.handle_event(fragment2, stack_id)
+      Support.TransactionConsumer.assert_consume(consumers, [fragment2])
+
+      assert LsnTracker.get_last_processed_lsn(stack_id) == txn_lsn
+    end
+
+    test "stays put when a shape first appears in the commit fragment", ctx do
+      %{stack_id: stack_id, prev_lsn: prev_lsn, txn_lsn: txn_lsn} = ctx
+
+      late_consumer =
+        start_link_supervised!(
+          {Support.TransactionConsumer,
+           id: :late,
+           stack_id: stack_id,
+           parent: self(),
+           shape: @late_shape,
+           shape_handle: "#{@shape_handle}-late"},
+          id: {:consumer, :late}
+        )
+
+      late_consumers = [{:late, late_consumer}]
+
+      [fragment1, fragment2] =
+        txn_fragments(100, txn_lsn, [
+          %{changes: [new_record(txn_lsn, 0, "1")], has_begin?: true},
+          %{changes: [new_record(txn_lsn, 2, "2")], has_commit?: true}
+        ])
+
+      assert :ok = ShapeLogCollector.handle_event(fragment1, stack_id)
+
+      # The EventRouter cannot know yet that this shape takes part in the
+      # transaction, which is exactly why the proof must not advance.
+      Support.TransactionConsumer.refute_consume(late_consumers)
+      assert LsnTracker.get_last_processed_lsn(stack_id) == prev_lsn
+
+      assert :ok = ShapeLogCollector.handle_event(fragment2, stack_id)
+
+      Support.TransactionConsumer.assert_consume(late_consumers, [%{fragment2 | has_begin?: true}])
+
+      assert LsnTracker.get_last_processed_lsn(stack_id) == txn_lsn
+    end
+
+    test "only advances once every participating consumer has handled the commit", ctx do
+      %{stack_id: stack_id, consumers: consumers, prev_lsn: prev_lsn, txn_lsn: txn_lsn} = ctx
+
+      [fragment1, fragment2] =
+        txn_fragments(100, txn_lsn, [
+          %{changes: [new_record(txn_lsn, 0, "1")], has_begin?: true},
+          %{
+            changes: [
+              new_record(txn_lsn, 2, "block-until-released", %{
+                "handle" => "#{@shape_handle}-2"
+              })
+            ],
+            has_commit?: true
+          }
+        ])
+
+      assert :ok = ShapeLogCollector.handle_event(fragment1, stack_id)
+      Support.TransactionConsumer.assert_consume(consumers, [fragment1])
+
+      task = Task.async(fn -> ShapeLogCollector.handle_event(fragment2, stack_id) end)
+
+      assert_receive {Support.TransactionConsumer, {2, _pid}, {:blocked, from}}, 1000
+
+      # The collector is still inside ConsumerRegistry.publish/2 waiting on this
+      # consumer, so the transaction is not durable for every shape yet.
+      assert LsnTracker.get_last_processed_lsn(stack_id) == prev_lsn
+
+      GenServer.reply(from, :ok)
+
+      assert :ok = Task.await(task)
+      assert LsnTracker.get_last_processed_lsn(stack_id) == txn_lsn
+    end
+
+    test "advances on a transaction that affects no shapes", ctx do
+      %{stack_id: stack_id, consumers: consumers, txn_lsn: txn_lsn} = ctx
+
+      # A transaction filtered out entirely still has to move the proof forward,
+      # otherwise clients would stall behind traffic they don't care about.
+      assert :ok =
+               ShapeLogCollector.handle_event(complete_txn_fragment(100, txn_lsn, []), stack_id)
+
+      Support.TransactionConsumer.refute_consume(consumers)
+      assert LsnTracker.get_last_processed_lsn(stack_id) == txn_lsn
+    end
+
+    defp new_record(lsn, op_index, id, extra \\ %{}) do
+      %Changes.NewRecord{
+        relation: {"public", "test_table"},
+        record: Map.merge(%{"id" => id}, extra),
+        log_offset: LogOffset.new(lsn, op_index)
+      }
     end
   end
 

--- a/packages/sync-service/test/support/transaction_consumer.ex
+++ b/packages/sync-service/test/support/transaction_consumer.ex
@@ -85,7 +85,7 @@ defmodule Support.TransactionConsumer do
 
   def handle_call(
         {:handle_event, %Changes.TransactionFragment{} = txn_fragment, _ctx},
-        _from,
+        from,
         state
       ) do
     send(state.parent, {__MODULE__, {state.id, self()}, [txn_fragment]})
@@ -99,6 +99,13 @@ defmodule Support.TransactionConsumer do
         }
       ] ->
         exit(reason)
+
+      [%Changes.NewRecord{record: %{"id" => "block-until-released", "handle" => ^handle}}] ->
+        # Hold the reply so the test can hold the ShapeLogCollector inside
+        # ConsumerRegistry.publish/2 and observe its state mid-fan-out. The
+        # test releases us with `GenServer.reply(from, :ok)`.
+        send(state.parent, {__MODULE__, {state.id, self()}, {:blocked, from}})
+        {:noreply, state}
 
       _ ->
         {:reply, :ok, state}


### PR DESCRIPTION
Fixes #4755

## Problem

Since transactions started being published as `TransactionFragment`s, every fragment of a large transaction carries the transaction's **final** LSN — `MessageConverter` sets `txn_fragment.lsn = msg.final_lsn` on `Begin` and derives every change's `log_offset` from it. `ShapeLogCollector.publish/2` then called `LsnTracker.set_last_processed_lsn/2` unconditionally after fanning each fragment out to consumers, before the `commit`-bearing branch.

Consumers, meanwhile, deliberately keep a transaction unreadable until they see its commit fragment: `maybe_complete_pending_txn/2` short-circuits on `%TransactionFragment{commit: nil}`, and `append_fragment_to_log` explicitly does not advance `last_seen_txn_offset` — only `signal_txn_commit/2` does.

That leaves a window, for any transaction larger than `max_batch_size` (default 100), where a non-live shape request is answered with an `up-to-date` control message advertising `global_last_seen_lsn = T` while no shape log contains any data for `T` yet. A later request can then return changes at that same `T`. Clients that use the global LSN to align multiple shape streams can durably commit `T` with one shape's changes missing, and only recover by refetching.

The API's non-live branch is where this surfaces:

```elixir
# In non-live mode, we're reading from disk. We trust the global max because it's updated
# after all disk writes. We take the max because we might be reading from disk before a global update.
max(global_last_seen_lsn, chunk_end_offset.tx_offset)
```

The premise held when the value was a per-transaction LSN; it stopped holding when it became a per-fragment one.

## Fix

Move the public LSN update into the commit-bearing branch of `publish/2`, next to the `broadcast_last_seen_lsn` call that was already gated that way. `state.last_processed_offset` still advances per fragment — it is what orders and de-duplicates fragments internally — but only a commit fragment now moves the publicly visible LSN.

One behavioural consequence worth flagging: the tracker update now lands after the undeliverable-shape reduction (`handle_writer_down` classification) rather than before it. That ordering seems the more correct one — crashed consumers are invalidated before the proof goes public — but it is a change from the previous sequence.

## Notes on the regression

The unconditional call dates to #3541, which replaced the `last_processed_lsn` state field (LSN of the last complete transaction, guarded by `Lsn.is_larger`) with `last_processed_offset` (a per-fragment `LogOffset`, assigned unconditionally) and rewrote the tracker call as `Lsn.from_integer(state.last_processed_offset.tx_offset)` — a type adaptation that silently changed what was being published.

The bug has been live since then. #3783 did not introduce it: before that PR consumers reassembled fragments in memory via `TransactionBuilder`, so data at `T` was equally unreadable after a non-commit fragment. #3783 only moved the hidden data from a consumer buffer into storage behind a hidden read frontier.
