### PR TITLE
Handle client-cancelled shape requests as disconnects instead of 500s

### DIFF
--- a/.changeset/client-disconnect-not-500.md
+++ b/.changeset/client-disconnect-not-500.md
@@ -1,0 +1,11 @@
+---
+"@core/sync-service": patch
+---
+
+Handle client-cancelled shape requests as disconnects instead of server errors.
+A live long-poll now aborts as soon as the client resets the HTTP/2 stream,
+releasing the handler process and its admission permit immediately instead of
+holding them for the remainder of the long-poll timeout. Transport errors
+raised when sending a response to a client that already went away are now
+recorded as status 499 with a `shape_req.client_disconnected` span attribute
+rather than surfacing as phantom 500s with recorded exceptions.

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -131,11 +131,31 @@ defmodule Electric.Plug.ServeShapePlug do
     end
 
     normalized_reason = Exception.normalize(kind, reason, stack)
-    status = if kind == :error, do: Plug.Exception.status(normalized_reason), else: 500
 
-    conn
-    |> Conn.put_status(status)
-    |> handle_error(kind, normalized_reason, stack)
+    if client_disconnected?(kind, normalized_reason) do
+      handle_client_disconnect(conn)
+    else
+      status = if kind == :error, do: Plug.Exception.status(normalized_reason), else: 500
+
+      conn
+      |> Conn.put_status(status)
+      |> handle_error(kind, normalized_reason, stack)
+    end
+  end
+
+  # The client tore down the request (HTTP/2 RST_STREAM, or a closed socket on
+  # HTTP/1) before the response could be sent — Bandit surfaces that as a raise
+  # from inside send_resp/send_chunked. Nobody can read a response (an error
+  # body included), and it is not a server error, so: no error body, no
+  # record_exception, status 499 for span/metric accounting. The transport
+  # error is still reraised by our caller for Bandit to handle natively —
+  # Bandit closes client-reset streams quietly (`log_client_closures: false`
+  # by default) instead of crash-logging.
+  defp client_disconnected?(:error, %Bandit.TransportError{error: :closed}), do: true
+  defp client_disconnected?(_kind, _reason), do: false
+
+  defp handle_client_disconnect(conn) do
+    Conn.put_status(conn, Api.Response.client_disconnect_status())
   end
 
   defp handle_error(conn, kind, exception, stack) do
@@ -592,6 +612,12 @@ defmodule Electric.Plug.ServeShapePlug do
       "shape_req.offset" => conn.query_params["offset"],
       "shape_req.is_shape_rotated" => attrs[:ot_is_shape_rotated] || false,
       "shape_req.is_long_poll_timeout" => attrs[:ot_is_long_poll_timeout] || false,
+      # The status check covers disconnects discovered only at send time
+      # (Bandit.TransportError caught in handle_caught/4), which never get a
+      # response struct carrying the trace attr.
+      "shape_req.client_disconnected" =>
+        attrs[:ot_is_client_disconnected] ||
+          conn.status == Api.Response.client_disconnect_status(),
       "shape_req.is_empty_response" => attrs[:ot_is_empty_response] || false,
       "shape_req.is_immediate_response" => attrs[:ot_is_immediate_response] || true,
       "shape_req.is_cached" => if(conn.status, do: conn.status == 304),

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -107,22 +107,18 @@ defmodule Electric.Plug.ServeShapePlug do
     end
   end
 
+  # Normalize the error and translate it into an appropriate HTTP response.
+  #
   # If the response was already sent (e.g. send_chunked partway through a
   # stream), we can't meaningfully recover — re-raise so the caller sees the
-  # original error. Otherwise normalize and delegate to handle_errors/2.
+  # original error.
   #
-  # Pre-existing limitation on the re-raise path: the
-  # [:electric, :plug, :serve_shape] telemetry event is NOT emitted when we
-  # re-raise. This is inherited from Plug.ErrorHandler's identical
-  # {:plug_conn, :sent} check — earlier approaches (outer/inner split;
-  # register_before_send) had the same behaviour, because once the response
-  # has been committed we no longer have access to the accumulated conn.
+  # Pre-existing limitation on the re-raise path: the [:electric, :plug, :serve_shape]
+  # telemetry event is NOT emitted when we re-raise, because once the response has been
+  # committed we no longer have access to the accumulated conn.
   #
   # The admission permit is still released and the OTEL span is still popped
   # via the `after` clause in call/2 — only the aggregate metric is lost.
-  # This triggers only when Plug.Conn.chunk/2 raises mid-stream; client
-  # disconnects are already handled explicitly as {:error, "closed"} in
-  # Api.Response.send_stream/2 without raising.
   defp handle_caught(conn, kind, reason, stack) do
     receive do
       {:plug_conn, :sent} -> :erlang.raise(kind, reason, stack)
