### PR TITLE
Disable Bandit's HTTP/2 reset-stream rate limit by default

### DIFF
--- a/.changeset/h2-reset-stream-rate.md
+++ b/.changeset/h2-reset-stream-rate.md
@@ -1,0 +1,11 @@
+---
+"@core/sync-service": patch
+---
+
+Disable Bandit's HTTP/2 reset-stream rate limit by default and expose it as
+`ELECTRIC_TWEAKS_HTTP2_MAX_RESET_STREAM_RATE`. The limit closes an entire
+connection once a client sends more than 500 `RST_STREAM` frames in 10 seconds,
+dropping every request in flight on it. Behind a proxy that multiplexes many end
+clients onto a few upstream connections, routine client-side cancellations of
+live requests were enough to trip it, killing the parked long-polls of unrelated
+clients and leaking their admission permits.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -311,6 +311,12 @@ config :electric,
   http_api_num_acceptors: env!("ELECTRIC_TWEAKS_HTTP_API_NUM_ACCEPTORS", :integer, 100),
   conn_max_requests: env!("ELECTRIC_TWEAKS_CONN_MAX_REQUESTS", :integer, nil),
   handler_fullsweep_after: env!("ELECTRIC_TWEAKS_HANDLER_FULLSWEEP_AFTER", :integer, nil),
+  http2_max_reset_stream_rate:
+    env!(
+      "ELECTRIC_TWEAKS_HTTP2_MAX_RESET_STREAM_RATE",
+      &Electric.Config.parse_http2_max_reset_stream_rate!/1,
+      nil
+    ),
   tcp_send_timeout:
     env!("ELECTRIC_TCP_SEND_TIMEOUT", &Electric.Config.parse_human_readable_time!/1, nil),
   tcp_read_timeout:

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -157,6 +157,7 @@ defmodule Electric.Application do
         flush_stall_grace_period: get_env(opts, :flush_stall_grace_period),
         conn_max_requests: get_env(opts, :conn_max_requests),
         handler_fullsweep_after: get_env(opts, :handler_fullsweep_after),
+        http2_max_reset_stream_rate: get_env(opts, :http2_max_reset_stream_rate),
         process_spawn_opts: get_env(opts, :process_spawn_opts),
         consumer_gc_heap_threshold: get_env(opts, :consumer_gc_heap_threshold)
       ],
@@ -369,13 +370,25 @@ defmodule Electric.Application do
         []
       end
 
+    # Bandit's reset-stream rate limit (a Rapid Reset mitigation) closes the entire
+    # connection once a client sends too many RST_STREAM frames, killing every stream
+    # on it without running their cleanup. A proxy that multiplexes many end clients
+    # onto one upstream connection trips it with ordinary long-poll cancellations, and
+    # since Bandit leaves `max_concurrent_streams` unbounded the limit does not close
+    # off any attack that opening streams without resetting them wouldn't achieve.
+    http_2_opts =
+      case Keyword.get(tweaks, :http2_max_reset_stream_rate, :disabled) do
+        :disabled -> [max_reset_stream_rate: nil]
+        {count, period_ms} -> [max_reset_stream_rate: {count, period_ms}]
+      end
+
     [
       {Bandit,
        [
          plug: {Electric.Plug.Router, router_opts},
          port: get_env(opts, :service_port),
          http_1_options: http_1_opts,
-         http_2_options: [],
+         http_2_options: http_2_opts,
          thousand_island_options: thousand_island_options(opts ++ ti_opts)
        ]}
     ]

--- a/packages/sync-service/lib/electric/config.ex
+++ b/packages/sync-service/lib/electric/config.ex
@@ -123,6 +123,14 @@ defmodule Electric.Config do
     # forces a fullsweep after N minor collections to reclaim that memory.
     # See https://www.erlang.org/doc/apps/erts/erlang.html#spawn_opt/4
     handler_fullsweep_after: nil,
+    # Sets max_reset_stream_rate for Bandit HTTP/2 connections: the number of client
+    # RST_STREAM frames tolerated per connection within a time window before Bandit
+    # tears down the whole connection with ENHANCE_YOUR_CALM. Bandit defaults to
+    # {500, 10_000}. Disabled here: tearing down a connection kills every in-flight
+    # stream on it, and behind a proxy that multiplexes many end clients onto a few
+    # upstream connections, ordinary client-side cancellations of long-polls are
+    # enough to trip it. Electric handles cancellations per stream instead.
+    http2_max_reset_stream_rate: :disabled,
     ## Performance tweaks
     publication_alter_debounce_ms: 0,
     # allow for configuring per-process `Process.spawn_opt()`. In the form
@@ -612,6 +620,47 @@ defmodule Electric.Config do
 
   def parse_top_process_limit!(str) do
     case parse_top_process_limit(str) do
