### PR TITLE
fix(sync-service): start the consumer of a dependency shape on demand when its materializer starts

### DIFF
--- a/.changeset/start-dependency-consumer-on-demand.md
+++ b/.changeset/start-dependency-consumer-on-demand.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Start the consumer of a dependency shape on demand when its materializer starts. A dependency shape can be registered with a completed snapshot but no running consumer (for example when restored on restart after its parent was removed, since consumers only start lazily on transaction routing). Requests for a parent shape then failed repeatedly: the dependency materializer crashed calling the missing consumer, the parent was invalidated, and the still-registered dependency poisoned every retry.

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -153,18 +153,18 @@ defmodule Electric.Shapes.Consumer.Materializer do
     shape_storage = Storage.for_shape(shape_handle, stack_storage)
 
     try do
-      case Consumer.await_snapshot_start(stack_id, shape_handle, :infinity) do
-        :started ->
-          {:ok, subscribed_offset} =
-            Consumer.subscribe_materializer(stack_id, shape_handle, self())
+      with {:ok, _consumer_pid} <- ensure_consumer_running(stack_id, shape_handle),
+           :started <- Consumer.await_snapshot_start(stack_id, shape_handle, :infinity) do
+        {:ok, subscribed_offset} =
+          Consumer.subscribe_materializer(stack_id, shape_handle, self())
 
-          Process.monitor(Consumer.whereis(stack_id, shape_handle),
-            tag: {:consumer_down, state.shape_handle}
-          )
+        Process.monitor(Consumer.whereis(stack_id, shape_handle),
+          tag: {:consumer_down, state.shape_handle}
+        )
 
-          {:noreply, %{state | subscribed_offset: subscribed_offset},
-           {:continue, {:read_stream, shape_storage}}}
-
+        {:noreply, %{state | subscribed_offset: subscribed_offset},
+         {:continue, {:read_stream, shape_storage}}}
+      else
         {:error, _reason} ->
           {:stop, :shutdown, state}
       end
@@ -173,6 +173,18 @@ defmodule Electric.Shapes.Consumer.Materializer do
       :exit, reason ->
         Logger.warning("Materializer startup failed with exit reason: #{inspect(reason)}")
         {:stop, :shutdown, state}
+    end
+  end
+
+  # A registered shape can have no running consumer: consumers for restored
+  # shapes start lazily on their first transaction, and a dependency shape
+  # orphaned by its parent's removal is restored as a plain shape on restart.
+  # Start the consumer on demand — the same mechanism the transaction routing
+  # path uses — instead of assuming one is running.
+  defp ensure_consumer_running(stack_id, shape_handle) do
+    case Consumer.whereis(stack_id, shape_handle) do
+      pid when is_pid(pid) -> {:ok, pid}
+      nil -> Electric.ShapeCache.start_consumer_for_handle(shape_handle, stack_id)
     end
   end
 

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1078,6 +1078,85 @@ defmodule Electric.ShapeCacheTest do
       assert_receive {ShapeCache.ShapeCleaner, :cleanup, ^subshape_handle}
     end
 