@@ -131,38 +127,25 @@ defmodule Electric.Plug.ServeShapePlug do
     end
 
     normalized_reason = Exception.normalize(kind, reason, stack)
-
-    if client_disconnected?(kind, normalized_reason) do
-      handle_client_disconnect(conn)
-    else
-      status = if kind == :error, do: Plug.Exception.status(normalized_reason), else: 500
-
-      conn
-      |> Conn.put_status(status)
-      |> handle_error(kind, normalized_reason, stack)
-    end
+    handle_error(conn, kind, normalized_reason, stack)
   end
 
   # The client tore down the request (HTTP/2 RST_STREAM, or a closed socket on
-  # HTTP/1) before the response could be sent — Bandit surfaces that as a raise
-  # from inside send_resp/send_chunked. Nobody can read a response (an error
-  # body included), and it is not a server error, so: no error body, no
-  # record_exception, status 499 for span/metric accounting. The transport
-  # error is still reraised by our caller for Bandit to handle natively —
-  # Bandit closes client-reset streams quietly (`log_client_closures: false`
-  # by default) instead of crash-logging.
-  defp client_disconnected?(:error, %Bandit.TransportError{error: :closed}), do: true
-  defp client_disconnected?(_kind, _reason), do: false
-
-  defp handle_client_disconnect(conn) do
+  # HTTP/1) before the response could be sent.
+  #
+  # Bandit surfaces this condition as a raise from inside send_resp/send_chunked.
+  defp handle_error(conn, :error, %Bandit.TransportError{error: :closed}, _stack) do
     Conn.put_status(conn, Api.Response.client_disconnect_status())
   end
 
   defp handle_error(conn, kind, exception, stack) do
     OpenTelemetry.record_exception(kind, exception, stack)
+
+    status = if kind == :error, do: Plug.Exception.status(exception), else: 500
     error_str = Exception.format(kind, exception)
 
     conn
+    |> Conn.put_status(status)
     |> assign(:error_str, error_str)
     |> handle_specific_error(kind, exception)
   end
@@ -612,9 +595,6 @@ defmodule Electric.Plug.ServeShapePlug do
       "shape_req.offset" => conn.query_params["offset"],
       "shape_req.is_shape_rotated" => attrs[:ot_is_shape_rotated] || false,
       "shape_req.is_long_poll_timeout" => attrs[:ot_is_long_poll_timeout] || false,
-      # The status check covers disconnects discovered only at send time
-      # (Bandit.TransportError caught in handle_caught/4), which never get a
-      # response struct carrying the trace attr.
       "shape_req.client_disconnected" =>
         attrs[:ot_is_client_disconnected] ||
           conn.status == Api.Response.client_disconnect_status(),

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -886,6 +886,18 @@ defmodule Electric.Shapes.Api do
 
       {^ref, :out_of_bounds_timeout} ->
         :out_of_bounds_timeout
+
+      # Bandit's HTTP/2 connection process forwards a client's RST_STREAM to
+      # this handler process as a plain message (Bandit-private format, see
+      # Bandit.HTTP2.Stream.deliver_rst_stream/2). Matching it here lets us
+      # abandon the long poll — releasing this process and its admission
+      # permit — the moment the client cancels the request, instead of
+      # discovering the reset only when the response send fails after the
+      # full long-poll timeout. HTTP/1 has no equivalent early signal; there
+      # the reset surfaces as Bandit.TransportError at send time, handled in
+      # Electric.Plug.ServeShapePlug.
+      {:bandit, {:rst_stream, _error_code}} ->
+        :client_disconnect
     after
       long_poll_timeout ->
         :long_poll_timeout
@@ -899,6 +911,12 @@ defmodule Electric.Shapes.Api do
     |> determine_log_chunk_offset()
     |> determine_up_to_date()
     |> do_serve_shape_log()
+  end
+
+  defp handle_live_change_result(:client_disconnect, request) do
+    request
+    |> update_attrs(%{ot_is_client_disconnected: true})
+    |> Response.client_disconnect()
   end
 
   defp handle_live_change_result({:shape_rotation, new_handle}, request) do

--- a/packages/sync-service/lib/electric/shapes/api.ex
+++ b/packages/sync-service/lib/electric/shapes/api.ex
@@ -887,15 +887,15 @@ defmodule Electric.Shapes.Api do
       {^ref, :out_of_bounds_timeout} ->
         :out_of_bounds_timeout
 
-      # Bandit's HTTP/2 connection process forwards a client's RST_STREAM to
-      # this handler process as a plain message (Bandit-private format, see
-      # Bandit.HTTP2.Stream.deliver_rst_stream/2). Matching it here lets us
-      # abandon the long poll — releasing this process and its admission
-      # permit — the moment the client cancels the request, instead of
-      # discovering the reset only when the response send fails after the
-      # full long-poll timeout. HTTP/1 has no equivalent early signal; there
-      # the reset surfaces as Bandit.TransportError at send time, handled in
-      # Electric.Plug.ServeShapePlug.
+      # Bandit's HTTP/2 connection process forwards a client's RST_STREAM to this handler
+      # process as a plain message (Bandit-private format).
+      #
+      # Matching it here lets us abandon the long poll the moment the client cancels the
+      # request, instead of discovering the reset only when the response send fails after
+      # the full long-poll timeout.
+      #
+      # HTTP/1 has no equivalent early signal; there the reset surfaces as
+      # Bandit.TransportError at send time, handled in Electric.Plug.ServeShapePlug.
       {:bandit, {:rst_stream, _error_code}} ->
         :client_disconnect
     after

--- a/packages/sync-service/lib/electric/shapes/api/response.ex
+++ b/packages/sync-service/lib/electric/shapes/api/response.ex
@@ -112,8 +112,7 @@ defmodule Electric.Shapes.Api.Response do
     %{response | finalized?: true}
   end
 
-  # nginx's "client closed request" convention. Never sent to anyone — the
-  # client has already reset the stream — it exists so server-side accounting
+  # nginx's "client closed request" convention. It exists so server-side accounting
   # (spans, metrics) records a client disconnect rather than a server error.
   @client_disconnect_status 499
 

--- a/packages/sync-service/lib/electric/shapes/api/response.ex
+++ b/packages/sync-service/lib/electric/shapes/api/response.ex
@@ -112,6 +112,26 @@ defmodule Electric.Shapes.Api.Response do
     %{response | finalized?: true}
   end
 
+  # nginx's "client closed request" convention. Never sent to anyone — the
+  # client has already reset the stream — it exists so server-side accounting
+  # (spans, metrics) records a client disconnect rather than a server error.
+  @client_disconnect_status 499
+
+  def client_disconnect_status, do: @client_disconnect_status
+
+  @doc """
+  Response for a live request whose client cancelled mid-long-poll.
+  """
+  def client_disconnect(%Api.Request{response: response}) do
+    ensure_cleanup(%{
+      response
+      | status: @client_disconnect_status,
+        chunked: false,
+        up_to_date: false,
+        body: []
+    })
+  end
+
   def invalid_request(api_or_request, args) do
     error(api_or_request, "Invalid request", args)
   end
@@ -131,7 +151,22 @@ defmodule Electric.Shapes.Api.Response do
     Api.encode_error_message(api_or_request, body)
   end
 
+  # A client-disconnect response has no reader: the empty body is still
+  # drained so the cleanup operations appended by ensure_cleanup/1 run, and
+  # send_resp still fires to satisfy the Plug contract — having consumed the
+  # rst_stream notification, Bandit silently discards frames addressed to the
+  # reset stream (and on HTTP/1 the send raises Bandit.TransportError, which
+  # Electric.Plug.ServeShapePlug classifies as the same disconnect).
   @spec send(Plug.Conn.t(), t()) :: Plug.Conn.t()
+  def send(%Plug.Conn{} = conn, %__MODULE__{status: @client_disconnect_status} = response) do
+    validate_response_finalized!(response)
+    _drained = Enum.into(response.body, [])
+
+    conn
+    |> Plug.Conn.put_resp_header("cache-control", "no-store")
+    |> Plug.Conn.send_resp(@client_disconnect_status, "")
+  end
+
   def send(%Plug.Conn{} = conn, %__MODULE__{chunked: false} = response) do
     validate_response_finalized!(response)
 

--- a/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
+++ b/packages/sync-service/test/electric/plug/serve_shape_plug_test.exs
@@ -61,6 +61,16 @@ defmodule Electric.Plug.ServeShapePlugTest do
   # Higher timeout is needed for some tests that tend to run slower on CI.
   @receive_timeout 2000
 
+  defmodule RstStreamAdapter do
+    @moduledoc false
+    # Stands in for Bandit's adapter when the client has already reset the
+    # HTTP/2 stream: any attempt to send the response raises, exactly like
+    # Bandit.HTTP2.Stream.do_recv_rst_stream!/2 does.
+    def send_resp(_state, _status, _headers, _body) do
+      raise Bandit.TransportError, message: "Client reset stream normally", error: :closed
+    end
+  end
+
   @moduletag :tmp_dir
 
   setup [
@@ -760,6 +770,100 @@ defmodule Electric.Plug.ServeShapePlugTest do
 
       assert get_resp_header(conn, "electric-up-to-date") == [""]
       assert get_resp_header(conn, "electric-has-data") == ["false"]
+    end
+
+    test "aborts a live long-poll as soon as the client resets the HTTP/2 stream", ctx do
+      patch_shape_cache(
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
+          {@test_shape_handle, @test_offset}
+        end,
+        has_shape?: fn @test_shape_handle, _opts -> true end,
+        await_snapshot_start: fn @test_shape_handle, _ -> :started end
+      )
+
+      test_pid = self()
+
+      expect_storage(
+        get_chunk_end_log_offset: fn @test_offset, _ -> nil end,
+        get_log_stream: fn @test_offset, _, @test_opts ->
+          send(test_pid, :got_log_stream)
+          []
+        end
+      )
+
+      task =
+        Task.async(fn ->
+          ctx
+          |> conn(
+            :get,
+            %{"table" => "public.users"},
+            "?offset=#{@test_offset}&handle=#{@test_shape_handle}&live=true"
+          )
+          |> call_serve_shape_plug(ctx)
+        end)
+
+      assert_receive :got_log_stream, @receive_timeout
+
+      # Simulate Bandit's HTTP/2 connection process delivering the client's
+      # RST_STREAM (error code 8 = CANCEL) to the request-handler process.
+      Registry.dispatch(ctx.registry, @test_shape_handle, fn [{pid, _ref}] ->
+        send(pid, {:bandit, {:rst_stream, 8}})
+      end)
+
+      # The default long_poll_timeout is 20s here, so completing well within
+      # a second proves the poll was aborted by the reset, not the timeout.
+      conn = Task.await(task, 1000)
+
+      assert conn.status == 499
+      assert conn.resp_body == ""
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+    end
+
+    test "records a client disconnect when the response send hits a reset stream", ctx do
+      patch_shape_cache(
+        resolve_shape_handle: fn @test_shape_handle, @test_shape, _stack_id, _opts ->
+          {@test_shape_handle, @test_offset}
+        end,
+        has_shape?: fn @test_shape_handle, _opts -> true end,
+        await_snapshot_start: fn @test_shape_handle, _ -> :started end
+      )
+
+      expect_storage(
+        get_chunk_end_log_offset: fn @test_offset, _ -> nil end,
+        get_log_stream: fn @test_offset, _, @test_opts -> [] end
+      )
+
+      ctx = Map.put(ctx, :long_poll_timeout, 100)
+
+      telemetry_ref =
+        :telemetry_test.attach_event_handlers(self(), [[:electric, :plug, :serve_shape]])
+
+      conn =
+        ctx
+        |> conn(
+          :get,
+          %{"table" => "public.users"},
+          "?offset=#{@test_offset}&handle=#{@test_shape_handle}&live=true"
+        )
+        |> then(fn conn -> %{conn | adapter: {RstStreamAdapter, elem(conn.adapter, 1)}} end)
+
+      error =
+        assert_raise Plug.Conn.WrapperError, fn ->
+          call_serve_shape_plug(conn, ctx)
+        end
+
+      # The transport error is reraised for Bandit to handle natively (it
+      # closes client-reset streams quietly), but the request is accounted
+      # for as a client disconnect, not a 500.
+      assert %Bandit.TransportError{error: :closed} = error.reason
+      assert error.conn.status == 499
+
+      # Note: `live` is false here because the exception path only sees the
+      # pre-pipeline conn without the request assign (see the moduledoc note
+      # in ServeShapePlug) — the root span's `shape_req.is_live` attr is
+      # unaffected as it falls back to query params.
+      assert_received {[:electric, :plug, :serve_shape], ^telemetry_ref, %{count: 1},
+                       %{status: 499}}
     end
 
     test "returns electric-has-data: false for offset=now requests", ctx do


### PR DESCRIPTION
Fixes #4790

Two complementary changes:

1. **Abort the long poll the moment the cancel arrives.** `wait_for_live_change/2` now also matches Bandit's `{:bandit, {:rst_stream, _}}` notification and completes the request immediately — status 499, empty body, change-listener cleanup — releasing the process and admission permit at cancel time. The message format is Bandit-private (`Bandit.HTTP2.Stream.deliver_rst_stream/2`); the receive clause carries a comment pinning that. HTTP/1 has no equivalent early signal and is covered by the second change only.

2. **Classify send-time transport failures as client disconnects.** A `%Bandit.TransportError{error: :closed}` caught around the plug pipeline is now accounted for as status 499 (nginx's "client closed request" convention) with a `shape_req.client_disconnected` span attribute — no `record_exception`, no unreadable error body — and is reraised for Bandit to close the stream through its native quiet path (`log_client_closures: false` by default). This mirrors how the chunked streaming path already treats `{:error, "closed"}` as a quiet halt.

The `[:electric, :plug, :serve_shape]` telemetry event still fires for these requests (with status 499), so cancellation volume stays measurable while dropping out of the 5xx error signal.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4Hiytggpfq8UqvFnshh5r
