### PR TITLE
Only apply conn_max_requests to HTTP/1 connections

### DIFF
--- a/.changeset/quiet-goats-listen.md
+++ b/.changeset/quiet-goats-listen.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Stop applying `ELECTRIC_TWEAKS_CONN_MAX_REQUESTS` to HTTP/2 connections. The limit is only meaningful for HTTP/1, where it recycles long-lived handler processes at a request boundary. Under HTTP/2 it made Bandit tear down the whole multiplexed connection with GOAWAY/REFUSED_STREAM once the cumulative stream count reached the limit (50 by default), disrupting in-flight streams and causing reconnect bursts.

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -355,7 +355,14 @@ defmodule Electric.Application do
         n -> [{:handler_fullsweep_after, n} | ti_opts]
       end
 
-    shared_http_opts =
+    # `max_requests` is only applied to HTTP/1 connections. There, requests are served
+    # sequentially by a long-lived handler process and the limit recycles that process
+    # (and its accumulated heap) at a request boundary to avoid accumulating garbage memory.
+    #
+    # Under HTTP/2, requests already run in short-lived per-stream processes, and reaching
+    # `max_requests` would make Bandit tear down the whole multiplexed connection close all its
+    # streams.
+    http_1_opts =
       if max_requests = Keyword.get(tweaks, :conn_max_requests) do
         [max_requests: max_requests]
       else
@@ -367,8 +374,8 @@ defmodule Electric.Application do
        [
          plug: {Electric.Plug.Router, router_opts},
          port: get_env(opts, :service_port),
-         http_1_options: shared_http_opts,
-         http_2_options: shared_http_opts,
+         http_1_options: http_1_opts,
+         http_2_options: [],
          thousand_island_options: thousand_island_options(opts ++ ti_opts)
        ]}
     ]

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -111,9 +111,9 @@ defmodule Electric.Config do
     # shape is invalidated to unpin the stack-wide flush boundary. The storage
     # contract already says writes slower than this should raise.
     flush_stall_grace_period: :timer.minutes(1),
-    # Sets max_requests for Bandit handler processes:
+    # Sets max_requests for Bandit HTTP/1 handler processes:
     # https://hexdocs.pm/bandit/Bandit.html#t:http_1_options/0
-    # "The maximum number of requests to serve in a single HTTP/{1,2}
+    # "The maximum number of requests to serve in a single HTTP/1
     # connection before closing the connection"
     conn_max_requests: 50,
     # Sets fullsweep_after for Bandit handler processes.

--- a/packages/sync-service/test/electric/config_test.exs
+++ b/packages/sync-service/test/electric/config_test.exs
@@ -60,6 +60,17 @@ defmodule Electric.ConfigTest do
       refute Keyword.has_key?(default_opts[:thousand_island_options], :read_timeout)
     end
 
+    test "api_server/1 applies conn_max_requests to HTTP/1 connections only" do
+      [{Bandit, bandit_opts}] = Electric.Application.api_server(tweaks: [conn_max_requests: 50])
+
+      assert bandit_opts[:http_1_options][:max_requests] == 50
+      refute Keyword.has_key?(bandit_opts[:http_2_options], :max_requests)
+
+      [{Bandit, default_opts}] = Electric.Application.api_server([])
+      refute Keyword.has_key?(default_opts[:http_1_options], :max_requests)
+      refute Keyword.has_key?(default_opts[:http_2_options], :max_requests)
+    end
+
     test "configuration/1", ctx do
       Electric.Application.configuration(
         Keyword.take(ctx.initial_config, [:replication_connection_opts])


### PR DESCRIPTION
`ELECTRIC_TWEAKS_CONN_MAX_REQUESTS` was being applied to both HTTP/1 and HTTP/2 Bandit connections, but the option means very different things under each protocol.

Under HTTP/1, reaching `max_requests` closes the connection at a request boundary, recycling the long-lived handler process and its accumulated heap — the reason the tweak exists. Under HTTP/2, requests already run in short-lived per-stream processes, and once the cumulative stream count reaches `max_requests` Bandit raises a connection-level error and tears down the whole multiplexed connection with GOAWAY/`REFUSED_STREAM`. With the default of 50, this routinely cycled HTTP/2 connections, disrupted in-flight streams, and could produce synchronized reconnect bursts.

The limit is now only passed in `http_1_options`; HTTP/2 connections keep Bandit's default of no request limit.

Fixes #4771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zNLCRpP2XfBci3xmyTEGn
