### PR TITLE
fix(sync-service): start missing dependency consumers before their parent

### DIFF
--- a/.changeset/start-dependency-consumer-on-demand.md
+++ b/.changeset/start-dependency-consumer-on-demand.md
@@ -1,0 +1,5 @@
+---
+'@core/sync-service': patch
+---
+
+Start the consumer of a dependency shape on demand when its materializer starts. A dependency shape can be registered with a completed snapshot but no running consumer (for example when restored on restart after its parent was removed, since consumers only start lazily on transaction routing). Requests for a parent shape then failed repeatedly: the dependency materializer crashed calling the missing consumer, the parent was invalidated, and the still-registered dependency poisoned every retry.

--- a/.changeset/start-dependency-consumer-on-demand.md
+++ b/.changeset/start-dependency-consumer-on-demand.md
@@ -2,4 +2,4 @@
 '@core/sync-service': patch
 ---
 
-Start the consumer of a dependency shape on demand when its materializer starts. A dependency shape can be registered with a completed snapshot but no running consumer (for example when restored on restart after its parent was removed, since consumers only start lazily on transaction routing). Requests for a parent shape then failed repeatedly: the dependency materializer crashed calling the missing consumer, the parent was invalidated, and the still-registered dependency poisoned every retry.
+Start the consumer of an existing subquery dependency shape if it isn't running when a new parent shape resolves to it. Previously such a parent request failed with a 500 on every retry: the dependency's materializer found no consumer, the parent was invalidated, and the still-registered dependency poisoned the next attempt.

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -342,22 +342,14 @@ defmodule Electric.ShapeCache do
     # from the broadcast.
     if not is_nil(otel_ctx), do: OpenTelemetry.set_current_context(otel_ctx)
 
-    case ShapeStatus.fetch_shape_by_handle(state.stack_id, shape_handle) do
-      {:ok, shape} ->
-        {
-          :reply,
-          restore_shape_and_dependencies(shape_handle, shape, %{
-            stack_id: state.stack_id,
-            action: :restore,
-            otel_ctx: otel_ctx,
-            feature_flags: state.feature_flags
-          }),
-          state
-        }
+    opts = %{
+      stack_id: state.stack_id,
+      otel_ctx: otel_ctx,
+      feature_flags: state.feature_flags
+    }
 
-      :error ->
-        {:reply, {:error, :no_shape}, state}
-    end
+    result = try_restoring_shape_and_dependencies(state.stack_id, shape_handle, opts)
+    {:reply, result, state}
   end
 
   defp safe_maybe_create_shape(shape, opts) do
@@ -407,38 +399,21 @@ defmodule Electric.ShapeCache do
     end
   end
 
-  # An existing inner (subquery dependency) shape may have no running consumer: a
-  # dependency whose parent was removed survives `ShapeStatus.prune_subquery_shapes/1`
-  # on restart as a plain shape, and consumers for restored shapes only start lazily
-  # on transaction routing. `start_shape/3` for the parent assumes its dependencies'
-  # consumers are running (the materializer it starts for each dependency subscribes
-  # to that dependency's consumer), so start any missing one here, before the parent
-  # is started. Going through `restore_shape_and_dependencies/3` with the inner `opts`
-  # keeps the `is_subquery_shape?` flag and covers nested dependencies.
+  # An existing inner shape may have no running consumer: a subquery dependency whose parent
+  # was removed survives `ShapeStatus.prune_subquery_shapes/1` on restart as a plain shape,
+  # and consumers for restored shapes only start lazily on transaction routing.
   defp ensure_inner_consumer_running(
          shape_handle,
          %{is_subquery_shape?: true, stack_id: stack_id} = opts
        ) do
-    if is_nil(Shapes.ConsumerRegistry.whereis(stack_id, shape_handle)) do
-      # The shape in hand was parsed from the parent's subquery, so its
-      # `shape_dependencies_handles` aren't filled in. Restore from the persisted
-      # shape, as the transaction-routing restore path does.
-      case ShapeStatus.fetch_shape_by_handle(stack_id, shape_handle) do
-        {:ok, shape} ->
-          with {:ok, _pid} <-
-                 restore_shape_and_dependencies(
-                   shape_handle,
-                   shape,
-                   Map.put(opts, :action, :restore)
-                 ) do
-            :ok
-          end
+    consumer_pid = Shapes.ConsumerRegistry.whereis(stack_id, shape_handle)
 
