### PR TITLE
fix(examples): forward abort signal in tanstack-db-web-starter Electric proxy

### DIFF
--- a/examples/tanstack-db-web-starter/src/lib/electric-proxy.ts
+++ b/examples/tanstack-db-web-starter/src/lib/electric-proxy.ts
@@ -42,10 +42,16 @@ export function prepareElectricUrl(requestUrl: string): URL {
 /**
  * Proxies a request to Electric SQL and returns the response
  * @param originUrl - The prepared Electric SQL URL
+ * @param signal - The incoming request's abort signal. Forwarding it means a client disconnect
+ *   also cancels the upstream request, instead of leaving a `live=true` long-poll holding a
+ *   connection to Electric until it times out.
  * @returns The proxied response
  */
-export async function proxyElectricRequest(originUrl: URL): Promise<Response> {
-  const response = await fetch(originUrl)
+export async function proxyElectricRequest(
+  originUrl: URL,
+  signal?: AbortSignal
+): Promise<Response> {
+  const response = await fetch(originUrl, { signal })
   const headers = new Headers(response.headers)
   headers.delete(`content-encoding`)
   headers.delete(`content-length`)

--- a/examples/tanstack-db-web-starter/src/routes/api/projects.ts
+++ b/examples/tanstack-db-web-starter/src/routes/api/projects.ts
@@ -20,7 +20,7 @@ const serve = async ({ request }: { request: Request }) => {
   )
   originUrl.searchParams.set(`params[1]`, session.user.id)
 
-  return proxyElectricRequest(originUrl)
+  return proxyElectricRequest(originUrl, request.signal)
 }
 
 export const Route = createFileRoute(`/api/projects`)({

--- a/examples/tanstack-db-web-starter/src/routes/api/todos.ts
+++ b/examples/tanstack-db-web-starter/src/routes/api/todos.ts
@@ -17,7 +17,7 @@ const serve = async ({ request }: { request: Request }) => {
   originUrl.searchParams.set(`where`, `$1 = ANY(user_ids)`)
   originUrl.searchParams.set(`params[1]`, session.user.id)
 
-  return proxyElectricRequest(originUrl)
+  return proxyElectricRequest(originUrl, request.signal)
 }
 
 export const Route = createFileRoute(`/api/todos`)({

--- a/examples/tanstack-db-web-starter/src/routes/api/users.ts
+++ b/examples/tanstack-db-web-starter/src/routes/api/users.ts
@@ -14,7 +14,7 @@ const serve = async ({ request }: { request: Request }) => {
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `users`)
 
-  return proxyElectricRequest(originUrl)
+  return proxyElectricRequest(originUrl, request.signal)
 }
 
 export const Route = createFileRoute(`/api/users`)({


### PR DESCRIPTION
## Problem

`proxyElectricRequest` calls `fetch(originUrl)` without forwarding the incoming request's `AbortSignal`. When a client goes away mid-request — a page reload, a navigation, a closed tab — the proxy's upstream call to Electric has no cancellation path and keeps running to completion.

For `live=true` long-polls that is the full long-poll timeout. Measured against a local Electric (`electricsql/electric:latest`, default settings), proxying through a TanStack Start route:

```
unsignalled upstream long-poll held open for: 20004 ms  (status 200)
signalled upstream released after:                1 ms  (AbortError)
```

Each abandoned live request pins one upstream connection and one `fetch` slot for ~20s after the client that wanted it is already gone.

This compounds with the concurrency limit that `skills/electric-proxy-auth/SKILL.md` already documents:

> Bun caps simultaneous `fetch()` calls at **256 per process** by default. Excess requests queue silently — the proxy keeps accepting inbound connections but upstream calls to Electric stall, surfacing as latency spikes rather than errors.

A page holding ~10 shapes leaks ~10 slots per reload, each for ~20s. Roughly 26 abandoned page loads inside one 20-second window is enough to exhaust the pool — easily reached when a deploy causes many connected clients to reconnect at once. The symptom is the latency spike the skill describes; the missing signal is one of its causes.

## Change

Forward the request's `AbortSignal` to the upstream `fetch`:

```ts
export async function proxyElectricRequest(
  originUrl: URL,
  signal?: AbortSignal
): Promise<Response> {
  const response = await fetch(originUrl, { signal })
```

and pass `request.signal` at the three call sites (`todos`, `users`, `projects`).

The parameter is optional, so this is source-compatible with any existing caller.

## Same pattern elsewhere

I kept this PR to the one starter to stay reviewable, but the same `fetch(originUrl)` without a signal appears in:

- `examples/tanstack-db-expo-starter/api/index.ts` (~line 138)
- `website/docs/sync/guides/auth.md` (proxy examples around lines 152, 407, 414, 624, 644)
- `packages/typescript-client/skills/electric-proxy-auth/SKILL.md` (~line 51)