+      {:ok, result} -> result
+      {:error, message} -> raise Dotenvy.Error, message: message
+    end
+  end
+
+  @doc """
+  Parse an HTTP/2 reset-stream rate limit of the form `<count>/<duration>` into the
+  `{count, period_ms}` tuple Bandit expects, or `disabled` into `:disabled`.
+
+  ## Examples
+
+    iex> parse_http2_max_reset_stream_rate("500/10s")
+    {:ok, {500, 10000}}
+
+    iex> parse_http2_max_reset_stream_rate("disabled")
+    {:ok, :disabled}
+
+    iex> parse_http2_max_reset_stream_rate("500")
+    {:error, ~S'invalid HTTP/2 reset stream rate: "500". Expected format: <count>/<duration> (e.g. 500/10s) or disabled'}
+  """
+  @spec parse_http2_max_reset_stream_rate(binary) ::
+          {:ok, {pos_integer, pos_integer} | :disabled} | {:error, binary}
+  def parse_http2_max_reset_stream_rate(str) do
+    with false <- String.downcase(str) == "disabled",
+         [count_str, period_str] <- String.split(str, "/"),
+         {count, ""} when count > 0 <- Integer.parse(count_str),
+         {:ok, period_ms} <- parse_human_readable_time(period_str) do
+      {:ok, {count, period_ms}}
+    else
+      true ->
+        {:ok, :disabled}
+
+      _ ->
+        {:error,
+         "invalid HTTP/2 reset stream rate: #{inspect(str)}. " <>
+           "Expected format: <count>/<duration> (e.g. 500/10s) or disabled"}
+    end
+  end
+
+  def parse_http2_max_reset_stream_rate!(str) do
+    case parse_http2_max_reset_stream_rate(str) do
       {:ok, result} -> result
       {:error, message} -> raise Dotenvy.Error, message: message
     end

--- a/packages/sync-service/lib/electric/stack_supervisor.ex
+++ b/packages/sync-service/lib/electric/stack_supervisor.ex
@@ -169,6 +169,10 @@ defmodule Electric.StackSupervisor do
                        type: {:or, [:non_neg_integer, nil]},
                        default: nil
                      ],
+                     http2_max_reset_stream_rate: [
+                       type: {:or, [{:tuple, [:pos_integer, :pos_integer]}, {:in, [:disabled]}]},
+                       default: Electric.Config.default(:http2_max_reset_stream_rate)
+                     ],
                      process_spawn_opts: [type: :map, default: %{}],
                      consumer_gc_heap_threshold: [
                        type: {:or, [:non_neg_integer, nil]},

--- a/packages/sync-service/test/electric/config_test.exs
+++ b/packages/sync-service/test/electric/config_test.exs
@@ -206,6 +206,16 @@ defmodule Electric.ConfigTest do
       [initial_config: initial_config]
     end
 
+    test "configuration/1 is accepted by the StackSupervisor options schema", ctx do
+      config =
+        Electric.Application.configuration(
+          Keyword.take(ctx.initial_config, [:replication_connection_opts])
+        )
+
+      assert {:ok, _} =
+               NimbleOptions.validate(Map.new(config), Electric.StackSupervisor.opts_schema())
+    end
+
     test "consumer_gc_heap_threshold opt is threaded into tweaks", ctx do
       threshold = 209_715_200
 

--- a/packages/sync-service/test/electric/config_test.exs
+++ b/packages/sync-service/test/electric/config_test.exs
@@ -71,6 +71,24 @@ defmodule Electric.ConfigTest do
       refute Keyword.has_key?(default_opts[:http_2_options], :max_requests)
     end
 
+    test "api_server/1 disables Bandit's HTTP/2 reset-stream rate limit by default" do
+      [{Bandit, default_opts}] = Electric.Application.api_server([])
+
+      assert Keyword.fetch!(default_opts[:http_2_options], :max_reset_stream_rate) == nil
+    end
+
+    test "api_server/1 applies http2_max_reset_stream_rate when configured" do
+      [{Bandit, bandit_opts}] =
+        Electric.Application.api_server(tweaks: [http2_max_reset_stream_rate: {500, 10_000}])
+
+      assert bandit_opts[:http_2_options][:max_reset_stream_rate] == {500, 10_000}
+
+      [{Bandit, disabled_opts}] =
+        Electric.Application.api_server(tweaks: [http2_max_reset_stream_rate: :disabled])
+
+      assert Keyword.fetch!(disabled_opts[:http_2_options], :max_reset_stream_rate) == nil
+    end
+
     test "configuration/1", ctx do
       Electric.Application.configuration(
         Keyword.take(ctx.initial_config, [:replication_connection_opts])
@@ -138,6 +156,28 @@ defmodule Electric.ConfigTest do
       assert {:error, msg} = parse_top_process_limit("foo")
       assert msg =~ "invalid top process limit"
       assert msg =~ "Expected format: count:<N> or mem_percent:<N>"
+    end
+  end
+
+  describe "parse_http2_max_reset_stream_rate/1" do
+    import Electric.Config, only: [parse_http2_max_reset_stream_rate: 1]
+
+    test "parses <count>/<duration>" do
+      assert {:ok, {500, 10_000}} = parse_http2_max_reset_stream_rate("500/10s")
+      assert {:ok, {50, 1_000}} = parse_http2_max_reset_stream_rate("50/1000ms")
+      assert {:ok, {1, 60_000}} = parse_http2_max_reset_stream_rate("1/1m")
+    end
+
+    test "accepts disabled" do
+      assert {:ok, :disabled} = parse_http2_max_reset_stream_rate("disabled")
+      assert {:ok, :disabled} = parse_http2_max_reset_stream_rate("DISABLED")
+    end
+
+    test "rejects invalid input" do
+      for input <- ["", "500", "0/10s", "-5/10s", "abc/10s", "500/abc", "500/0s", "500/10s/1"] do
+        assert {:error, msg} = parse_http2_max_reset_stream_rate(input)
+        assert msg =~ "invalid HTTP/2 reset stream rate"
+      end
     end
   end
 

--- a/website/docs/sync/api/config.md
+++ b/website/docs/sync/api/config.md
@@ -353,7 +353,7 @@ When Electric runs behind a connection-pooling reverse proxy or load balancer (A
     name="ELECTRIC_TWEAKS_HTTP2_MAX_RESET_STREAM_RATE"
     defaultValue="disabled"
     example="500/10s">
-Maximum number of HTTP/2 stream resets (`RST_STREAM` frames) a single client connection may send within a time window, in the form `<count>/<duration>`, or `disabled`. When a connection exceeds the limit, Electric closes the whole connection and every request still in flight on it is dropped.
+Maximum number of HTTP/2 stream resets (`RST_STREAM` frames) a single client connection may send within a time window, in the form `COUNT/DURATION` (for example `500/10s`), or `disabled`. When a connection exceeds the limit, Electric closes the whole connection and every request still in flight on it is dropped.
 
 This is disabled by default. Behind a reverse proxy that multiplexes many end clients onto a few upstream HTTP/2 connections, ordinary client-side cancellations of live requests are enough to trip the limit and disconnect every other client sharing that connection. Set it only if Electric is directly exposed to untrusted HTTP/2 clients and you want the rate limit as a defence against HTTP/2 Rapid Reset style abuse.
 

--- a/website/docs/sync/api/config.md
+++ b/website/docs/sync/api/config.md
@@ -347,6 +347,18 @@ When Electric runs behind a connection-pooling reverse proxy or load balancer (A
 
 </EnvVarConfig>
 
+### ELECTRIC_TWEAKS_HTTP2_MAX_RESET_STREAM_RATE
+
+<EnvVarConfig
+    name="ELECTRIC_TWEAKS_HTTP2_MAX_RESET_STREAM_RATE"
+    defaultValue="disabled"
+    example="500/10s">
+Maximum number of HTTP/2 stream resets (`RST_STREAM` frames) a single client connection may send within a time window, in the form `<count>/<duration>`, or `disabled`. When a connection exceeds the limit, Electric closes the whole connection and every request still in flight on it is dropped.
+
+This is disabled by default. Behind a reverse proxy that multiplexes many end clients onto a few upstream HTTP/2 connections, ordinary client-side cancellations of live requests are enough to trip the limit and disconnect every other client sharing that connection. Set it only if Electric is directly exposed to untrusted HTTP/2 clients and you want the rate limit as a defence against HTTP/2 Rapid Reset style abuse.
+
+</EnvVarConfig>
+
 ### ELECTRIC_SHAPE_CHUNK_BYTES_THRESHOLD
 
 <EnvVarConfig


### PR DESCRIPTION
## Summary

Bandit closes an entire HTTP/2 connection with `ENHANCE_YOUR_CALM` once a client sends more than 500 `RST_STREAM` frames within 10 seconds (its default `max_reset_stream_rate`, a Rapid Reset mitigation). The connection handler stops with `{:shutdown, :local_closed}`, which kills every stream process on the connection without running the plug's `after` clause, so every parked long-poll on it leaks its admission permit.

Behind a reverse proxy that multiplexes many end clients onto a few upstream h2c connections, routine client-side cancellations of live requests are enough to trip the limit under load. A production deployment hit it seven times over two days, each occurrence tearing down a connection with hundreds of streams in flight and lining up with a 503 spike.

Electric already handles cancellations per stream (#4791), and Bandit leaves `max_concurrent_streams` unbounded, so the limit does not close off any attack that opening streams without resetting them would not achieve.

## Changes

- Pass `max_reset_stream_rate: nil` to Bandit's `http_2_options` by default.
- Expose the limit as `ELECTRIC_TWEAKS_HTTP2_MAX_RESET_STREAM_RATE`, accepting `<count>/<duration>` (e.g. `500/10s`) or `disabled`, for deployments that expose Electric directly to untrusted HTTP/2 clients and want Bandit's protection back.
- Document the new variable in the config reference.

Refs #4772

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BK9jwfWqKuypoGrmSWkN5f