-        :error ->
-          {:error, :no_shape}
-      end
-    else
+    if consumer_pid do
       :ok
+    else
+      with {:ok, _pid} <- try_restoring_shape_and_dependencies(stack_id, shape_handle, opts) do
+        :ok
+      end
     end
   end
 
@@ -494,6 +469,16 @@ defmodule Electric.ShapeCache do
         # purge because we know the consumer isn't running
         clean_shape(shape_handle, stack_id)
         :error
+    end
+  end
+
+  defp try_restoring_shape_and_dependencies(stack_id, shape_handle, opts) do
+    case ShapeStatus.fetch_shape_by_handle(stack_id, shape_handle) do
+      {:ok, shape} ->
+        restore_shape_and_dependencies(shape_handle, shape, Map.put(opts, :action, :restore))
+
+      :error ->
+        {:error, :no_shape}
     end
   end
 

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -378,9 +378,13 @@ defmodule Electric.ShapeCache do
     # fetch_handle_by_shape_critical is a slower but guaranteed consistent
     # shape lookup
     with {:ok, shape_handle} <- ShapeStatus.fetch_handle_by_shape_critical(stack_id, shape),
-         {:ok, offset} <- fetch_latest_offset(stack_id, shape_handle) do
+         {:ok, offset} <- fetch_latest_offset(stack_id, shape_handle),
+         :ok <- ensure_inner_consumer_running(shape_handle, opts) do
       {:ok, {shape_handle, offset}}
     else
+      {:error, _reason} = error ->
+        error
+
       :error ->
         with {:ok, shape_handles} <- safe_maybe_create_inner_shapes(shape, opts) do
           shape = %{shape | shape_dependencies_handles: shape_handles}
@@ -402,6 +406,43 @@ defmodule Electric.ShapeCache do
         end
     end
   end
+
+  # An existing inner (subquery dependency) shape may have no running consumer: a
+  # dependency whose parent was removed survives `ShapeStatus.prune_subquery_shapes/1`
+  # on restart as a plain shape, and consumers for restored shapes only start lazily
+  # on transaction routing. `start_shape/3` for the parent assumes its dependencies'
+  # consumers are running (the materializer it starts for each dependency subscribes
+  # to that dependency's consumer), so start any missing one here, before the parent
+  # is started. Going through `restore_shape_and_dependencies/3` with the inner `opts`
+  # keeps the `is_subquery_shape?` flag and covers nested dependencies.
+  defp ensure_inner_consumer_running(
+         shape_handle,
+         %{is_subquery_shape?: true, stack_id: stack_id} = opts
+       ) do
+    if is_nil(Shapes.ConsumerRegistry.whereis(stack_id, shape_handle)) do
+      # The shape in hand was parsed from the parent's subquery, so its
+      # `shape_dependencies_handles` aren't filled in. Restore from the persisted
+      # shape, as the transaction-routing restore path does.
+      case ShapeStatus.fetch_shape_by_handle(stack_id, shape_handle) do
+        {:ok, shape} ->
+          with {:ok, _pid} <-
+                 restore_shape_and_dependencies(
+                   shape_handle,
+                   shape,
+                   Map.put(opts, :action, :restore)
+                 ) do
+            :ok
+          end
+
+        :error ->
+          {:error, :no_shape}
+      end
+    else
+      :ok
+    end
+  end
+
+  defp ensure_inner_consumer_running(_shape_handle, _opts), do: :ok
 
   defp safe_maybe_create_inner_shapes(%Shape{shape_dependencies: []}, _opts) do
     {:ok, []}

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -153,18 +153,18 @@ defmodule Electric.Shapes.Consumer.Materializer do
     shape_storage = Storage.for_shape(shape_handle, stack_storage)
 
     try do
-      case Consumer.await_snapshot_start(stack_id, shape_handle, :infinity) do
-        :started ->
-          {:ok, subscribed_offset} =
-            Consumer.subscribe_materializer(stack_id, shape_handle, self())
+      with {:ok, _consumer_pid} <- ensure_consumer_running(stack_id, shape_handle),
+           :started <- Consumer.await_snapshot_start(stack_id, shape_handle, :infinity) do
+        {:ok, subscribed_offset} =
+          Consumer.subscribe_materializer(stack_id, shape_handle, self())
 