+    test "starts the consumer of a registered dependency shape that has none running", ctx do
+      # A dependency (subquery) shape can be registered in ShapeStatus with a
+      # completed snapshot but no running consumer — e.g. restored on restart
+      # as a plain shape after its parent was removed (`prune_subquery_shapes/1`
+      # only matches dependencies through a surviving parent), with consumers
+      # only started lazily on transaction routing. A new parent then resolves
+      # its subquery to this handle, and its dependency materializer must start
+      # the consumer rather than fail and invalidate the parent — which would
+      # repeat on every retry, since the dependency stays registered.
+      Support.TestUtils.patch_snapshotter(fn parent,
+                                             shape_handle,
+                                             _shape,
+                                             %{snapshot_fun: snapshot_fun} ->
+        GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_100})
+        snapshot_fun.([])
+        GenServer.cast(parent, {:snapshot_started, shape_handle})
+      end)
+
+      {parent_handle, _} =
+        ShapeCache.get_or_create_shape_handle(@shape_with_subquery, ctx.stack_id)
+
+      assert ShapeCache.await_snapshot_start(parent_handle, ctx.stack_id) == :started
+
+      {:ok, shape} = ShapeCache.fetch_shape_by_handle(parent_handle, ctx.stack_id)
+      [dependency_handle] = shape.shape_dependencies_handles
+
+      # Remove the parent shape, orphaning the dependency.
+      ShapeCache.clean_shape(parent_handle, ctx.stack_id)
+      assert_shape_cleanup(parent_handle)
+
+      # Stop the dependency's consumer with the suspend reason, which
+      # deregisters it from the ConsumerRegistry without removing the shape —
+      # the dependency's materializer exits with it. This leaves the exact
+      # restored-orphan state: registered handle, completed snapshot, no
+      # consumer process, no materializer.
+      :ok =
+        Electric.Shapes.Consumer.stop(
+          ctx.stack_id,
+          dependency_handle,
+          Electric.ShapeCache.ShapeCleaner.consumer_suspend_reason()
+        )
+
+      assert wait_until(
+               fn ->
+                 is_nil(Electric.Shapes.Consumer.whereis(ctx.stack_id, dependency_handle)) and
+                   is_nil(
+                     GenServer.whereis(
+                       Electric.Shapes.Consumer.Materializer.name(
+                         ctx.stack_id,
+                         dependency_handle
+                       )
+                     )
+                   )
+               end,
+               1_000
+             )
+
+      assert ShapeStatus.has_shape_handle?(ctx.stack_id, dependency_handle)
+      assert ShapeStatus.snapshot_started?(ctx.stack_id, dependency_handle)
+
+      # A new request for the parent shape resolves the subquery to the same
+      # dependency handle. Its materializer must start the missing consumer,
+      # letting the parent initialize and the request succeed.
+      {second_parent_handle, _} =
+        ShapeCache.get_or_create_shape_handle(@shape_with_subquery, ctx.stack_id)
+
+      refute second_parent_handle == parent_handle
+
+      assert ShapeCache.await_snapshot_start(second_parent_handle, ctx.stack_id) == :started
+
+      {:ok, second_shape} =
+        ShapeCache.fetch_shape_by_handle(second_parent_handle, ctx.stack_id)
+
+      assert second_shape.shape_dependencies_handles == [dependency_handle]
+
+      dependency_pid = Electric.Shapes.Consumer.whereis(ctx.stack_id, dependency_handle)
+      assert is_pid(dependency_pid) and Process.alive?(dependency_pid)
+    end
+
     test "should wait for consumer to come up", ctx do
       Support.TestUtils.patch_snapshotter(fn parent, shape_handle, _, _ ->
         GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_100})


### PR DESCRIPTION
## The problem

In production (sync-service 1.7.11) we observed requests for a shape with a subquery failing with a 500 on every attempt. The flow for each request:

1. The request creates the parent shape, which resolves its subquery to an already-registered dependency shape handle.
2. A materializer is started for the dependency, but its startup crashes because the dependency shape has no running consumer:

   ```
   13:09:59.266 shape_handle=71390006-1787076343081033 [warning] Materializer startup failed with exit reason: {:noproc, {GenServer, :call, [nil, :await_snapshot_start, :infinity]}}
   ```

3. The parent consumer's initialization then finds no live materializer to subscribe to and invalidates itself:

   ```
   13:09:59.268 shape_handle=71390006-1787076343081033 [warning] Materializer for shape is not alive, invalidating shape
   ```

4. The request process, blocked in `await_snapshot_start` on the parent consumer, crashes when the consumer stops, producing the 500:

   ```
   13:09:59.271 request_id=GM8OY-MeYP1uOKAAlDMC [error] ** (exit) exited in: GenServer.call(#PID<0.444658.0>, :await_snapshot_start, 45000)
   ```

This path is problematic because nothing in it restarts the dependency's consumer or removes the dependency's registration: only the parent is cleaned up. The client's retry creates a new parent, resolves the subquery to the same dependency handle, and fails identically. We observed a single user looping through this for 17 minutes (28 requests, 28 500s) with no recovery, and the same loop affecting tens of users per day.

## Why is the dependency's consumer not running?

We do not know. What we can say is that the state exists in production: the dependency handle is registered in ShapeStatus with a completed snapshot, but no consumer process is running and the ConsumerRegistry lookup returns nil (visible in the `GenServer.call(nil, ...)` above).

One guess: the dependency was orphaned before a restart (parents are removed by several cleanup paths that leave their dependencies registered), and `prune_subquery_shapes/1` only matches dependencies through a surviving parent, so an orphan is restored as a plain shape, whose consumer only starts lazily on transaction routing. The timeline fits (the failing handles predate the pod's last restart), but we have not confirmed this is the producer, and there may be others.

## The (partial) solution

Have the materializer start the missing consumer via `ShapeCache.start_consumer_for_handle/3`, the same mechanism the transaction routing path uses to lazily start consumers, instead of assuming one is running. The dependency's snapshot and log are intact on disk, so this recovers the existing shape rather than discarding it, and the parent request succeeds.

Adds a regression test that constructs the registered-but-no-consumer state and asserts a new parent request recovers the existing dependency (same handle, consumer restarted) instead of looping.

This does not address whatever root cause leaves a registered dependency shape without a running consumer in the first place; it makes the state recoverable when it is encountered.
