### PR TITLE
Wait for in-flight writers before adding tables to the publication

### DIFF
--- a/.changeset/publication-add-table-writer-barrier.md
+++ b/.changeset/publication-add-table-writer-barrier.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Wait for in-flight transactions that have written to a table to finish before committing the table's addition to the publication. Previously, such a transaction's writes were neither emitted by the replication stream (they predate the addition) nor included in the initial snapshot (the transaction was still open), so any shape created on the table right after it was added - e.g. after a `TRUNCATE` invalidated the previous shapes - was silently missing those rows for its whole lifetime.

--- a/packages/sync-service/lib/electric/db_configuration_error.ex
+++ b/packages/sync-service/lib/electric/db_configuration_error.ex
@@ -28,6 +28,14 @@ defmodule Electric.DbConfigurationError do
     }
   end
 
+  def table_lock_timeout(table) do
+    %Electric.DbConfigurationError{
+      type: :table_lock_timeout,
+      message:
+        "Timed out waiting for in-flight transactions writing to #{table} to finish before adding it to the publication"
+    }
+  end
+
   def publication_not_owned(pub_name) do
     %Electric.DbConfigurationError{
       type: :publication_not_owned,

--- a/packages/sync-service/lib/electric/postgres/configuration.ex
+++ b/packages/sync-service/lib/electric/postgres/configuration.ex
@@ -4,6 +4,7 @@ defmodule Electric.Postgres.Configuration do
   a provided connection.
   """
   require Logger
+  alias Electric.DbConfigurationError
   alias Electric.Utils
   alias Electric.Replication.PublicationManager
 
@@ -89,9 +90,60 @@ defmodule Electric.Postgres.Configuration do
 
     run_in_transaction(
       conn,
-      &exec_alter_publication_for_table(&1, publication_name, :add, table),
+      fn conn ->
+        case exec_alter_publication_for_table(conn, publication_name, :add, table) do
+          :ok -> wait_for_in_flight_writers(conn, table)
+          :noop -> :ok
+          {:error, _} = error -> error
+        end
+      end,
       timeout
     )
+  end
+
+  # Logical decoding evaluates publication membership per change, against the catalog state at
+  # the point in the WAL where the change was made. A transaction that wrote to the table
+  # *before* the `ALTER PUBLICATION ... ADD TABLE` commits therefore never has those writes
+  # emitted by the replication stream, even if it commits after. The only way for such writes to
+  # reach a shape is through the initial snapshot, and the snapshot only includes them if the
+  # transaction has committed by the time the snapshot is taken.
+  #
+  # `ALTER PUBLICATION ... ADD TABLE` only takes a SHARE UPDATE EXCLUSIVE lock on the table, which
+  # doesn't conflict with writers, so on its own it gives no such guarantee. Taking a SHARE lock
+  # here closes the gap: it conflicts with the ROW EXCLUSIVE lock every writer holds until its
+  # transaction ends, so it is only granted once all in-flight writers have finished, and writers
+  # that arrive while it's pending queue up behind it and end up writing after the addition has
+  # committed, which is decoded normally. Since this runs inside the same transaction as the
+  # addition, the addition doesn't commit - and shapes waiting on it don't start snapshotting -
+  # until then.
+  #
+  # This mirrors what the `ALTER TABLE ... REPLICA IDENTITY FULL` in
+  # `configure_table_for_replication/4` has always done implicitly via its stronger ACCESS
+  # EXCLUSIVE lock. The wait is bounded by the transaction timeout, on expiry of which the whole
+  # transaction, addition included, is rolled back and the configuration reported as failed.
+  #
+  # Only called when this transaction is the one adding the table, i.e. when it holds the SHARE
+  # UPDATE EXCLUSIVE lock from the `ALTER PUBLICATION`. That lock serialises concurrent
+  # configurators on the same table, so no two of them can hold SHARE at the same time and then
+  # deadlock on upgrading it to ACCESS EXCLUSIVE for the replica identity change. If the table was
+  # already in the publication there is no gap to close, and taking the lock would open that
+  # deadlock up.
+  defp wait_for_in_flight_writers(conn, table) do
+    case Postgrex.query(conn, "LOCK TABLE #{table} IN SHARE MODE", []) do
+      {:ok, _} ->
+        :ok
+
+      # `query_canceled` is what the transaction timeout produces, `lock_not_available` what a
+      # `lock_timeout` configured on the database side does.
+      # A failed `LOCK` leaves the transaction aborted, and the addition must not be committed
+      # without the barrier in any case, so roll the whole transaction back.
+      {:error, %Postgrex.Error{postgres: %{code: code}}}
+      when code in [:query_canceled, :lock_not_available] ->
+        Postgrex.rollback(conn, DbConfigurationError.table_lock_timeout(table))
+
+      {:error, reason} ->
+        Postgrex.rollback(conn, reason)
+    end
   end
 
   @spec set_table_replica_identity_full(Postgrex.conn(), Electric.oid_relation(), timeout()) ::
@@ -122,6 +174,12 @@ defmodule Electric.Postgres.Configuration do
         with :ok <- add_table_to_publication(conn, publication_name, oid_relation),
              :ok <- set_table_replica_identity_full(conn, oid_relation) do
           :ok
+        else
+          # If the nested `add_table_to_publication/4` rolled back, the outer transaction is
+          # already marked as failed and committing it would report a bare `{:error, :rollback}`,
+          # losing the reason. Roll back explicitly to propagate it instead. For the errors the
+          # nested calls recover from via savepoints there is nothing to commit anyway.
+          {:error, reason} -> Postgrex.rollback(conn, reason)
         end
       end,
       timeout
@@ -147,13 +205,21 @@ defmodule Electric.Postgres.Configuration do
 
     run_in_transaction(
       conn,
-      &exec_alter_publication_for_table(&1, publication_name, :drop, table),
+      fn conn ->
+        case exec_alter_publication_for_table(conn, publication_name, :drop, table) do
+          result when result in [:ok, :noop] -> :ok
+          {:error, _} = error -> error
+        end
+      end,
       timeout
     )
   end
 
+  # Returns `:noop` when the table was already in the requested state, i.e. the publication was
+  # not altered. Note that in that case the savepoint rollback also releases the lock that
+  # `ALTER PUBLICATION` took on the table.
   @spec exec_alter_publication_for_table(Postgrex.conn(), String.t(), :add | :drop, String.t()) ::
-          :ok | {:error, term()}
+          :ok | :noop | {:error, term()}
   defp exec_alter_publication_for_table(conn, publication_name, op_atom, table) do
     op =
       case op_atom do
@@ -178,11 +244,11 @@ defmodule Electric.Postgres.Configuration do
         case reason do
           # undefined object can happen when removing a table that was already removed
           %{postgres: %{code: :undefined_object, message: "relation" <> _}} when op_atom == :drop ->
-            :ok
+            :noop
 
           # duplicate object can happen when adding a table that was already added
           %{postgres: %{code: :duplicate_object}} when op_atom == :add ->
-            :ok
+            :noop
 
           _ ->
             {:error, reason}

--- a/packages/sync-service/test/electric/postgres/configuration_test.exs
+++ b/packages/sync-service/test/electric/postgres/configuration_test.exs
@@ -40,6 +40,89 @@ defmodule Electric.Postgres.ConfigurationTest do
       assert :ok = Configuration.add_table_to_publication(conn, publication, oid_rel)
     end
 
+    @tag connection_opt_overrides: [pool_size: 2]
+    test "adds table to publication only once in-flight writers have finished", %{
+      pool: conn,
+      publication_name: publication
+    } do
+      oid = get_table_oid(conn, {"public", "items"})
+      oid_rel = {oid, {"public", "items"}}
+      test_pid = self()
+
+      # A transaction that wrote to the table before it was added to the publication. Logical
+      # decoding evaluates publication membership per change, so this write is never emitted by
+      # the replication stream. It can only reach a shape via the initial snapshot, which is why
+      # the addition must not commit until the writer has finished: a snapshot taken after that
+      # point sees the write, while any later write is emitted by the stream.
+      writer =
+        Task.async(fn ->
+          Postgrex.transaction(conn, fn conn ->
+            Postgrex.query!(
+              conn,
+              "INSERT INTO items (id, value) VALUES (gen_random_uuid(), 'pre-publication')",
+              []
+            )
+
+            send(test_pid, :written)
+            receive(do: (:commit -> :ok))
+          end)
+        end)
+
+      assert_receive :written
+
+      adder =
+        Task.async(fn ->
+          Configuration.add_table_to_publication(conn, publication, oid_rel, :infinity)
+        end)
+
+      adder_ref = adder.ref
+      refute_receive {^adder_ref, _}, 500
+
+      send(writer.pid, :commit)
+      assert {:ok, :ok} = Task.await(writer)
+      assert :ok = Task.await(adder)
+
+      assert list_tables_in_publication(conn, publication) == [{"public", "items"}]
+    end
+
+    @tag connection_opt_overrides: [pool_size: 2, parameters: [lock_timeout: "100"]]
+    test "fails to add table to publication if timing out on an in-flight writer", %{
+      pool: conn,
+      publication_name: publication
+    } do
+      oid = get_table_oid(conn, {"public", "items"})
+      oid_rel = {oid, {"public", "items"}}
+      test_pid = self()
+
+      # A server-side `lock_timeout` is used rather than the client-side transaction timeout, as
+      # the latter tears the connection down at the deadline and races with the server's own
+      # cancellation of the statement, making the resulting error type non-deterministic.
+      writer =
+        Task.async(fn ->
+          Postgrex.transaction(conn, fn conn ->
+            Postgrex.query!(
+              conn,
+              "INSERT INTO items (id, value) VALUES (gen_random_uuid(), 'pre-publication')",
+              []
+            )
+
+            send(test_pid, :written)
+            receive(do: (:commit -> :ok))
+          end)
+        end)
+
+      assert_receive :written
+
+      assert {:error, %Electric.DbConfigurationError{type: :table_lock_timeout}} =
+               Configuration.add_table_to_publication(conn, publication, oid_rel)
+
+      # the addition must have been rolled back along with the failed barrier
+      assert list_tables_in_publication(conn, publication) == []
+
+      send(writer.pid, :commit)
+      assert {:ok, :ok} = Task.await(writer)
+    end
+
     test "sets REPLICA IDENTITY on the table", %{pool: conn} do
       assert get_table_identity(conn, {"public", "items"}) == "d"
       oid = get_table_oid(conn, {"public", "items"})


### PR DESCRIPTION
Fixes #4773

## Problem

Logical decoding evaluates publication membership per change, against the catalog state at that point in the WAL. A transaction that wrote to a table *before* `ALTER PUBLICATION … ADD TABLE` committed therefore never has those writes emitted by the replication stream, even if it commits afterwards. The only way for such writes to reach a shape is the initial snapshot, and the snapshot only includes them if the transaction has committed by the time the snapshot is taken.

`ALTER PUBLICATION … ADD TABLE` takes only a SHARE UPDATE EXCLUSIVE lock, which doesn't conflict with writers, so the addition can commit — and the shape waiting on it can start snapshotting — while such a writer is still open. Its writes then end up in neither the snapshot (excluded via `xip_list`) nor the log, and the shape is silently missing them for its whole lifetime.

```
INSERT while unpublished  → not decoded (predates the addition)
                            └── transaction stays open
ADD TABLE commits
snapshot taken            → transaction excluded via xip_list
transaction commits       → rows permanently absent from the shape
```

The first-time-add path (`configure_table_for_replication/4`) has always been protected by accident: its `ALTER TABLE … REPLICA IDENTITY FULL` takes ACCESS EXCLUSIVE in the same transaction, which can't be granted until every in-flight writer has finished. The unprotected path is the add-only one, taken when the table is already `REPLICA IDENTITY FULL` — i.e. every re-add after the last shape on a table was removed (`TRUNCATE` invalidation as in the report, shape expiry, schema-change invalidation, …) and first adds of tables the user pre-set to FULL.

## Fix

`add_table_to_publication/4` now takes `LOCK TABLE … IN SHARE MODE` in the same transaction as the `ADD TABLE`, but only when this transaction is the one actually adding the table. SHARE conflicts with the ROW EXCLUSIVE lock every writer holds until its transaction ends, so the addition doesn't commit until all in-flight writers have finished; writers that arrive meanwhile queue up behind it and write after the addition, which is decoded normally. This makes the add-only path behave the way the first-time-add path already does, with a weaker lock.

- The lock is skipped when `ADD TABLE` reports the table as already present: there is no gap to close, and — since the savepoint rollback releases the SHARE UPDATE EXCLUSIVE lock — two concurrent configurators could otherwise both hold SHARE and deadlock upgrading to ACCESS EXCLUSIVE for the replica identity change (caught by the existing concurrency test).
- The wait is bounded by the existing action timeout. On expiry the whole transaction, addition included, is rolled back and the failure is reported as a `DbConfigurationError` of type `table_lock_timeout` (a known, retryable error → 503 with `Retry-After` for clients, no shape removal), instead of leaking the raw `query_canceled` as an "unexpected error" 500. A server-side `lock_timeout` (`lock_not_available`) is mapped the same way.
- `configure_table_for_replication/4` rolls back explicitly when a nested step fails, so the reason propagates instead of the bare `{:error, :rollback}` → "Transaction unexpectedly rolled back" that a failed nested transaction would otherwise produce.

## Trade-off

Shape creation on a table now waits for in-flight writers on that table (bounded by the action timeout, 5 s by default). While the SHARE request is pending, new writers on the table queue behind it — the same behaviour the first-time-add path has always had. A pending SHARE request also queues behind `VACUUM` / `CREATE INDEX CONCURRENTLY` on the table; a non-blocking variant of the barrier that avoids that is tracked separately.

Independently of Electric, the same "write while unpublished, commit after" transaction triggers a walsender relation-cache bug in PostgreSQL that drops later changes to the table (fixed upstream in PG 18, back-patched in the August 2025 minor releases); the deployment guidance should recommend a PG minor that includes it.