-          Process.monitor(Consumer.whereis(stack_id, shape_handle),
-            tag: {:consumer_down, state.shape_handle}
-          )
+        Process.monitor(Consumer.whereis(stack_id, shape_handle),
+          tag: {:consumer_down, state.shape_handle}
+        )
 
-          {:noreply, %{state | subscribed_offset: subscribed_offset},
-           {:continue, {:read_stream, shape_storage}}}
-
+        {:noreply, %{state | subscribed_offset: subscribed_offset},
+         {:continue, {:read_stream, shape_storage}}}
+      else
         {:error, _reason} ->
           {:stop, :shutdown, state}
       end
@@ -173,6 +173,18 @@ defmodule Electric.Shapes.Consumer.Materializer do
       :exit, reason ->
         Logger.warning("Materializer startup failed with exit reason: #{inspect(reason)}")
         {:stop, :shutdown, state}
+    end
+  end
+
+  # A registered shape can have no running consumer: consumers for restored
+  # shapes start lazily on their first transaction, and a dependency shape
+  # orphaned by its parent's removal is restored as a plain shape on restart.
+  # Start the consumer on demand — the same mechanism the transaction routing
+  # path uses — instead of assuming one is running.
+  defp ensure_consumer_running(stack_id, shape_handle) do
+    case Consumer.whereis(stack_id, shape_handle) do
+      pid when is_pid(pid) -> {:ok, pid}
+      nil -> Electric.ShapeCache.start_consumer_for_handle(shape_handle, stack_id)
     end
   end
 

--- a/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
+++ b/packages/sync-service/lib/electric/shapes/consumer/materializer.ex
@@ -153,18 +153,18 @@ defmodule Electric.Shapes.Consumer.Materializer do
     shape_storage = Storage.for_shape(shape_handle, stack_storage)
 
     try do
-      with {:ok, _consumer_pid} <- ensure_consumer_running(stack_id, shape_handle),
-           :started <- Consumer.await_snapshot_start(stack_id, shape_handle, :infinity) do
-        {:ok, subscribed_offset} =
-          Consumer.subscribe_materializer(stack_id, shape_handle, self())
+      case Consumer.await_snapshot_start(stack_id, shape_handle, :infinity) do
+        :started ->
+          {:ok, subscribed_offset} =
+            Consumer.subscribe_materializer(stack_id, shape_handle, self())
 
-        Process.monitor(Consumer.whereis(stack_id, shape_handle),
-          tag: {:consumer_down, state.shape_handle}
-        )
+          Process.monitor(Consumer.whereis(stack_id, shape_handle),
+            tag: {:consumer_down, state.shape_handle}
+          )
 
-        {:noreply, %{state | subscribed_offset: subscribed_offset},
-         {:continue, {:read_stream, shape_storage}}}
-      else
+          {:noreply, %{state | subscribed_offset: subscribed_offset},
+           {:continue, {:read_stream, shape_storage}}}
+
         {:error, _reason} ->
           {:stop, :shutdown, state}
       end
@@ -173,18 +173,6 @@ defmodule Electric.Shapes.Consumer.Materializer do
       :exit, reason ->
         Logger.warning("Materializer startup failed with exit reason: #{inspect(reason)}")
         {:stop, :shutdown, state}
-    end
-  end
-
-  # A registered shape can have no running consumer: consumers for restored
-  # shapes start lazily on their first transaction, and a dependency shape
-  # orphaned by its parent's removal is restored as a plain shape on restart.
-  # Start the consumer on demand — the same mechanism the transaction routing
-  # path uses — instead of assuming one is running.
-  defp ensure_consumer_running(stack_id, shape_handle) do
-    case Consumer.whereis(stack_id, shape_handle) do
-      pid when is_pid(pid) -> {:ok, pid}
-      nil -> Electric.ShapeCache.start_consumer_for_handle(shape_handle, stack_id)
     end
   end
 

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1084,9 +1084,10 @@ defmodule Electric.ShapeCacheTest do
       # as a plain shape after its parent was removed (`prune_subquery_shapes/1`
       # only matches dependencies through a surviving parent), with consumers
       # only started lazily on transaction routing. A new parent then resolves
