### PR TITLE
Preserve data messages during replay suppression in the TypeScript client

### DIFF
--- a/.changeset/fresh-cursors-keep-rows.md
+++ b/.changeset/fresh-cursors-keep-rows.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/client': patch
+---
+
+Preserve data messages when suppressing cached up-to-date notifications during replay.

--- a/packages/typescript-client/SPEC.md
+++ b/packages/typescript-client/SPEC.md
@@ -241,7 +241,7 @@ up-to-date; replay is meaningless.
 
 - ErrorState:
   `handleResponseMetadata` returns `{ action: 'ignored', state: this }`
-  and `handleMessageBatch` returns `{ state: this, suppressBatch: false, becameUpToDate: false }`
+  and `handleMessageBatch` returns `{ state: this, suppressUpToDate: false, becameUpToDate: false }`
 - PausedState:
   `handleMessageBatch` and `handleSseConnectionClosed` are no-ops
   and `handleResponseMetadata` delegates to `previousState`, preserving the paused wrapper for `accepted` and `stale-retry` transitions (`ignored` returns `this`)
@@ -291,6 +291,16 @@ Other states don't carry SSE state — when transitioning from a non-Live state
 back to Live, SSE state resets to defaults.
 
 **Enforcement**: Dedicated test (`SSE state is preserved through LiveState self-transitions`).
+
+### C9: Replay suppression must not discard data messages
+
+When a non-SSE replay reaches an up-to-date message with the same cursor as the
+previous session, the duplicate `up-to-date` control message is suppressed. Every
+other message in that batch, including inserts, updates, and deletes, is still
+delivered to stream subscribers. A fresh up-to-date message is delivered once the
+cursor advances.
+
+**Enforcement**: Dedicated test (`should preserve change messages while suppressing a cached up-to-date`).
 
 ## Shape notification semantics
 
@@ -368,31 +378,32 @@ observing an intermediate empty-rows notification. The
 | C6         | -     | -           | yes            |
 | C7         | -     | yes         | yes            |
 | C8         | -     | -           | yes            |
+| C9         | -     | -           | yes            |
 
 ### Code -> Doc: Is each test derived from the spec?
 