-      # its subquery to this handle, and its dependency materializer must start
-      # the consumer rather than fail and invalidate the parent — which would
-      # repeat on every retry, since the dependency stays registered.
+      # its subquery to this handle, and the ShapeCache must start the missing
+      # consumer before starting the parent — otherwise the parent's materializer
+      # finds no consumer, the parent is invalidated, and that repeats on every
+      # retry, since the dependency stays registered.
       Support.TestUtils.patch_snapshotter(fn parent,
                                              shape_handle,
                                              _shape,
@@ -1139,8 +1140,8 @@ defmodule Electric.ShapeCacheTest do
       assert ShapeStatus.snapshot_started?(ctx.stack_id, dependency_handle)
 
       # A new request for the parent shape resolves the subquery to the same
-      # dependency handle. Its materializer must start the missing consumer,
-      # letting the parent initialize and the request succeed.
+      # dependency handle. The missing consumer must be started, letting the
+      # parent initialize and the request succeed.
       {second_parent_handle, _} =
         ShapeCache.get_or_create_shape_handle(@shape_with_subquery, ctx.stack_id)
 
@@ -1155,6 +1156,11 @@ defmodule Electric.ShapeCacheTest do
 
       dependency_pid = Electric.Shapes.Consumer.whereis(ctx.stack_id, dependency_handle)
       assert is_pid(dependency_pid) and Process.alive?(dependency_pid)
+
+      # The restarted consumer must be initialized as a subquery (inner) shape, i.e.
+      # buffer whole transactions rather than stream fragments, like any other
+      # dependency consumer.
+      assert %{write_unit: :txn} = :sys.get_state(dependency_pid)
     end
 
     test "should wait for consumer to come up", ctx do

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1079,15 +1079,9 @@ defmodule Electric.ShapeCacheTest do
     end
 
     test "starts the consumer of a registered dependency shape that has none running", ctx do
-      # A dependency (subquery) shape can be registered in ShapeStatus with a
-      # completed snapshot but no running consumer — e.g. restored on restart
-      # as a plain shape after its parent was removed (`prune_subquery_shapes/1`
-      # only matches dependencies through a surviving parent), with consumers
-      # only started lazily on transaction routing. A new parent then resolves
-      # its subquery to this handle, and the ShapeCache must start the missing
-      # consumer before starting the parent — otherwise the parent's materializer
-      # finds no consumer, the parent is invalidated, and that repeats on every
-      # retry, since the dependency stays registered.
+      # After restart, an orphaned dependency may remain registered with a completed
+      # snapshot but no consumer. Reusing it must restart the consumer before the
+      # new parent's materializer starts, or the parent is repeatedly invalidated.
       Support.TestUtils.patch_snapshotter(fn parent,
                                              shape_handle,
                                              _shape,
@@ -1109,11 +1103,8 @@ defmodule Electric.ShapeCacheTest do
       ShapeCache.clean_shape(parent_handle, ctx.stack_id)
       assert_shape_cleanup(parent_handle)
 
-      # Stop the dependency's consumer with the suspend reason, which
-      # deregisters it from the ConsumerRegistry without removing the shape —
-      # the dependency's materializer exits with it. This leaves the exact
-      # restored-orphan state: registered handle, completed snapshot, no
-      # consumer process, no materializer.
+      # Suspend the dependency without deleting its completed shape, reproducing
+      # the post-restart orphan state.
       :ok =
         Electric.Shapes.Consumer.stop(
           ctx.stack_id,

--- a/packages/sync-service/test/electric/shape_cache_test.exs
+++ b/packages/sync-service/test/electric/shape_cache_test.exs
@@ -1078,6 +1078,85 @@ defmodule Electric.ShapeCacheTest do
       assert_receive {ShapeCache.ShapeCleaner, :cleanup, ^subshape_handle}
     end
 
+    test "starts the consumer of a registered dependency shape that has none running", ctx do
+      # A dependency (subquery) shape can be registered in ShapeStatus with a
+      # completed snapshot but no running consumer — e.g. restored on restart
+      # as a plain shape after its parent was removed (`prune_subquery_shapes/1`
+      # only matches dependencies through a surviving parent), with consumers
+      # only started lazily on transaction routing. A new parent then resolves
+      # its subquery to this handle, and its dependency materializer must start
+      # the consumer rather than fail and invalidate the parent — which would
+      # repeat on every retry, since the dependency stays registered.
+      Support.TestUtils.patch_snapshotter(fn parent,
+                                             shape_handle,
+                                             _shape,
+                                             %{snapshot_fun: snapshot_fun} ->
+        GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_100})
+        snapshot_fun.([])
+        GenServer.cast(parent, {:snapshot_started, shape_handle})
+      end)
+
+      {parent_handle, _} =
+        ShapeCache.get_or_create_shape_handle(@shape_with_subquery, ctx.stack_id)
+
+      assert ShapeCache.await_snapshot_start(parent_handle, ctx.stack_id) == :started
+
+      {:ok, shape} = ShapeCache.fetch_shape_by_handle(parent_handle, ctx.stack_id)
+      [dependency_handle] = shape.shape_dependencies_handles
+
+      # Remove the parent shape, orphaning the dependency.
+      ShapeCache.clean_shape(parent_handle, ctx.stack_id)
+      assert_shape_cleanup(parent_handle)
+
+      # Stop the dependency's consumer with the suspend reason, which
+      # deregisters it from the ConsumerRegistry without removing the shape —
+      # the dependency's materializer exits with it. This leaves the exact
+      # restored-orphan state: registered handle, completed snapshot, no
+      # consumer process, no materializer.
+      :ok =
+        Electric.Shapes.Consumer.stop(
+          ctx.stack_id,
+          dependency_handle,
+          Electric.ShapeCache.ShapeCleaner.consumer_suspend_reason()
+        )
+
+      assert wait_until(
+               fn ->
+                 is_nil(Electric.Shapes.Consumer.whereis(ctx.stack_id, dependency_handle)) and
+                   is_nil(
+                     GenServer.whereis(
+                       Electric.Shapes.Consumer.Materializer.name(
+                         ctx.stack_id,
+                         dependency_handle
+                       )
+                     )
+                   )
+               end,
+               1_000
+             )
+
+      assert ShapeStatus.has_shape_handle?(ctx.stack_id, dependency_handle)
+      assert ShapeStatus.snapshot_started?(ctx.stack_id, dependency_handle)
+
+      # A new request for the parent shape resolves the subquery to the same
+      # dependency handle. Its materializer must start the missing consumer,
+      # letting the parent initialize and the request succeed.
+      {second_parent_handle, _} =
+        ShapeCache.get_or_create_shape_handle(@shape_with_subquery, ctx.stack_id)
+
+      refute second_parent_handle == parent_handle
+
+      assert ShapeCache.await_snapshot_start(second_parent_handle, ctx.stack_id) == :started
+
+      {:ok, second_shape} =
+        ShapeCache.fetch_shape_by_handle(second_parent_handle, ctx.stack_id)
+
+      assert second_shape.shape_dependencies_handles == [dependency_handle]
+
+      dependency_pid = Electric.Shapes.Consumer.whereis(ctx.stack_id, dependency_handle)
+      assert is_pid(dependency_pid) and Process.alive?(dependency_pid)
+    end
+
     test "should wait for consumer to come up", ctx do
       Support.TestUtils.patch_snapshotter(fn parent, shape_handle, _, _ ->
         GenServer.cast(parent, {:pg_snapshot_known, shape_handle, @pg_snapshot_xmin_100})


### PR DESCRIPTION
This PR is based on the code from https://github.com/electric-sql/electric/pull/4774 and supersedes it.

## Problem

A subquery dependency can remain registered in ShapeStatus with a completed snapshot but no running consumer. When a new parent resolves its subquery to that existing handle, parent startup assumes the dependency consumer already exists. Its materializer fails to subscribe, the parent is invalidated, and every retry repeats the same failure because the dependency remains registered.

One way to reach this state is for a dependency to become orphaned before restart. The restart pruning pass only recognizes dependencies through surviving parents, while restored standalone shapes start consumers lazily when transaction routing first needs them.

## Solution

When ShapeCache resolves an existing shape while creating an inner shape, ensure its consumer is running before starting the parent. Missing consumers are restored through the same dependency-aware path used by transaction routing, while preserving `is_subquery_shape?: true` so the recovered dependency buffers complete transactions.

The shared restoration helper also removes duplicated consumer-starting logic.

## Test

The regression test constructs the registered/completed-snapshot/no-consumer state, requests a new parent, and verifies that:

- the existing dependency handle is reused;
- its consumer is restarted before the parent initializes;
- the recovered dependency uses `write_unit: :txn`.

Focused verification: `mix test test/electric/shape_cache_test.exs:1081`.

## Follow-up

A pre-existing edge case remains when an already-running standalone consumer is later reused as a dependency: its write mode must be promoted at a transaction boundary. That behavior is addressed in [#4780](https://github.com/electric-sql/electric/pull/4780).