-| Test File / Section            | Spec Reference          |
-| ------------------------------ | ----------------------- |
-| Tier 1: scenario builder tests | I0-I11 (via auto-check) |
-| Tier 2: transition truth table | All 70 cells            |
-| Algebraic property tests       | I3, I4, I10, I11, I8    |
-| Fuzz testing                   | I0-I12 (all invariants) |
-| Mutation testing               | I0-I12 (robustness)     |
-| shouldUseSse guard tests       | LiveState SSE behavior  |
-| SSE connection closed tests    | LiveState SSE fallback  |
-| applyUrlParams tests           | URL construction        |
-| Schema adoption tests          | C4                      |
-| 204/200 lastSyncedAt tests     | C5                      |
-| SSE offset tests               | C6                      |
-| Stale handle tests             | C7                      |
-| ReplayingState suppress tests  | Replay cursor semantics |
+| Test File / Section            | Spec Reference              |
+| ------------------------------ | --------------------------- |
+| Tier 1: scenario builder tests | I0-I11 (via auto-check)     |
+| Tier 2: transition truth table | All 70 cells                |
+| Algebraic property tests       | I3, I4, I10, I11, I8        |
+| Fuzz testing                   | I0-I12 (all invariants)     |
+| Mutation testing               | I0-I12 (robustness)         |
+| shouldUseSse guard tests       | LiveState SSE behavior      |
+| SSE connection closed tests    | LiveState SSE fallback      |
+| applyUrlParams tests           | URL construction            |
+| Schema adoption tests          | C4                          |
+| 204/200 lastSyncedAt tests     | C5                          |
+| SSE offset tests               | C6                          |
+| Stale handle tests             | C7                          |
+| ReplayingState suppress tests  | Replay cursor semantics, C9 |
 
 ### Gaps
 
 | Gap                            | Status | Notes                                         |
 | ------------------------------ | ------ | --------------------------------------------- |
 | SSE fallback to long polling   | Tested | Direct construction only (DSL doesn't expose) |
-| ReplayingState suppressBatch   | Tested | Direct construction only (DSL doesn't expose) |
+| ReplayingState suppression     | Tested | Direct construction only (DSL doesn't expose) |
 | ErrorState.reset()             | Tested | Direct construction (DSL doesn't have reset)  |
 | handleMessageBatch no-messages | Tested | Direct construction (edge case)               |
 

--- a/packages/typescript-client/SPEC.md
+++ b/packages/typescript-client/SPEC.md
@@ -302,6 +302,13 @@ cursor advances.
 
 **Enforcement**: Dedicated test (`should preserve change messages while suppressing a cached up-to-date`).
 
+**Reachability note**: This is a state-machine invariant, not a server scenario.
+The server only sets `electric-cursor` on `live=true` responses, the client only
+sends `live=true` from LiveState, and ReplayingState is only entered from a
+fetching state — so against a conforming server the first up-to-date a replaying
+stream sees never carries a cursor and suppression does not fire. The dedicated
+test drives the branch with a synthetic cursor header on a non-live response.
+
 ## Shape notification semantics
 
 The `Shape` class (`shape.ts`) wraps a `ShapeStream` and notifies subscribers

--- a/packages/typescript-client/SPEC.md
+++ b/packages/typescript-client/SPEC.md
@@ -297,10 +297,13 @@ back to Live, SSE state resets to defaults.
 When a non-SSE replay reaches an up-to-date message with the same cursor as the
 previous session, the duplicate `up-to-date` control message is suppressed. Every
 other message in that batch, including inserts, updates, and deletes, is still
-delivered to stream subscribers. A fresh up-to-date message is delivered once the
+delivered to stream subscribers. If suppression leaves the batch empty (it carried
+nothing but the duplicate `up-to-date`), subscribers are not notified at all rather
+than receiving an empty batch. A fresh up-to-date message is delivered once the
 cursor advances.
 
-**Enforcement**: Dedicated test (`should preserve change messages while suppressing a cached up-to-date`).
+**Enforcement**: Dedicated tests (`should preserve change messages while suppressing a cached up-to-date`,
+`should not notify subscribers for a batch emptied by replay suppression`).
 
 **Reachability note**: This is a state-machine invariant, not a server scenario.
 The server only sets `electric-cursor` on `live=true` responses, the client only

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -1554,11 +1554,7 @@ export class ShapeStream<T extends Row<unknown> = Row>
 
     if (hasUpToDateMessage) {
       this.#refreshCatchUpWatchdogActive = false
-      if (transition.suppressBatch) {
-        return
-      }
-
-      if (this.#currentFetchUrl) {
+      if (!transition.suppressUpToDate && this.#currentFetchUrl) {
         const shapeKey = canonicalShapeKey(this.#currentFetchUrl)
         upToDateTracker.recordUpToDate(
           shapeKey,
@@ -1570,6 +1566,9 @@ export class ShapeStream<T extends Row<unknown> = Row>
 
     // Filter messages using snapshot tracker
     const messagesToProcess = batch.filter((message) => {
+      if (transition.suppressUpToDate && isUpToDateMessage(message)) {
+        return false
+      }
       if (isChangeMessage(message)) {
         const changeLsn = message.headers.lsn
         if (typeof changeLsn === `string` && changeLsn) {
@@ -1593,6 +1592,8 @@ export class ShapeStream<T extends Row<unknown> = Row>
 
       return true // Always process control messages
     })
+
+    if (messagesToProcess.length === 0) return
 
     await this.#publish(messagesToProcess, {
       allowReentrantBypass: opts.allowReentrantPublishBypass,

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -1595,6 +1595,14 @@ export class ShapeStream<T extends Row<unknown> = Row>
       return true // Always process control messages
     })
 
+    // A replay batch that carried nothing but the suppressed up-to-date has
+    // nothing to deliver. Skip the callback rather than publishing an empty
+    // batch: subscribers are promised one or more messages per notification,
+    // and the pre-suppression code never notified for a suppressed replay.
+    // Batches emptied by the snapshot tracker alone are still published as
+    // before.
+    if (messagesToProcess.length === 0 && transition.suppressUpToDate) return
+
     await this.#publish(messagesToProcess, {
       allowReentrantBypass: opts.allowReentrantPublishBypass,
     })

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -1566,9 +1566,6 @@ export class ShapeStream<T extends Row<unknown> = Row>
 
     // Filter messages using snapshot tracker
     const messagesToProcess = batch.filter((message) => {
-      if (transition.suppressUpToDate && isUpToDateMessage(message)) {
-        return false
-      }
       if (isChangeMessage(message)) {
         const changeLsn = message.headers.lsn
         if (typeof changeLsn === `string` && changeLsn) {
@@ -1588,6 +1585,11 @@ export class ShapeStream<T extends Row<unknown> = Row>
           // not once the database has passed the snapshot's LSN.
           this.#snapshotTracker.lastSeenUpdate(BigInt(lastSeenLsn))
         }
+
+        // A replayed up-to-date for the previous session's cursor still
+        // carries real WAL progress, which is applied above; only its
+        // delivery to subscribers is skipped.
+        if (transition.suppressUpToDate) return false
       }
 
       return true // Always process control messages

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -1595,8 +1595,6 @@ export class ShapeStream<T extends Row<unknown> = Row>
       return true // Always process control messages
     })
 
-    if (messagesToProcess.length === 0) return
-
     await this.#publish(messagesToProcess, {
       allowReentrantBypass: opts.allowReentrantPublishBypass,
     })

--- a/packages/typescript-client/src/shape-stream-state.ts
+++ b/packages/typescript-client/src/shape-stream-state.ts
@@ -90,7 +90,7 @@ export interface MessageBatchInput {
 
 export interface MessageBatchTransition {
   state: ShapeStreamState
-  suppressBatch: boolean
+  suppressUpToDate: boolean
   becameUpToDate: boolean
 }
 
@@ -196,7 +196,7 @@ export abstract class ShapeStreamState {
   }
 
   handleMessageBatch(_input: MessageBatchInput): MessageBatchTransition {
-    return { state: this, suppressBatch: false, becameUpToDate: false }
+    return { state: this, suppressUpToDate: false, becameUpToDate: false }
   }
 
   // --- Universal transitions ---
@@ -323,7 +323,7 @@ abstract class ActiveState extends ShapeStreamState {
 
   handleMessageBatch(input: MessageBatchInput): MessageBatchTransition {
     if (!input.hasMessages || !input.hasUpToDateMessage) {
-      return { state: this, suppressBatch: false, becameUpToDate: false }
+      return { state: this, suppressUpToDate: false, becameUpToDate: false }
     }
 
     // Has up-to-date message — compute shared fields for the transition
@@ -350,7 +350,7 @@ abstract class ActiveState extends ShapeStreamState {
   ): MessageBatchTransition {
     return {
       state: new LiveState(shared),
-      suppressBatch: false,
+      suppressUpToDate: false,
       becameUpToDate: true,
     }
   }
@@ -546,7 +546,7 @@ export class LiveState extends ActiveState {
   ): MessageBatchTransition {
     return {
       state: new LiveState(shared, this.sseState),
-      suppressBatch: false,
+      suppressUpToDate: false,
       becameUpToDate: true,
     }
   }
@@ -638,13 +638,13 @@ export class ReplayingState extends ActiveState {
     shared: SharedStateFields,
     input: MessageBatchInput
   ): MessageBatchTransition {
-    // Suppress replayed cache data when cursor has not moved since
+    // Suppress the replayed up-to-date notification when the cursor has not moved since
     // the previous session (non-SSE only).
-    const suppressBatch =
+    const suppressUpToDate =
       !input.isSse && this.#replayCursor === input.currentCursor
     return {
       state: new LiveState(shared),
-      suppressBatch,
+      suppressUpToDate,
       becameUpToDate: true,
     }
   }

--- a/packages/typescript-client/test/shape-stream-state.test.ts
+++ b/packages/typescript-client/test/shape-stream-state.test.ts
@@ -287,7 +287,7 @@ describe(`shape stream state machine`, () => {
       makeMessageBatchInput({ currentCursor: `cursor-1` })
     )
 
-    expect(transition.suppressBatch).toBe(true)
+    expect(transition.suppressUpToDate).toBe(true)
     expect(transition.state).toBeInstanceOf(LiveState)
     expect(transition.state.replayCursor).toBe(undefined)
   })
@@ -303,7 +303,7 @@ describe(`shape stream state machine`, () => {
       makeMessageBatchInput({ currentCursor: `cursor-2` })
     )
 
-    expect(transition.suppressBatch).toBe(false)
+    expect(transition.suppressUpToDate).toBe(false)
     expect(transition.state).toBeInstanceOf(LiveState)
   })
 
@@ -318,7 +318,7 @@ describe(`shape stream state machine`, () => {
       makeMessageBatchInput({ isSse: true, currentCursor: `cursor-1` })
     )
 
-    expect(transition.suppressBatch).toBe(false)
+    expect(transition.suppressUpToDate).toBe(false)
     expect(transition.state).toBeInstanceOf(LiveState)
   })
 
@@ -594,7 +594,7 @@ describe(`shape stream state machine`, () => {
     )
 
     expect(transition.state).toBe(syncing)
-    expect(transition.suppressBatch).toBe(false)
+    expect(transition.suppressUpToDate).toBe(false)
     expect(transition.becameUpToDate).toBe(false)
   })
 

--- a/packages/typescript-client/test/up-to-date-tracker.test.ts
+++ b/packages/typescript-client/test/up-to-date-tracker.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
-import { ShapeStream } from '../src'
+import { type Message, ShapeStream } from '../src'
 import { UpToDateTracker, upToDateTracker } from '../src/up-to-date-tracker'
 
 describe(`UpToDateTracker`, () => {
@@ -212,6 +212,102 @@ describe(`UpToDateTracker`, () => {
     // Neither should trigger replay mode after clear
     expect(tracker.shouldEnterReplayMode(shapeKey1)).toBe(null)
     expect(tracker.shouldEnterReplayMode(shapeKey2)).toBe(null)
+  })
+
+  it(`should preserve change messages while suppressing a cached up-to-date`, async () => {
+    const table = `replayed_rows`
+    const shapeKey = `${shapeUrl}?table=${table}`
+    const rowKey = `dashboard-version-1`
+    const notifications: Array<Array<Message>> = []
+
+    upToDateTracker.recordUpToDate(shapeKey, `cursor-1`)
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              key: rowKey,
+              value: { id: rowKey },
+              headers: { operation: `insert` },
+            },
+            { headers: { control: `up-to-date` } },
+          ]),
+          {
+            status: 200,
+            headers: {
+              'electric-handle': `test-handle-1`,
+              'electric-offset': `0_0`,
+              'electric-schema': `{}`,
+              'electric-cursor': `cursor-1`,
+              'electric-up-to-date': `true`,
+            },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ headers: { control: `up-to-date` } }]), {
+          status: 200,
+          headers: {
+            'electric-handle': `test-handle-1`,
+            'electric-offset': `0_0`,
+            'electric-schema': `{}`,
+            'electric-cursor': `cursor-2`,
+            'electric-up-to-date': `true`,
+          },
+        })
+      )
+
+    const stream = new ShapeStream({
+      url: shapeUrl,
+      params: { table },
+      signal: aborter.signal,
+      fetchClient: fetchMock,
+      subscribe: true,
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        aborter.abort()
+        reject(new Error(`Timed out waiting for fresh up-to-date`))
+      }, 500)
+
+      stream.subscribe(
+        (messages) => {
+          notifications.push(messages)
+          const hasUpToDate = messages.some(
+            (message) =>
+              `control` in message.headers &&
+              message.headers.control === `up-to-date`
+          )
+          if (hasUpToDate) {
+            clearTimeout(timeout)
+            aborter.abort()
+            resolve()
+          }
+        },
+        (error) => {
+          clearTimeout(timeout)
+          reject(error)
+        }
+      )
+    })
+
+    const receivedMessages = notifications.flat()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(
+      receivedMessages.some(
+        (message) => `key` in message && message.key === rowKey
+      )
+    ).toBe(true)
+    expect(
+      receivedMessages.some(
+        (message) =>
+          `control` in message.headers &&
+          message.headers.control === `up-to-date`
+      )
+    ).toBe(true)
+    expect(stream.isUpToDate).toBe(true)
   })
 
   it(`should suppress cached up-to-dates during replay mode`, async () => {

--- a/packages/typescript-client/test/up-to-date-tracker.test.ts
+++ b/packages/typescript-client/test/up-to-date-tracker.test.ts
@@ -215,6 +215,11 @@ describe(`UpToDateTracker`, () => {
   })
 
   it(`should preserve change messages while suppressing a cached up-to-date`, async () => {
+    // Pins the ReplayingState invariant (SPEC.md C9), not a server scenario:
+    // a real server only sets `electric-cursor` on live responses, and the
+    // client is never in ReplayingState when it issues a live request. The
+    // cursor header on this non-live initial response is synthetic so that
+    // the suppression branch runs at all.
     const table = `replayed_rows`
     const shapeKey = `${shapeUrl}?table=${table}`
     const rowKey = `dashboard-version-1`

--- a/packages/typescript-client/test/up-to-date-tracker.test.ts
+++ b/packages/typescript-client/test/up-to-date-tracker.test.ts
@@ -315,6 +315,87 @@ describe(`UpToDateTracker`, () => {
     expect(stream.isUpToDate).toBe(true)
   })
 
+  it(`should not notify subscribers for a batch emptied by replay suppression`, async () => {
+    // Same synthetic setup as the test above (SPEC.md C9): the cursor header on
+    // a non-live response is what drives the suppression branch. Here the
+    // replayed batch carries only the duplicate up-to-date, so filtering leaves
+    // nothing to deliver and subscribers must not be invoked with `[]`.
+    const table = `replayed_empty`
+    const shapeKey = `${shapeUrl}?table=${table}`
+    const notifications: Array<Array<Message>> = []
+
+    upToDateTracker.recordUpToDate(shapeKey, `cursor-1`)
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ headers: { control: `up-to-date` } }]), {
+          status: 200,
+          headers: {
+            'electric-handle': `test-handle-1`,
+            'electric-offset': `0_0`,
+            'electric-schema': `{}`,
+            'electric-cursor': `cursor-1`,
+            'electric-up-to-date': `true`,
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ headers: { control: `up-to-date` } }]), {
+          status: 200,
+          headers: {
+            'electric-handle': `test-handle-1`,
+            'electric-offset': `0_0`,
+            'electric-schema': `{}`,
+            'electric-cursor': `cursor-2`,
+            'electric-up-to-date': `true`,
+          },
+        })
+      )
+
+    const stream = new ShapeStream({
+      url: shapeUrl,
+      params: { table },
+      signal: aborter.signal,
+      fetchClient: fetchMock,
+      subscribe: true,
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        aborter.abort()
+        reject(new Error(`Timed out waiting for fresh up-to-date`))
+      }, 500)
+
+      stream.subscribe(
+        (messages) => {
+          notifications.push(messages)
+          const hasUpToDate = messages.some(
+            (message) =>
+              `control` in message.headers &&
+              message.headers.control === `up-to-date`
+          )
+          if (hasUpToDate) {
+            clearTimeout(timeout)
+            aborter.abort()
+            resolve()
+          }
+        },
+        (error) => {
+          clearTimeout(timeout)
+          reject(error)
+        }
+      )
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    // Exactly one notification: the fresh up-to-date. The suppressed replay
+    // batch produced no callback at all, not an empty one.
+    expect(notifications).toHaveLength(1)
+    expect(notifications[0]).toHaveLength(1)
+    expect(notifications[0][0].headers.control).toBe(`up-to-date`)
+    expect(stream.isUpToDate).toBe(true)
+  })
+
   it(`should suppress cached up-to-dates during replay mode`, async () => {
     const notifications: any[] = []
 


### PR DESCRIPTION
Supersedes #4723 by @joshdchang, rebased on `main` with follow-up commits. Josh's original commit is preserved as-is.

## Problem

When a fresh `ShapeStream` enters replay mode (the up-to-date tracker holds a recent cursor for the shape) and the first up-to-date it sees carries that same cursor, `ReplayingState` requested suppression of the *whole batch*: `#onMessages` returned before publishing anything. A batch of `[insert, …, up-to-date]` therefore lost its rows while the stream's offset still advanced past them.

## Fix

- Represent the transition as `suppressUpToDate` instead of `suppressBatch`. The snapshot-tracker filtering runs as usual and only the duplicate `up-to-date` control message is removed before notifying subscribers.
- Apply the `global_last_seen_lsn` bookkeeping for a suppressed up-to-date before dropping it, so suppression affects delivery to subscribers only, not snapshot retirement.
- Document the invariant as C9 in the client `SPEC.md`.

The original PR also skipped the subscriber callback when the filtered batch was empty. That applied outside replay mode as well (a batch whose changes were all rejected by the snapshot tracker previously published an empty array), so it is not included here; the pre-existing behaviour is kept.

## Reachability

The suppression branch cannot fire against a conforming server: `electric-cursor` is only set on `live=true` responses, the client only sends `live=true` from `LiveState`, and `ReplayingState` is only entered around a non-live request. The first up-to-date a replaying stream sees therefore never carries a cursor. The state-machine semantics were still wrong and are fixed here; the C9 test and spec entry are annotated as pinning the invariant with a synthetic cursor header rather than describing a server scenario. Whether the replay mechanism should exist at all is left for a follow-up.

Fixes #4722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCuaAMyknYeVkfWMkyGuuS
